### PR TITLE
Tweak permissions on initial creation and for releases

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -140,7 +140,10 @@ echo '----';
 [ -d {{ $shared_dir }}/storage/framework/cache ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/framework/cache;
 [ -d {{ $shared_dir }}/storage/framework/views ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/framework/views;
 
-[ -d {{ $app_base }}/tmp ] || mkdir -p 0775 {{ $app_base }}/tmp;
+chmod -R g+s {{ $shared_dir }}/storage
+chmod -R g+s {{ $release_dir }}
+
+[ -d {{ $app_base }}/tmp ] || mkdir -p 0770 {{ $app_base }}/tmp;
 @endtask
 
 @task('updaterepo_localsrc', ['on' => 'local'])
@@ -257,6 +260,7 @@ echo "RemoteRelease Environment file setup Done.";
 @task('prepare_remoterelease', ['on' => $remote_server])
 echo "RemoteRelease Prepare...";
 rsync --progress -e ssh -avzh --delay-updates --delete {{ $source_dir }}/ {{ $release_dir }}/{{ $release }}/;
+chmod -R g+s {{ $release_dir }}/{{ $release }}
 echo "RemoteRelease Prepare Done.";
 @endtask
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "main": "public/index.php",
   "scripts": {


### PR DESCRIPTION
add permissions to set the group sticky bit on creation of the initial site directories and on the release after it is deployed.

Fix {{ $app_base}}/tmp to have the same 770 permissions as the others.

version bump to 3.0.6