### PR TITLE
addthis support for social sharing

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -94,6 +94,9 @@ class NewsController extends Controller
         // Set the selected category
         $categories = $this->news->setSelectedCategory($categories, null);
 
+        // Set the meta image information
+        $request->data['meta']['image'] = $this->news->getImageUrl($news);
+
         return view('news-individual', merge($request->data, $news, $categories));
     }
 }

--- a/app/Repositories/NewsRepository.php
+++ b/app/Repositories/NewsRepository.php
@@ -45,7 +45,7 @@ class NewsRepository implements NewsRepositoryContract
             'order_by' => 'display_order',
             'sort' => 'ASC',
             'server_location' => 'both',
-            'fields' => 'news_id|title|link|posted|app_id|slug',
+            'fields' => 'news_id|title|link|posted|app_id|slug|filename',
             'before' => 'now',
         ];
 
@@ -70,7 +70,7 @@ class NewsRepository implements NewsRepositoryContract
             'is_active' => '1',
             'order_by' => 'posted',
             'sort' => 'DESC',
-            'fields' => 'news_id|title|link|posted|app_id|slug|excerpt',
+            'fields' => 'news_id|title|link|posted|app_id|slug|excerpt|filename',
             'server_location' => 'both',
             'limit' => $limit,
             'archive' => '1',
@@ -95,7 +95,7 @@ class NewsRepository implements NewsRepositoryContract
             'is_active' => '1',
             'order_by' => 'posted',
             'sort' => 'DESC',
-            'fields' => 'news_id|title|link|posted|app_id|slug|excerpt|is_archive|ending|body',
+            'fields' => 'news_id|title|link|posted|app_id|slug|excerpt|is_archive|ending|body|filename',
             'server_location' => 'both',
             'limit' => 1,
         ];
@@ -151,5 +151,27 @@ class NewsRepository implements NewsRepositoryContract
         }
 
         return $categories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImageUrl($news)
+    {
+        // If the news item has an image attached
+        if (isset($news['news']['filename']) && $news['news']['filename'] !== '') {
+            return $news['news']['filename'];
+        }
+
+        // Scan the news body for the first image
+        $doc = new \DOMDocument();
+        @$doc->loadHTML($news['news']['body']);
+        $images = $doc->getElementsByTagName('img');
+
+        if ($images->item(0) !== null) {
+            return $images->item(0)->getAttribute('src');
+        }
+
+        return null;
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -181,6 +181,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Facebook Open Graph
+    |--------------------------------------------------------------------------
+    |
+    | Here you can setup open graph tied to a specific application. This will
+    | output the appropriate meta tags in the head of the document.
+    |
+    */
+    'facebook_profile_id' => null,
+    'facebook_app_id' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/contracts/Repositories/NewsRepositoryContract.php
+++ b/contracts/Repositories/NewsRepositoryContract.php
@@ -57,4 +57,12 @@ interface NewsRepositoryContract
      * @return array
      */
     public function setSelectedCategory($categories, $slug);
+
+    /**
+     * Get the image url for the meta data.
+     *
+     * @param array $news
+     * @return array
+     */
+    public function getImageUrl($news);
 }

--- a/factories/NewsItem.php
+++ b/factories/NewsItem.php
@@ -33,6 +33,7 @@ class NewsItem implements FactoryContract
                 'archive' => 1,
                 'link' => '',
                 'body' => $this->faker->paragraph,
+                'filename' => '',
             ];
         }
 

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -6,6 +6,7 @@ import './modules/spf';
 import './modules/formfilter';
 import './modules/slick';
 import './modules/magnific-popup';
+import './modules/share';
 
 // Foundation Modules
 import './modules/accordion';

