### PR TITLE
Pull all profiles from the dropdown options rather than all groups from the API

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -45,11 +45,11 @@ class ProfileController extends Controller
         // Get the options for the dropdown
         $dropdown_group_options = $this->profile->getDropdownOptions($selected_group, $forced_profile_group_id);
 
-        // Determine which group to filter by
-        $group_id = $forced_profile_group_id === null ? $selected_group : $forced_profile_group_id;
+        // Determine which group(s) to filter by
+        $group_ids = $this->profile->getGroupIds($selected_group, $forced_profile_group_id, $dropdown_groups['dropdown_groups']);
 
         // Get the profiles
-        $profiles = $this->profile->getProfiles($site_id, $group_id);
+        $profiles = $this->profile->getProfiles($site_id, $group_ids);
 
         // Disable hero images
         $request->data['hero'] = false;

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -76,6 +76,22 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
+    public function getGroupIds($selected_group, $forced_profile_group_id, $dropdown_groups)
+    {
+        // Use the selected group or the forced one from custom page fields
+        $group_ids = $forced_profile_group_id === null ? $selected_group : $forced_profile_group_id;
+
+        // Use all the IDs from the dropdown since the initial selection is "All Profiles"
+        if ($group_ids === null) {
+            $group_ids = ltrim(implode(array_keys($dropdown_groups), '|'), '|');
+        }
+
+        return $group_ids;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDropdownOfGroups($site_id)
     {
         $params = [

--- a/tests/app/Repositories/ProfileRepositoryTest.php
+++ b/tests/app/Repositories/ProfileRepositoryTest.php
@@ -159,4 +159,29 @@ class ProfileRepositoryTest extends TestCase
         // Since the API returned an error we shouldn't have any profiles
         $this->assertEmpty($profiles['profiles']);
     }
+
+    /**
+     * @covers App\Repositories\ProfileRepository::getGroupIds
+     * @test
+     */
+    public function getting_profile_group_ids_should_return_correct_string()
+    {
+        // Fake a dropdown array of group_id => group name
+        $limit = $this->faker->numberBetween(1, 10);
+        $dropdown = $this->faker->words($limit, false);
+
+        // If no forced ID and no selection has been made the result should be all group_ids from the dropdown
+        $group_ids = app('App\Repositories\ProfileRepository')->getGroupIds(null, null, $dropdown);
+        $this->assertEquals(implode(array_keys($dropdown), '|'), $group_ids);
+
+        // Forcing a group ID
+        $forced_id = $this->faker->numberBetween(0, $limit - 1);
+        $group_ids = app('App\Repositories\ProfileRepository')->getGroupIds(null, $forced_id, $dropdown);
+        $this->assertEquals($forced_id, $group_ids);
+
+        // Selected from the dropdown
+        $selected = array_rand($dropdown, 1);
+        $group_ids = app('App\Repositories\ProfileRepository')->getGroupIds($selected, null, $dropdown);
+        $this->assertEquals($selected, $group_ids);
+    }
 }


### PR DESCRIPTION
There are three ways to determine what to filter profile groups by:

1. Forced profile ID from custom fields
2. The selected ID they pick from the dropdown
3. The default "All Profiles" option.

Option 3 is where the problem was. It would query based on all groups coming back from the API rather than the groups offered in the dropdown selection. This new commit will allow you customize the dropdown array of groups and the final query to the API to get "All Profiles" will reflect whats in the dropdown.