### PR TITLE
Force composer to use HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script:
   - make runtests
-  - phpunit --coverage-clover build/logs/clover.xml
+  - php vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+cache:
+    directories:
+        - $HOME/.composer/cache/files
 
 branches:
   only:
@@ -21,7 +24,8 @@ before_script:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn
   # Install dependencies and build the project
-  - make install
+  - make yarn
+  - make composerinstalldev
   - make build
 
 script:

--- a/makefile
+++ b/makefile
@@ -46,7 +46,7 @@ yarncheck: $(YARNFILE)
 	yarn outdated
 
 runtests: $(COMPOSERFILE)
-	phpunit
+	php vendor/bin/phpunit
 
 phplint: $(COMPOSERFILE)
 	php-cs-fixer fix

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ yarn: $(YARNFILE)
 	yarn
 
 composerinstall: $(COMPOSERFILE)
-	composer update --lock
+	composer update --lock --prefer-dist --no-scripts --no-interaction
 
 composerinstalldev: $(COMPOSERFILE)
 	composer install --prefer-dist --no-scripts --no-interaction && composer dump-autoload --optimize;


### PR DESCRIPTION
Fix issue for Travis-CI fails with a zlib_error when installing using composer.

- Adds Composer packages to Travis-CI cache
- Run `make yarn` and `make composerinstalldev` individually instead of `make install` to ignore running `composer update` due to it being slower than `composer install`
- Run `php vendor/bin/phpunit` instead of `phpunit` to use the composer installed version

```
composer update --lock
Loading composer repositories with package information
Updating dependencies (including require-dev)
Failed to decode response: zlib_decode(): data error
Retrying with degraded mode, check https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode for more info
                             
  [ErrorException]           
  zlib_decode(): data error  
                             
update [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--lock] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [--with-dependencies] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-i|--interactive] [--root-reqs] [--] [<packages>]...
make: *** [composerinstall] Error 1
The command "make install" failed and exited with 2 during .
```