### PR TITLE
Feature/new window with SPF JS

### DIFF
--- a/resources/js/modules/spf.js
+++ b/resources/js/modules/spf.js
@@ -40,7 +40,7 @@ import spf from 'spf/dist/spf';
             $('body').addClass('spf-link');
 
             // Disable SPF on any links with a file extention
-            $("a[href*='.']").each(function(){
+            $("a[href*='.'],a[target=_blank]").each(function(){
                 this.classList.add('spf-nolink');
             });
 

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -149,6 +149,15 @@
 
     <hr>
 
+    <h2>Links that should not pick up SPF JS</h2>
+
+    <ul>
+        <li><a href="filename.pdf">Anything with a file extension</a> Ex: <code>.pdf</code></li>
+        <li><a href="/styleguide" target="_blank">Relative URLs that open in new window</a> <code>target="_blank"</code></li>
+    </ul>
+
+    <hr>
+
     <h2>Maginific Pop-up</h2>
     <p>Any valid YouTube URL starting with <code>youtu.be</code> or <code>youtube.com/watch</code> will open a lightbox with the video.</p>
     <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="View YouTube Video"></a></p>


### PR DESCRIPTION
## Issue

SPF JS picks up any URL that is relative to the current domain and ignores the `target="_blank"` attribute.

## Solution

Using the same method as excluding files with an extension, `.pdf`'s, this will also exclude any link that goes to a `_blank` window.

## Result

![spf-blank](https://user-images.githubusercontent.com/37359/28027398-f28d7c80-6566-11e7-802c-4eaee3f044ae.png)

## Additional

To verify this is working two links have been added to the `/styleguide` page to test the functionality. 