### PR TITLE
Release/3.0.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+## Contributing
+When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
+
+### How to Contribute
+1. Please open an issue before submitting a pull request.
+1. Fork the waynestate/base-site.
+1. Make your changes on the fork.
+1. Add any necessary tests for your change under the `tests` folder
+1. Submit a PR to the waynestate/base-site **develop** branch.
+
+### Coding conventions
+
+Start reading our code and you'll get the hang of it. We optimize for readability:
+
+* We require [EditorConfig](http://editorconfig.org/) to be used with your IDE to take advantage of the project's `.editorconfig` settings.
+* PSR-2 Coding Standard - The easiest way to apply the conventions is to run `make phplint`, which uses [PHP Coding Standards Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).
+    * It will use the `.php_cs` file within the project to tailor to our code styling.
+
+### Security
+
+If you discover any security related issues, please email web@wayne.edu instead of using the issue tracker.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "public/index.php",
   "scripts": {


### PR DESCRIPTION
Fixes issues with the project for Travis-CI with optimizations to caching composer packages and running the correct version of PHPUnit

- Adds Composer packages to Travis-CI cache
- Run make yarn and make composerinstalldev individually instead of make install to ignore running composer update due to it being slower than composer install
- Run php vendor/bin/phpunit instead of phpunit to use the composer installed version