### PR TITLE
Feature/no menu

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -60,13 +60,12 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
         $top_menu_id = $this->getTopMenuId($data['menu']['id'], config('app.top_menu_id'), $menus);
 
         // Get the top menu
-        $top_menu = $this->getTopMenu(
+        $top_menu = $top_menu_id === null ? null : $top_menu = $this->getTopMenu(
             $menus[$top_menu_id],
             $data['page']['id']
         );
 
-        // Get the site's menu
-        $site_menu = $this->getSiteMenu(
+        $site_menu = $data['menu']['id'] === null ? null : $this->getSiteMenu(
             $menus[$data['menu']['id']],
             $data['page']['id']
         );
@@ -104,6 +103,11 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
             $menus['show_site_menu'] = false;
         }
 
+        // If no menu is selected then hide the site menu
+        if ($menus['site_menu_output'] === null) {
+            $menus['show_site_menu'] = false;
+        }
+
         return $menus;
     }
 
@@ -112,7 +116,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
      */
     public function getSiteMenuOutput($menu)
     {
-        return $this->displayMenu->render(['menu' => $menu]);
+        return $menu === null ? null : $this->displayMenu->render(['menu' => $menu]);
     }
 
     /**
@@ -120,7 +124,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
      */
     public function getTopMenuOutput($menu)
     {
-        return $this->displayMenu->render(['menu' => $menu, 'menu_class' => 'menu-top show-for-menu-top-up']);
+        return $menu === null ? null : $this->displayMenu->render(['menu' => $menu, 'menu_class' => 'menu-top show-for-menu-top-up']);
     }
 
     /**

--- a/styleguide/Pages/NoMenu.php
+++ b/styleguide/Pages/NoMenu.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class NoMenu extends Page
+{
+    /** {@inheritdoc} **/
+    public $path = '/styleguide/no/menu';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, [
+            'page' => [
+                'controller' => 'ChildpageController',
+                'title' => 'No Menu',
+                'id' => null,
+                'content' => [
+                    'main' => '<p>'.$this->faker->paragraph(8).'</p>
+                    <p>'.$this->faker->paragraph(8).'</p>
+                    <p>'.$this->faker->paragraph(8).'</p>',
+                ],
+            ],
+            'menu' => [
+                'id' => null,
+            ],
+        ]);
+    }
+}

--- a/styleguide/Pages/NotInMenu.php
+++ b/styleguide/Pages/NotInMenu.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class NotInMenu extends Page
+{
+    /** {@inheritdoc} **/
+    public $path = '/styleguide/not/in/menu';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, [
+            'page' => [
+                'controller' => 'ChildpageController',
+                'title' => 'Not In Menu',
+                'id' => null,
+                'content' => [
+                    'main' => '<p>'.$this->faker->paragraph(8).'</p>
+                    <p>'.$this->faker->paragraph(8).'</p>
+                    <p>'.$this->faker->paragraph(8).'</p>',
+                ],
+            ],
+            'menu' => [
+                'id' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/styleguide/Repositories/PageRepositoryTest.php
+++ b/tests/styleguide/Repositories/PageRepositoryTest.php
@@ -26,6 +26,7 @@ class PageRepositoryTest extends TestCase
 
             $response = $this->call('GET', $path);
 
+            $this->assertTrue(is_string($path), 'ERROR: Path to styleguide page not found. Make sure it exists in the styleguide menu. Optionally you can added public $path = \'/styleguide/path/to/page\' in your styleguide Page class.');
             $this->assertEquals(200, $response->status(), 'Styleguide error at path: '.$path);
         });
     }


### PR DESCRIPTION
Issue: If `$menu['id']` is equal to null, the page errors because a null index doesn't exist on `$menus`.

Solution: Conditionally check for null and set the top and site menu output as null if no menu is found. Also force the site menu to be hidden, this way the content spans 100% across the grid.