### PR TITLE
Reset API key for tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,6 +31,9 @@ class TestCase extends \Laravel\Lumen\Testing\TestCase
         // Force the top menu to be enabled for now since the tests are written specifically for this condition
         config(['app.top_menu_enabled' => true]);
 
+        // Reset the WSU API key so we never make real connections to the API
+        config(['app.wsu_api_key' => '']);
+
         // Create a new faker that every test can use
         $this->faker = (new Factory)->create();
     }


### PR DESCRIPTION
Reset the WSU API key so the tests never make a real connection and will error if it tries to.