### PR TITLE
Feature/directory template

### DIFF
--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -1,0 +1,41 @@
+<?php
+/*
+* Status: Public
+* Description: Directory Template
+* Default: false
+*/
+
+namespace App\Http\Controllers;
+
+use Contracts\Repositories\ProfileRepositoryContract;
+use Illuminate\Http\Request;
+
+class DirectoryController extends Controller
+{
+    /**
+     * Construct the ProfileController.
+     *
+     * @param ProfileRepositoryContract $profile
+     */
+    public function __construct(ProfileRepositoryContract $profile)
+    {
+        $this->profile = $profile;
+    }
+
+    /**
+     * Display directory listing view.
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        // Determine what site to pull profiles from
+        $site_id = isset($request->data['data']['profile_site_id']) ? $request->data['data']['profile_site_id'] : $request->data['site']['id'];
+
+        // Get the profiles
+        $profiles = $this->profile->getProfilesByGroup($site_id);
+
+        return view('directory', merge($request->data, $profiles));
+    }
+}

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -160,6 +160,14 @@ class ProfileRepository implements ProfileRepositoryContract
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
 
+        // Filter down the groups based on the parent group from the config
+        $profile_groups['results'] = collect($profile_groups['results'])
+            ->filter(function ($item) {
+                return (int) $item['parent_id'] === config('app.profile_parent_group_id');
+            })
+            ->toArray();
+
+        // Only return the display name ordered by the display order
         $groupsArray = collect($profile_groups['results'])
             ->sortBy('display_order')
             ->map(function ($item) {

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -67,10 +67,10 @@ class ProfileRepository implements ProfileRepositoryContract
         $group_ids = $this->getGroupIds(null, null, $dropdown_groups['dropdown_groups']);
 
         // Get all the profiles
-        $allProfiles = $this->getProfiles($site_id, $group_ids);
+        $all_profiles = $this->getProfiles($site_id, $group_ids);
 
-        // Return an array of profiles organized by the group they are in
-        $grouped = collect($allProfiles['profiles'])->map(function ($profile) {
+        // Organize profiles by the group they are in keyed by accessid
+        $grouped = collect($all_profiles['profiles'])->map(function ($profile) {
             return collect($profile['groups'])->flatMap(function ($group) use ($profile) {
                 return [
                    'data' => $profile['data'],
@@ -84,6 +84,7 @@ class ProfileRepository implements ProfileRepositoryContract
         ->groupBy('group', true)
         ->toArray();
 
+        // Follow the ordering of groups from the CMS
         $profiles['profiles'] = $this->sortGroupsByDisplayOrder($grouped, $dropdown_groups['dropdown_groups']);
 
         return $profiles;

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -58,6 +58,32 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
+    public function getProfilesByGroup($site_id, $selected_group = null)
+    {
+        // Get all the profiles
+        $profiles = $this->getProfiles($site_id, $selected_group);
+
+        // Return an array of profiles organized by the group they are in
+        $grouped['profiles'] = collect($profiles['profiles'])->map(function ($profile) {
+            return collect($profile['groups'])->flatMap(function ($group) use ($profile) {
+                return [
+                   'data' => $profile['data'],
+                   'groups' => $profile['groups'],
+                   'group' => $group,
+                   'AccessID' => $profile['data']['AccessID'],
+               ];
+            });
+        })
+        ->keyBy('AccessID')
+        ->groupBy('group', true)
+        ->toArray();
+
+        return $grouped;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDropdownOptions($selected_group = null, $forced_profile_group_id = null)
     {
         // Default Options

--- a/config/app.php
+++ b/config/app.php
@@ -145,4 +145,16 @@ return [
     |
     */
     'profile_default_back_url' => '/profiles/',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Profile parent group ID
+    |--------------------------------------------------------------------------
+    |
+    | This will limit the groups displayed to only the children groups under
+    | this ID. Typically the group is called "Departments". If all desired
+    | groups are added to the root then leave this value as 0.
+    |
+    */
+    'profile_parent_group_id' => 0,
 ];

