### PR TITLE
Feature/contain hero image

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -99,7 +99,7 @@ return [
     */
     'hero_text_enabled' => true,
     'hero_text_controllers' => ['HomepageController'],
-    'hero_text_more' => 'View More',
+    'hero_text_more' => 'View more',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -88,6 +88,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Hero Contained
+    |--------------------------------------------------------------------------
+    |
+    | Force the hero image to be contained within the content area of the page.
+    | If set to false the hero image will expand 100% across the top of the
+    | site if it is not found in the menu.
+    |
+    */
+    'hero_contained' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Hero Text Enabled
     |--------------------------------------------------------------------------
     |
@@ -97,7 +109,7 @@ return [
     | is allowed to have this functionality.
     |
     */
-    'hero_text_enabled' => true,
+    'hero_text_enabled' => false,
     'hero_text_controllers' => ['HomepageController'],
     'hero_text_more' => 'View more',
 

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -3,7 +3,7 @@
 @section('content-area')
     @yield('top')
 
-    @if(isset($hero) && $hero != false && $site_menu['meta']['has_selected'] == false)
+    @if(isset($hero) && $hero != false && $site_menu['meta']['has_selected'] == false && config('app.hero_contained') === false)
         @include('components.hero', ['images' => $hero])
     @endif
 
@@ -34,7 +34,7 @@
 
         <div class="small-12 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))xlarge-12 large-12 @else xlarge-9 large-9 @endif columns content" data-off-canvas-content>
 
-            @if(isset($hero) && $hero != false && $site_menu['meta']['has_selected'] == true)
+            @if(isset($hero) && $hero != false && $site_menu['meta']['has_selected'] == true || config('app.hero_contained') === true)
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])
             @endif
 

--- a/styleguide/Http/Controllers/HeroFullController.php
+++ b/styleguide/Http/Controllers/HeroFullController.php
@@ -17,6 +17,8 @@ class HeroFullController extends Controller
     {
         $request->data['show_site_menu'] = false;
 
+        config(['app.hero_contained' => false]);
+
         return view('styleguide-childpage', merge($request->data));
     }
 }

--- a/styleguide/Http/Controllers/HeroFullMenuController.php
+++ b/styleguide/Http/Controllers/HeroFullMenuController.php
@@ -5,7 +5,7 @@ namespace Styleguide\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
-class HeroFullTextLinkController extends Controller
+class HeroFullMenuController extends Controller
 {
     /**
      * Display the full width hero view.
@@ -15,14 +15,7 @@ class HeroFullTextLinkController extends Controller
      */
     public function index(Request $request)
     {
-        // Set this controller in the allowed controllers list
-        config([
-            'app.hero_text_enabled' => true,
-            'app.hero_text_controllers' => ['HeroFullTextLinkController'],
-            'app.hero_contained' => false,
-        ]);
-
-        $request->data['show_site_menu'] = false;
+        config(['app.hero_contained' => false]);
 
         return view('styleguide-childpage', merge($request->data));
     }

--- a/styleguide/Pages/HeroFullMenu.php
+++ b/styleguide/Pages/HeroFullMenu.php
@@ -14,7 +14,7 @@ class HeroFullMenu extends Page
     {
         return app('Factories\Page')->create(1, [
             'page' => [
-                'controller' => 'ChildpageController',
+                'controller' => 'HeroFullMenuController',
                 'title' => 'Hero Full (Menu)',
                 'id' => 3,
                 'content' => [


### PR DESCRIPTION
Goal:

* Add the ability to configure the hero image to be contained if it isn't found in the menu.
* Make it the default option for base.

<img width="1277" alt="screen shot 2017-09-15 at 8 59 54 am" src="https://user-images.githubusercontent.com/634788/30485397-489e4e6a-99fb-11e7-93fc-ce183520ea8c.png">
