### PR TITLE
Fix the profile image from being too large

### DIFF
--- a/resources/scss/partials/_profile-view.scss
+++ b/resources/scss/partials/_profile-view.scss
@@ -11,6 +11,7 @@
 
 .content .profile__img {
     display: block;
+    width: auto;
     height: 270px;
     margin: rem-calc(40) auto 1em;
     padding: 0;

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -10,7 +10,7 @@
     @endif
 
     <div class="row profile__block">
-        <div class="small-12 large-4 columns">
+        <div class="small-12 large-4 xlarge-3 columns">
             @if(isset($profile['data']['Picture']['url']))
                 <img src="{{ $profile['data']['Picture']['url'] }}" alt="{{ $page['title'] }}" class="profile__img">
             @else
@@ -54,7 +54,7 @@
              </div>
         </div>
 
-        <div class="small-12 large-8 columns">
+        <div class="small-12 large-8 xlarge-9 columns">
             <h1 class="page-title show-for-large">{{ $page['title'] }}</h1>
 
             @foreach($profile['data'] as $field=>$data)


### PR DESCRIPTION
Fixes the case when images are really tall that it'll not stretch.

<img width="1237" alt="screen shot 2017-09-15 at 1 35 23 pm" src="https://user-images.githubusercontent.com/634788/30495697-005f9f80-9a1b-11e7-80f3-45aaf23ce361.png">

<img width="580" alt="screen shot 2017-09-15 at 1 35 31 pm" src="https://user-images.githubusercontent.com/634788/30495698-00625c02-9a1b-11e7-96f5-a001cfd9a722.png">
