### PR TITLE
Feature/menu flash fix

### DIFF
--- a/resources/scss/partials/_menu-offcanvas.scss
+++ b/resources/scss/partials/_menu-offcanvas.scss
@@ -11,6 +11,25 @@
         background-color: #262626;
         padding-left: 0;
         padding-right: 0;
+        // Animation for menu fade in
+        animation: fadein 1s;
+
+        // Delay animation for a bit so menu flash doesn't occur on faster 3g and up
+        @keyframes fadein {
+            0% {
+                opacity: 0;
+                height: 0;
+            }
+
+            90% {
+                opacity: 0;
+            }
+
+            100% {
+                opacity: 1;
+                height: 100%;
+            }
+        }
 
         // Selected State
         .selected a {

--- a/resources/scss/partials/_menu-top.scss
+++ b/resources/scss/partials/_menu-top.scss
@@ -142,3 +142,27 @@
 li.hide-for-menu-top-up {
     display: block;
 }
+
+#top-menu .menu-top {
+    @include breakpoint($menu-top-breakpoint down) {
+        // Animation for menu fade in
+        animation: fadein 1s;
+
+        // Delay animation for a bit so menu flash doesn't occur on faster 3g and up
+        @keyframes fadein {
+            0% {
+                opacity: 0;
+                height: 0;
+            }
+
+            90% {
+                opacity: 0;
+            }
+
+            100% {
+                opacity: 1;
+                height: 100%;
+            }
+        }
+    }
+}

--- a/resources/scss/partials/_utilities.scss
+++ b/resources/scss/partials/_utilities.scss
@@ -16,3 +16,25 @@
 .position-relative {
     position: relative;
 }
+
+.menu-delay {
+    // Animation for menu fade in
+    animation: fadein 1s;
+
+    // Delay animation for a bit so menu flash doesn't occur on faster 3g and up
+    @keyframes fadein {
+        0% {
+            opacity: 0;
+            height: 0;
+        }
+
+        90% {
+            opacity: 0;
+        }
+
+        100% {
+            opacity: 1;
+            height: 100%;
+        }
+    }
+}

--- a/resources/scss/partials/_utilities.scss
+++ b/resources/scss/partials/_utilities.scss
@@ -16,25 +16,3 @@
 .position-relative {
     position: relative;
 }
-
-.menu-delay {
-    // Animation for menu fade in
-    animation: fadein 1s;
-
-    // Delay animation for a bit so menu flash doesn't occur on faster 3g and up
-    @keyframes fadein {
-        0% {
-            opacity: 0;
-            height: 0;
-        }
-
-        90% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-            height: 100%;
-        }
-    }
-}


### PR DESCRIPTION
This is from a discussion from the dev meeting that the offcanvas menu flashes for a brief moment on page load.

I did some testing of putting in a css only delay with using "animation:" at different intervals to see the best results. After some tests 1 second seemed to work well for most cases.  This fix should work on most modern browsers including IE 10 up.

5 second delay (to show how the fix works only)
https://app.hyfy.io/v/abzY0o4v5CU/

1 second delay - before fix and after 
https://app.hyfy.io/v/abvViC1c5CU/

1 second delay on faster 3g
https://app.hyfy.io/v/abvViC1c5CU/

1 second delay on slow 3g
https://app.hyfy.io/v/abGTxESC5CU/

My next step was to add this as a class to use anywhere, but was having trouble placing it in the correct spot to get the same results as above.  Any help would be appreciated!