--- a/factories/Profile.php
+++ b/factories/Profile.php
@@ -12,9 +12,10 @@ class Profile implements FactoryContract
      *
      * @param Factory $faker
      */
-    public function __construct(Factory $faker)
+    public function __construct(Factory $faker, ProfileGroup $group)
     {
         $this->faker = $faker->create();
+        $this->group = $group;
     }
 
     /**
@@ -22,6 +23,8 @@ class Profile implements FactoryContract
      */
     public function create($limit = 1)
     {
+        $groups = collect($this->group->create(4));
+
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
                 'data' => [
@@ -42,6 +45,9 @@ class Profile implements FactoryContract
                         '<p>'.$this->faker->paragraph(10).'</p>',
                         '<p>'.$this->faker->paragraph(10).'</p>',
                     ],
+                ],
+                'groups' => [
+                    $groups->random()['display_name'],
                 ],
             ];
         }

--- a/factories/ProfileGroup.php
+++ b/factories/ProfileGroup.php
@@ -24,6 +24,7 @@ class ProfileGroup implements FactoryContract
     {
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
+                'parent_id' => 0,
                 'display_name' => ucfirst($this->faker->words(2, true)),
             ];
         }

--- a/factories/ProfileGroup.php
+++ b/factories/ProfileGroup.php
@@ -25,6 +25,7 @@ class ProfileGroup implements FactoryContract
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
                 'parent_id' => 0,
+                'display_order' => $i,
                 'display_name' => ucfirst($this->faker->words(2, true)),
             ];
         }

--- a/factories/ProfileGroup.php
+++ b/factories/ProfileGroup.php
@@ -24,7 +24,7 @@ class ProfileGroup implements FactoryContract
     {
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
-                'display_name' => $this->faker->word,
+                'display_name' => ucfirst($this->faker->words(2, true)),
             ];
         }
 

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -5,11 +5,11 @@
 
     {!! $page['content']['main'] !!}
 
-    @foreach($profiles as $key => $profiles)
+    @forelse($profiles as $key => $profiles)
         <h1>{{ $key }}</h1>
 
         <div class="row small-up-2 medium-up-3">
-            @forelse((array)$profiles as $profile)
+            @foreach((array)$profiles as $profile)
                 <div class="columns profile">
                     <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}" class="profile-img" style="background-image: url('{{ $profile['data']['Picture']['url'] or '/_resources/images/no-photo.svg' }}');" alt="{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}"></a>
                     <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</a>
@@ -18,9 +18,9 @@
                         <span>{{ $profile['data']['Title'] }}</span>
                     @endif
                 </div>
-            @empty
-                <p>No profiles found.</p>
-            @endforelse
+            @endforeach
         </div>
-    @endforeach
+    @empty
+        <p>No profiles found.</p>
+    @endforelse
 @endsection

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -1,0 +1,26 @@
+@extends('partials.content-area')
+
+@section('content')
+    <h1 class="page-title">{{ $page['title'] }}</h1>
+
+    {!! $page['content']['main'] !!}
+
+    @foreach($profiles as $key => $profiles)
+        <h1>{{ $key }}</h1>
+
+        <div class="row small-up-2 medium-up-3">
+            @forelse((array)$profiles as $profile)
+                <div class="columns profile">
+                    <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}" class="profile-img" style="background-image: url('{{ $profile['data']['Picture']['url'] or '/_resources/images/no-photo.svg' }}');" alt="{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}"></a>
+                    <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</a>
+
+                    @if(isset($profile['data']['Title']))
+                        <span>{{ $profile['data']['Title'] }}</span>
+                    @endif
+                </div>
+            @empty
+                <p>No profiles found.</p>
+            @endforelse
+        </div>
+    @endforeach
+@endsection

--- a/styleguide/Pages/Directory.php
+++ b/styleguide/Pages/Directory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class Directory extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, [
+            'page' => [
+                'controller' => 'DirectoryController',
+                'title' => 'Directory',
+                'id' => 101104,
+                'content' => [
+                    'main' => '',
+                ],
+            ],
+            'menu' => [
+                'id' => 1,
+            ],
+            'site' => [
+                'subsite-folder' => 'styleguide/',
+            ],
+        ]);
+    }
+}

