### PR TITLE
Show the menu when javascript is turned off

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -124,7 +124,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
      */
     public function getTopMenuOutput($menu)
     {
-        return $menu === null ? null : $this->displayMenu->render(['menu' => $menu, 'menu_class' => 'menu-top show-for-menu-top-up']);
+        return $menu === null ? null : $this->displayMenu->render(['menu' => $menu, 'menu_class' => 'menu-top']);
     }
 
     /**

--- a/resources/js/modules/offcanvas.js
+++ b/resources/js/modules/offcanvas.js
@@ -108,6 +108,9 @@ import 'foundation-sites/js/foundation.offcanvas';
             // If ooffcanvas is opening
             $('.off-canvas-wrapper').on('opened.zf.offcanvas', this.open);
 
+            // Apply initial classes
+            $('ul.menu-top').addClass('show-for-menu-top-up');
+
             // Redo offCanvas because of the random hash it creates so in SPF it will work
             var foundationOffCanvas = new window.Foundation.OffCanvas($('[data-off-canvas]'));
             window.WayneState.register('foundationOffCanvas', foundationOffCanvas);

--- a/resources/scss/partials/_menu-offcanvas.scss
+++ b/resources/scss/partials/_menu-offcanvas.scss
@@ -74,8 +74,6 @@
 
             // Menu Header top level (MAIN MENU)
             ul {
-                display: none; // Initially hides Top level Main Menu
-
                 li a {
                     background-color: #000;
                     border-bottom: none;

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -8,7 +8,7 @@
     @endif
 
     <div class="row">
-        <div class="xlarge-3 large-3 small-12 columns main-menu @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) hide-for-menu-top-up @endif off-canvas-absolute position-right" id="mainMenu" data-off-canvas role="navigation">
+        <div class="xlarge-3 large-3 small-12 columns main-menu @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) hide-for-menu-top-up @endif" id="mainMenu" data-off-canvas role="navigation">
             @if(isset($site_menu_output) && isset($top_menu_output) && $site_menu !== $top_menu)
                 <div class="offcanvas-main-menu">
                     <ul>


### PR DESCRIPTION
If a user has javascript turned off the menus will now be accessible. The only trade off is on mobile the menu will flash then hide (with javascript) for the first paint. After that, SPF will kick in and it won't be a concern.