### PR TITLE
redirect to / if they are trying to hit the URL of an old site that u…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+sudo: false
+dist: trusty
 language: php
 cache:
+    yarn: true
     directories:
         - $HOME/.composer/cache/files
 
@@ -14,16 +17,16 @@ php:
   - 7.0
   - 7.1
 
-before_script:
+before_install:
   # Install nvm for nodejs
-  - nvm install 4.3.0
-  - nvm use 4.3.0
-  # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+  - nvm install 8.7.0
+  - nvm use 8.7.0
+  # Install yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
+  - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add gulp
+
+before_script:
   # Install dependencies and build the project
   - make yarn
   - make composerinstalldev

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -35,6 +35,10 @@
     RewriteCond %{DOCUMENT_ROOT}/_static/%{REQUEST_URI} -f
     RewriteRule ^(.+) %{DOCUMENT_ROOT}/_static/$1 [L]
 
+    # Handle redirects for old index.php URLs to go to /
+    RewriteCond %{THE_REQUEST} ^.*/index\.php
+    RewriteRule ^(.*)index.php$ /$1 [R=307,L]
+
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Due to old sites using `index.php` as the homepage and switching to using the new base without the `.php` extension, going to www.example.wayne.edu/index.php would 404 instead of being the homepage.

This will check the `%{THE_REQUEST}` and determine if it has index.php to redirect it to / and not conflict with the core index.php