### PR TITLE
feature/fix-event-factory

### DIFF
--- a/factories/Event.php
+++ b/factories/Event.php
@@ -26,8 +26,8 @@ class Event implements FactoryContract
             $data[$i] = [
                 'url' => $this->faker->url,
                 'title' => $this->faker->sentence(rand(6, 10)),
-                'date' => $this->faker->dateTimeThisMonth('now')->format('Y-m-d H:i:s'),
-                'start_time' => $this->faker->dateTimeThisMonth('now')->format('Y-m-d H:i:s'),
+                'date' => $this->faker->dateTimeThisMonth('now')->format('Y-m-d'),
+                'start_time' => $this->faker->dateTimeThisMonth('now')->format('H:i:s'),
                 'is_all_day' => $this->faker->boolean,
             ];
         }


### PR DESCRIPTION
fix the event factory to fake the date and start_time the same as it is returned from the api

`date` should be returned as YYYY-MM-DD
`start_time` should be returned as HH:MM:SS