### PR TITLE
Add Travis-CI and Coveralls support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.1
 
 before_script:
+  # Turn off xdebug
+  - phpenv config-rm xdebug.ini
   # Install nvm for nodejs
   - nvm install 4.3.0
   - nvm use 4.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
 
 before_script:
-  # Install nvm/yarn
-  - nvm install 4.1.0
-  - nvm use 4.1.0
+  # Install nvm for nodejs
+  - nvm install 4.3.0
+  - nvm use 4.3.0
   # Repo for Yarn
   - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn
-  # Install dependencies and build base-site
+  # Install dependencies and build the project
   - make install
   - make build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
   - make install
   - make build
 
-script: phpunit
+script: make runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 
+branches:
+  only:
+  - master
+  - develop
+
 php:
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,10 @@ before_script:
   - make install
   - make build
 
-script: make runtests
+script:
+  - make runtests
+  - phpenv config-add xdebug.ini
+  - phpunit --coverage-clover build/logs/clover.xml
+
+after_script:
+  - php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ php:
   - hhvm
 
 before_script:
+  # Install nvm/yarn
+  - nvm install 4.1.0
+  - nvm use 4.1.0
+  # Repo for Yarn
+  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+  # Install dependencies and build base-site
   - make install
   - make build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - make install
+  - make build
+
+script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
   - 7.1
 
 before_script:
-  # Turn off xdebug
-  - phpenv config-rm xdebug.ini
   # Install nvm for nodejs
   - nvm install 4.3.0
   - nvm use 4.3.0
@@ -23,7 +21,6 @@ before_script:
 
 script:
   - make runtests
-  - phpenv config-add xdebug.ini
   - phpunit --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 Base Template
 ================
 
-[![Master Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=master)](https://travis-ci.org/waynestate/base-site) [![Develop Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=develop)](https://travis-ci.org/waynestate/base-site) [![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg)](https://coveralls.io/github/waynestate/base-site)
+| Branch | Build | Coverage |
+---|---|---
+| Master | [![Master Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=master)](https://travis-ci.org/waynestate/base-site) | [![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg?branch=master)](https://coveralls.io/github/waynestate/base-site?branch=master) |
+| Develop | [![Develop Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=develop)](https://travis-ci.org/waynestate/base-site) | [![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg?branch=develop)](https://coveralls.io/github/waynestate/base-site?branch=develop) | 
 
 Starter repository for creating a new website. Live demo can be found at https://base.wayne.edu/.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Base Template
 ================
 
+[![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg)](https://coveralls.io/github/waynestate/base-site)
+
 Starter repository for creating a new website. Live demo can be found at https://base.wayne.edu/.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Base Template
 ================
 
-[![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg)](https://coveralls.io/github/waynestate/base-site)
+[![Master Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=master)](https://travis-ci.org/waynestate/base-site) [![Develop Build Status](https://travis-ci.org/waynestate/base-site.svg?branch=develop)](https://travis-ci.org/waynestate/base-site) [![Coverage Status](https://coveralls.io/repos/github/waynestate/base-site/badge.svg)](https://coveralls.io/github/waynestate/base-site)
 
 Starter repository for creating a new website. Live demo can be found at https://base.wayne.edu/.
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "laravel/envoy": "^1.1",
         "phpunit/phpunit": "~4.0",
         "friendsofphp/php-cs-fixer": "^1.12",
-        "mockery/mockery": "~0.9"
+        "mockery/mockery": "~0.9",
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ba04603442747d6eaf0ac22b0d095ba",
+    "content-hash": "94446b02aaf918bbe5396cbf245e359f",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -3056,6 +3056,184 @@
             "time": "2016-12-01T00:05:05+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2017-02-28T22:50:30+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
             "name": "hamcrest/hamcrest-php",
             "version": "v1.2.2",
             "source": {
@@ -3154,12 +3332,12 @@
             "version": "0.9.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
+                "url": "https://github.com/mockery/mockery.git",
                 "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
                 "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
                 "shasum": ""
             },
@@ -3850,6 +4028,119 @@
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "satooshi/php-coveralls",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/satooshi/php-coveralls.git",
+                "reference": "d7285decc88dff59c5ff02c4b1052ab424ba7fa5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/satooshi/php-coveralls/zipball/d7285decc88dff59c5ff02c4b1052ab424ba7fa5",
+                "reference": "d7285decc88dff59c5ff02c4b1052ab424ba7fa5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^6.0",
+                "php": "^5.5 || ^7.0",
+                "psr/log": "^1.0",
+                "symfony/config": "^2.1 || ^3.0",
+                "symfony/console": "^2.1 || ^3.0",
+                "symfony/stopwatch": "^2.0 || ^3.0",
+                "symfony/yaml": "^2.0 || ^3.0"
+            },
+            "suggest": {
+                "symfony/http-kernel": "Allows Symfony integration"
+            },
+            "bin": [
+                "bin/coveralls"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Satooshi\\": "src/Satooshi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kitamura Satoshi",
+                    "email": "with.no.parachute@gmail.com",
+                    "homepage": "https://www.facebook.com/satooshi.jp"
+                }
+            ],
+            "description": "PHP client library for Coveralls API",
+            "homepage": "https://github.com/satooshi/php-coveralls",
+            "keywords": [
+                "ci",
+                "coverage",
+                "github",
+                "test"
+            ],
+            "time": "2017-03-31T10:12:47+00:00"
+        },
+        {
             "name": "sebastian/comparator",
             "version": "1.2.4",
             "source": {
@@ -4222,6 +4513,62 @@
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
+            "name": "symfony/config",
+            "version": "v3.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "8444bde28e3c2a33e571e6f180c2d78bfdc4480d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/8444bde28e3c2a33e571e6f180c2d78bfdc4480d",
+                "reference": "8444bde28e3c2a33e571e6f180c2d78bfdc4480d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/filesystem": "~2.8|~3.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~3.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-04T15:30:56+00:00"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v3.2.6",
             "source": {
@@ -4427,7 +4774,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "satooshi/php-coveralls": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "stylelint-config-standard": "~13.0.0"
   },
   "engines": {
-    "node": ">=4.1.0",
-    "npm": ">=3.3.0"
+    "node": ">=4.3.0",
+    "npm": ">=2.14.12"
   }
 }


### PR DESCRIPTION
Integrate Travis-CI build for supported PHP versions (5.5, 5.6, 7.0, 7.1) for develop/master branches

Integrate Coveralls code coverage for develop/master branches

Adds badges for both develop/master branches for Travis-CI and Coveralls to know the statuses easily and to make sure Pull Requests are passing before they can be merged.