--- a/resources/js/modules/share.js
+++ b/resources/js/modules/share.js
@@ -15,23 +15,28 @@ import jQuery from 'jquery';
          * Initialize
          */
         _init() {
-            if($('.addthis_sharing_toolbox').length > 0) {
-                if (!window.addthis) {
-                    // Asynchronous load of share icons
-                    var addthisScript = document.createElement('script');
-                    addthisScript.setAttribute('src', '//s7.addthis.com/js/300/addthis_widget.js#pubid=waynestate');
-                    addthisScript.setAttribute('async', 'async');
-                    document.body.appendChild(addthisScript);
-
-                    // Custom configuration for share icons
-                    var addthis_config = addthis_config || {};
-                    addthis_config.ui_508_compliant = true;
-                    addthis_config.ui_tabindex = 0;
-                }else{
-                    // Refreshes the share icons with the new URLs
-                    window.addthis.layers.refresh();
-                }
+            // Make sure addthis is desired on this page
+            if($('.addthis_sharing_toolbox').length == 0) {
+                return;
             }
+
+            if (!window.addthis) {
+                // Asynchronous load of share icons
+                var addthisScript = document.createElement('script');
+                addthisScript.setAttribute('src', '//s7.addthis.com/js/300/addthis_widget.js#pubid=waynestate');
+                addthisScript.setAttribute('async', 'async');
+                document.body.appendChild(addthisScript);
+
+                // Custom configuration for share icons
+                var addthis_config = addthis_config || {};
+                addthis_config.ui_508_compliant = true;
+                addthis_config.ui_tabindex = 0;
+
+                return;
+            }
+
+            // Refreshes the share icons with the new URLs
+            window.addthis.layers.refresh();
         }
     }
 

--- a/resources/js/modules/share.js
+++ b/resources/js/modules/share.js
@@ -1,0 +1,43 @@
+import jQuery from 'jquery';
+
+(function($) {
+    "use strict";
+
+    /**
+     * Sticky module.
+     */
+    class Share {
+        constructor() {
+            this._init();
+        }
+
+        /**
+         * Initialize
+         */
+        _init() {
+            if($('.addthis_sharing_toolbox').length > 0) {
+                if (!window.addthis) {
+                    // Asynchronous load of share icons
+                    var addthisScript = document.createElement('script');
+                    addthisScript.setAttribute('src', '//s7.addthis.com/js/300/addthis_widget.js#pubid=waynestate');
+                    addthisScript.setAttribute('async', 'async');
+                    document.body.appendChild(addthisScript);
+
+                    // Custom configuration for share icons
+                    var addthis_config = addthis_config || {};
+                    addthis_config.ui_508_compliant = true;
+                    addthis_config.ui_tabindex = 0;
+                }else{
+                    // Refreshes the share icons with the new URLs
+                    window.addthis.layers.refresh();
+                }
+            }
+        }
+    }
+
+    // Initialize
+    var share = new Share();
+
+    // Register this module
+    window.WayneState.register('share', share);
+})(jQuery);

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -51,6 +51,7 @@
 @import "partials/profile-listing";
 @import "partials/profile-view";
 @import "partials/rotate";
+@import "partials/share";
 
 // Reusable components
 @import "components/accordion";

--- a/resources/scss/partials/_share.scss
+++ b/resources/scss/partials/_share.scss
@@ -1,0 +1,32 @@
+.addthis_share {
+    color: #4b4b4b;
+    background-color: #e7e7e7;
+    padding: 8px 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    float: left;
+    line-height: 1em;
+    font-size: 14px;
+    margin-right: 3px;
+}
+
+.addthis_sharing_toolbox {
+    display: inline-block;
+    margin-bottom: 1em;
+
+    svg {
+        fill: #4b4b4b !important;
+        width: 20px !important;
+        height: 20px !important;
+    }
+}
+
+.at-icon-wrapper {
+    line-height: 20px;
+    height: 30px;
+    width: 30px;
+}
+
+a.at-icon-wrapper.at-share-btn {
+    background: #e7e7e7 !important;
+}

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -4,11 +4,10 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="Keywords" content="{{ $page['keywords'] }}" />
-    <meta name="Description" content="{{ $page['description'] }}" />
-    <meta http-equiv="last-modified" content="{{ $page['updated-at'] }}" />
     <meta name="Author" content="Wayne State University" />
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    @yield('meta')
+
     <title>@include('partials.head-title')</title>
 
     <link rel="icon" type="image/x-icon" href="https://wayne.edu/favicon.ico" />

