### PR TITLE
hotfix/3.0.12

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -1,12 +1,12 @@
 <?php
 
 // News listing route
-$app->get('{path:.*/?news}/category/{slug:.+}', ['middleware' => ['data', 'formy', 'spf'], 'uses' => 'NewsController@index']);
-$app->get('{path:.*/?news}/{slug:.+}-{id:\d+}', ['middleware' => ['data', 'formy', 'spf:show'], 'uses' => 'NewsController@show']);
-$app->get('{path:.*/?news}/', ['middleware' => ['data', 'formy', 'spf'], 'uses' => 'NewsController@index']);
+$app->get('{path:(?:.*\/|)news}/category/{slug:.+}', ['middleware' => ['data', 'formy', 'spf'], 'uses' => 'NewsController@index']);
+$app->get('{path:(?:.*\/|)news}/{slug:.+}-{id:\d+}', ['middleware' => ['data', 'formy', 'spf:show'], 'uses' => 'NewsController@show']);
+$app->get('{path:(?:.*\/|)news}/', ['middleware' => ['data', 'formy', 'spf'], 'uses' => 'NewsController@index']);
 
 // Individual profile route
-$app->get('{path:.*/?profile}/{accessid:.+}', ['middleware' => ['data', 'formy', 'spf:show'], 'uses' => 'ProfileController@show']);
+$app->get('{path:(?:.*\/|)profile}/{accessid:.+}', ['middleware' => ['data', 'formy', 'spf:show'], 'uses' => 'ProfileController@show']);
 
 // The wild card route is a catch all route that tries to resolve the requests path to a json file
 $app->addRoute(['GET', 'POST'], '{path:.*}', ['middleware' => ['data', 'formy', 'spf'], function ($path, Illuminate\Http\Request $request) use ($app) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "",
   "main": "public/index.php",
   "scripts": {


### PR DESCRIPTION
switch the wildcard `.*/?` regex to match subsites/paths conditionally

fixes false positives for the routes if they have a regular page named `lab-news` or `lab-profiles`

version bump to 3.0.12