### PR TITLE
Add CONTRIBUTING.md with basic guidelines on contributing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+## Contributing
+When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
+
+### How to Contribute
+1. Please open an issue before submitting a pull request.
+1. Fork the waynestate/base-site.
+1. Make your changes on the fork.
+1. Add any necessary tests for your change under the `tests` folder
+1. Submit a PR to the waynestate/base-site **develop** branch.
+
+### Coding conventions
+
+Start reading our code and you'll get the hang of it. We optimize for readability:
+
+* We require [EditorConfig](http://editorconfig.org/) to be used with your IDE to take advantage of the project's `.editorconfig` settings.
+* PSR-2 Coding Standard - The easiest way to apply the conventions is to run `make phplint`, which uses [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).
+    * It will use the `.php_cs` file within the project to tailor to our code styling.
+
+### Security
+
+If you discover any security related issues, please email web@wayne.edu instead of using the issue tracker.


### PR DESCRIPTION
Added a CONTRIBUTING.md file to the root of the project which outlines basic guidelines to how to contribute to the waynestate/base-site project.