--- a/resources/views/news-individual.blade.php
+++ b/resources/views/news-individual.blade.php
@@ -4,6 +4,9 @@
     <h1 class="page-title">{{ $news['title'] }}</h1>
 
     <div class="news-item">
+        <div class="addthis_share">Share</div>
+        <div class="addthis_sharing_toolbox"></div>
+
         <time datetime="{{ $news['posted'] }}">{{ apdatetime(date('F j, Y', strtotime($news['posted']))) }}</time>
 
         {!! $news['body'] !!}

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.' . (isset($layout) ? $layout : 'master'))
 
+@section('meta')
+    @include('partials.meta')
+@endsection
+
 @section('content-area')
     @yield('top')
 

--- a/resources/views/partials/meta.blade.php
+++ b/resources/views/partials/meta.blade.php
@@ -3,8 +3,8 @@
 <meta http-equiv="last-modified" content="{{ isset($page['updated-at']) ? $page['updated-at'] : '' }}" />
 
 <meta property="og:title" content="{{ isset($page['title']) ? $page['title'] : '' }}" />
-<meta property="og:image" content="{{ isset($image) ? $image : '' }}" />
-<meta property="og:image:alt" content="{{ isset($image_alt) ? $image_alt : '' }}" />
+<meta property="og:image" content="{{ isset($meta['image']) ? $meta['image'] : '' }}" />
+<meta property="og:image:alt" content="{{ isset($meta['image_alt']) ? $meta['image_alt'] : '' }}" />
 <meta property="og:description" content="{{ isset($page['description']) ? $page['description'] : '' }}" />
 <meta property="og:url" content="{{ isset($server['url']) ? $server['url'] : '' }}" />
 <meta property="og:type" content="article" />
@@ -24,5 +24,5 @@
 <meta name="twitter:description" content="{{ isset($page['description']) ? $page['description'] : '' }}">
 <meta name="twitter:url" content="{{ isset($server['url']) ? $server['url'] : '' }}">
 <meta name="twitter:site" content="@waynestate">
-<meta name="twitter:image" content="{{ isset($image) ? $image : '' }}">
+<meta name="twitter:image" content="{{ isset($meta['image']) ? $meta['image'] : '' }}">
 <meta property="article:published_time" content="{{ isset($page['updated-at']) ? $page['updated-at'] : '' }}" />

--- a/resources/views/partials/meta.blade.php
+++ b/resources/views/partials/meta.blade.php
@@ -1,0 +1,28 @@
+<meta name="Keywords" content="{{ isset($page['keywords']) ? $page['keywords'] : '' }}" />
+<meta name="Description" content="{{ isset($page['description']) ? $page['description'] : '' }}" />
+<meta http-equiv="last-modified" content="{{ isset($page['updated-at']) ? $page['updated-at'] : '' }}" />
+
+<meta property="og:title" content="{{ isset($page['title']) ? $page['title'] : '' }}" />
+<meta property="og:image" content="{{ isset($image) ? $image : '' }}" />
+<meta property="og:image:alt" content="{{ isset($image_alt) ? $image_alt : '' }}" />
+<meta property="og:description" content="{{ isset($page['description']) ? $page['description'] : '' }}" />
+<meta property="og:url" content="{{ isset($server['url']) ? $server['url'] : '' }}" />
+<meta property="og:type" content="article" />
+<meta property="og:updated_time" content="{{ isset($page['updated-at']) ? $page['updated-at'] : '' }}" />
+<meta property="og:site_name" content="{{ isset($site['title']) ? $site['title'] : '' }}" />
+
+@if(config('app.facebook_profile_id') !== null)
+<meta property="fb:profile_id" content="{{ config('app.facebook_profile_id') }}" />
+@endif
+
+@if(config('app.facebook_app_id') !== null)
+<meta property="fb:app_id" content="{{ config('app.facebook_app_id') }}" />
+@endif
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{  isset($page['title']) ? $page['title'] : ''  }}">
+<meta name="twitter:description" content="{{ isset($page['description']) ? $page['description'] : '' }}">
+<meta name="twitter:url" content="{{ isset($server['url']) ? $server['url'] : '' }}">
+<meta name="twitter:site" content="@waynestate">
+<meta name="twitter:image" content="{{ isset($image) ? $image : '' }}">
+<meta property="article:published_time" content="{{ isset($page['updated-at']) ? $page['updated-at'] : '' }}" />

