### PR TITLE
add `yarn global add gulp` to install gulp globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn
+  - yarn global add gulp
   # Install dependencies and build the project
   - make yarn
   - make composerinstalldev


### PR DESCRIPTION
fixes issue with travis-ci not finding gulp local installed by `make yarn`