--- a/styleguide/Repositories/MenuRepository.php
+++ b/styleguide/Repositories/MenuRepository.php
@@ -75,6 +75,16 @@ class MenuRepository extends Repository
                             'relative_url' => '/styleguide/profiles',
                             'submenu' => [],
                         ],
+                        101104 => [
+                            'menu_item_id' => '101104',
+                            'is_active' => '1',
+                            'page_id' => '101104',
+                            'target' => '',
+                            'display_name' => 'Directory',
+                            'class_name' => '',
+                            'relative_url' => '/styleguide/directory',
+                            'submenu' => [],
+                        ],
                     ],
                 ],
                 102 => [

--- a/styleguide/Repositories/ProfileRepository.php
+++ b/styleguide/Repositories/ProfileRepository.php
@@ -55,7 +55,7 @@ class ProfileRepository extends Repository
      */
     public function sortGroupsByDisplayOrder($grouped, $groups)
     {
-        // There is no need to sort the groups in the styleguide since the order doesn't matter
+        // There is no need to sort the groups in the styleguide since the order is random
         return $grouped;
     }
 }

--- a/styleguide/Repositories/ProfileRepository.php
+++ b/styleguide/Repositories/ProfileRepository.php
@@ -11,7 +11,7 @@ class ProfileRepository extends Repository
      */
     public function getProfiles($site_id, $selected_group = null)
     {
-        $limit = $selected_group != null ? rand(2, 5) : 10;
+        $limit = is_int($selected_group) ? rand(2, 5) : 20;
 
         $profiles['profiles'] = app('Factories\Profile')->create($limit);
 
@@ -48,5 +48,14 @@ class ProfileRepository extends Repository
     public function getBackToProfileListUrl($referer = null, $scheme = null, $host = null, $uri = null)
     {
         return '/styleguide/profiles';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sortGroupsByDisplayOrder($grouped, $groups)
+    {
+        // There is no need to sort the groups in the styleguide since the order doesn't matter
+        return $grouped;
     }
 }

--- a/tests/app/Repositories/ProfileRepositoryTest.php
+++ b/tests/app/Repositories/ProfileRepositoryTest.php
@@ -93,7 +93,7 @@ class ProfileRepositoryTest extends TestCase
      * @covers App\Repositories\ProfileRepository::getDropdownOfGroups
      * @test
      */
-    public function getting_dropdown_of_groups_shoudl_contain_all_the_groups()
+    public function getting_dropdown_of_groups_should_contain_all_the_groups()
     {
         // Fake return
         $return = [

--- a/tests/styleguide/Repositories/PageRepositoryTest.php
+++ b/tests/styleguide/Repositories/PageRepositoryTest.php
@@ -11,6 +11,7 @@ class PageRepositoryTest extends TestCase
      * @covers App\Http\Controllers\ChildpageController
      * @covers App\Http\Controllers\ProfileController
      * @covers App\Http\Controllers\NewsController
+     * @covers App\Http\Controllers\DirectoryController
      * @covers Styleguide\Repositories\PageRepository::getRequestData
      * @test
      */


### PR DESCRIPTION
This introduces:

* New template (controller) to display profiles out grouped by ProfileGroup. The output includes a heading of the group name above each group.
* A new config option called `app.profile_parent_group_id` which allows you to set the root parent to pull groups from. Typically this is either all top level groups (parent id of 0) or a group called "Departments".
* The profile groups returned from `ProfileRepository@getDropdownOfGroups` is now ordered by display_order instead of alphabetical order of `display_name`. This way the group order can be customized based on the sites needs.
* The profile listing is now keyed by AccessID so its easier to access users in the array.

Example output from the styleguide:

<img width="1217" alt="screen shot 2017-10-25 at 8 42 42 am" src="https://user-images.githubusercontent.com/634788/31999402-16a680be-b961-11e7-9f99-f352629e6ef8.png">