--- a/tests/Unit/Repositories/NewsRepositoryTest.php
+++ b/tests/Unit/Repositories/NewsRepositoryTest.php
@@ -137,4 +137,45 @@ class NewsRepositoryTest extends TestCase
 
         $this->assertEquals($return, $news);
     }
+
+    /**
+     * @covers App\Repositories\NewsRepository::getImageUrl
+     * @test
+     */
+    public function news_item_with_no_images_should_return_null()
+    {
+        $news['news']['filename'] = '';
+
+        $imageUrl = app('App\Repositories\NewsRepository')->getImageUrl($news);
+
+        $this->assertNull($imageUrl);
+    }
+
+    /**
+     * @covers App\Repositories\NewsRepository::getImageUrl
+     * @test
+     */
+    public function news_item_with_image_should_return_image()
+    {
+        $news['news']['filename'] = $this->faker->imageUrl();
+
+        $imageUrl = app('App\Repositories\NewsRepository')->getImageUrl($news);
+
+        $this->assertEquals($news['news']['filename'], $imageUrl);
+    }
+
+    /**
+     * @covers App\Repositories\NewsRepository::getImageUrl
+     * @test
+     */
+    public function news_item_with_body_image_should_return_image()
+    {
+        $image = $this->faker->imageUrl();
+
+        $news['news']['body'] = '<img src="'.$image.'">';
+
+        $imageUrl = app('App\Repositories\NewsRepository')->getImageUrl($news);
+
+        $this->assertEquals($image, $imageUrl);
+    }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -159,7 +159,7 @@ if (mix.inProduction()) {
                     extensions: ["html", "js", "php", "vue"]
                 }
             ],
-            whitelistPatterns: [/icon-/, /slick-/]
+            whitelistPatterns: [/icon-/, /slick-/, /mfp-/, /at-/]
         })
     );
 }


### PR DESCRIPTION
### Share buttons:
* The only requirement now to add sharing buttons is to have `<div class="addthis_sharing_toolbox"></div>` exist somewhere in the DOM
* Addthis is only loaded if the selector `addthis_sharing_toolbox` is found.
* SPFJS - The module takes care of refreshing the share icons when necessary
* Individual news view is the only page to use these buttons by default

### Meta information
* Meta is now split to a `partials/meta.blade.php` file so it can be overwritten from the view layer.
* By default all meta data is filled out based on the page, server, and site variables.
* SPFJS - I noticed that prior to this PR that no meta data is ever refresh with SPF. Meta data cannot be refreshed due to this issue: https://github.com/youtube/spfjs/issues/258 . We also can't wrap all the meta tags it in a `div` tag and replace the chunk (since a div tag isn't valid in the `head`). This isn't breaking anything though since all the share icons do another request for the page information.
* Since news by default is the only thing that uses sharing, it will figure out what image to use and set for the meta data so sharing via certain social networks will include this image (see the new tests).
* Facebook profile and application id's can be set in `app/config.php` now. These are public and allow the shared content to be associated to an account.

### Preview Image: 
<img width="906" alt="screen shot 2018-01-16 at 10 17 58 am" src="https://user-images.githubusercontent.com/634788/35010124-e04ef3f6-facf-11e7-8a94-85fa0d857670.png">
