### PR TITLE
Use REQUEST_URI instead of $1 so that way requests with filename exte…

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -7,7 +7,7 @@
 
     # Force www to non-www
     RewriteCond %{HTTP_HOST} ^www\.(.*)
-    RewriteRule ^.*$ https://%1/$1 [L,R=307]
+    RewriteRule ^.*$ https://%1%{REQUEST_URI} [L,R=307]
 
     # If HTTP and we are not on foo.dev, www-dev.foo, www-dev2.foo or www2.foo
     # then force HTTPS


### PR DESCRIPTION
Use REQUEST_URI instead of $1 so that way requests with filename extensions are redirected properly and not bounced back to the homepage.

To currently replicate the issue, visit a base site with https://www.domain.wayne.edu/filename.pdf . It will be redirected to the homepage instead of the file.