### PR TITLE
Feature/fix travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   # Install yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add gulp
 
 before_script:
   # Install dependencies and build the project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+dist: trusty
 language: php
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 dist: trusty
 language: php
 cache:
+    yarn: true
     directories:
         - $HOME/.composer/cache/files
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,15 @@ php:
   - 7.0
   - 7.1
 
-before_script:
+before_install:
   # Install nvm for nodejs
-  - nvm install 4.3.0
-  - nvm use 4.3.0
-  # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-  - yarn global add gulp
+  - nvm install 8.7.0
+  - nvm use 8.7.0
+  # Install yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+before_script:
   # Install dependencies and build the project
   - make yarn
   - make composerinstalldev


### PR DESCRIPTION
Update `.travis.yml` to

- be explicit in using container-based environment
- cache the yarn packages for faster testing
- move installing nodejs and yarn to `before_install` instead of `before_script`
- install gulp with yarn globally otherwise travis-ci won't find it
 