### PR TITLE
Add configuration for setting the NewRelic Application Name

### DIFF
--- a/app/Http/Middleware/NewRelicMiddleware.php
+++ b/app/Http/Middleware/NewRelicMiddleware.php
@@ -17,6 +17,9 @@ class NewRelicMiddleware
     {
         // Load the newrelic transaction
         if (extension_loaded('newrelic')) {
+            // Set the name of the Application
+            newrelic_set_appname(config('newrelic.app_name'));
+
             // Transaction name without GET params
             newrelic_name_transaction($request->server->get('REDIRECT_URL'));
 

--- a/config/newrelic.php
+++ b/config/newrelic.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | NewRelic Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the application name that is set within New Relic to collect
+    | metrics based on this application.
+    |
+    */
+    'app_name' => 'base'
+];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "",
   "main": "public/index.php",
   "scripts": {


### PR DESCRIPTION
Add `newrelic.php` config to allow configuring the name of the New Relic Application.

Add to NewRelicMiddleware the setting of the New Relic Application name using the newrelic config app_name

version bump to 3.0.5