### PR TITLE
Fix showing no profiles when you select "All Profiles" from the dropdown

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -39,11 +39,14 @@ class ProfileController extends Controller
         // Get the groups for the dropdown
         $dropdown_groups = $this->profile->getDropdownOfGroups($site_id);
 
+        // Set the selected group
+        $selected_group = $request->query('group') !== '' ? $request->query('group') : null;
+
         // Get the options for the dropdown
-        $dropdown_group_options = $this->profile->getDropdownOptions($request->query('group'), $forced_profile_group_id);
+        $dropdown_group_options = $this->profile->getDropdownOptions($selected_group, $forced_profile_group_id);
 
         // Determine which group to filter by
-        $group_id = $forced_profile_group_id === null ? $request->query('group') : $forced_profile_group_id;
+        $group_id = $forced_profile_group_id === null ? $selected_group : $forced_profile_group_id;
 
         // Get the profiles
         $profiles = $this->profile->getProfiles($site_id, $group_id);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "",
   "main": "public/index.php",
   "scripts": {


### PR DESCRIPTION
I found an issue when you select a group from the dropdown then pick "All Profiles". The get request is a blank string instead of NULL which results in no profiles coming back. When the value is null, the API call treats it as if you aren't trying to filter by a group id.