### PR TITLE
hotfix/4.3.2

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -26,20 +26,18 @@ class NewsController extends Controller
      * Display the news listing view.
      *
      * @param Request $request
-     * @param string $path
-     * @param string $slug
      * @return \Illuminate\View\View
      */
-    public function index(Request $request, $path, $slug = null)
+    public function index(Request $request)
     {
         // Get the news categories
         $categories = $this->news->getCategories($request->data['site']['id']);
 
         // Set the selected category
-        $categories = $this->news->setSelectedCategory($categories, $slug);
+        $categories = $this->news->setSelectedCategory($categories, $request->slug);
 
         // 404 the page since the category doens't exist or is inactive
-        if ($slug !== null && $categories['selected_news_category']['category_id'] === null) {
+        if ($request->slug !== null && $categories['selected_news_category']['category_id'] === null) {
             return abort('404');
         }
 
@@ -64,13 +62,12 @@ class NewsController extends Controller
      * Display the individual news item view.
      *
      * @param Request $request
-     * @param $id
      * @return \Illuminate\View\View
      */
-    public function show(Request $request, $id)
+    public function show(Request $request)
     {
         // Get the news item
-        $news = $this->news->getNewsItem($id, $request->data['site']['id']);
+        $news = $this->news->getNewsItem($request->id, $request->data['site']['id']);
 
         // If the news item does not belong in the archive and the time has expired, don't show it
         if (isset($news['error']) || $news['news']['archive'] == 0 && strtotime($news['news']['ending']) < time()) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -64,13 +64,13 @@ class ProfileController extends Controller
      * @param int $accessid
      * @return \Illuminate\View\View
      */
-    public function show(Request $request, $accessid = null)
+    public function show(Request $request)
     {
         // Determine what site to pull profiles from
         $site_id = isset($request->data['data']['profile_site_id']) ? $request->data['data']['profile_site_id'] : $request->data['site']['id'];
 
         // Get the profile information
-        $profile = $this->profile->getProfile($site_id, $accessid);
+        $profile = $this->profile->getProfile($site_id, $request->accessid);
 
         // Get the fields to display
         $fields = $this->profile->getFields();

--- a/app/Http/Middleware/SpfMiddleware.php
+++ b/app/Http/Middleware/SpfMiddleware.php
@@ -62,18 +62,33 @@ class SpfMiddleware
         $reflection = $this->getReflectionMethod($request->controller, $method);
 
         // Get the routes dependencies
-        $dependencies = $reflection->getParameters();
+        $dependencies = $this->getReflectionParameters($reflection);
 
-        // Build an array of parameters which can be passed to the reflection method
-        foreach ($dependencies as $key => $value) {
-            if ($value->getName() == 'request') {
-                $parameters[$value->getName()] = $request;
-            } elseif (isset($query[$value->getName()])) {
-                $parameters[$value->getName()] = $query[$value->getName()];
+        // Build an array of parameters
+        foreach ($dependencies as $value) {
+            if ($value == 'request') {
+                $parameters[$value] = $request;
+            } elseif (isset($query[$value])) {
+                $parameters[$value] = $query[$value];
             }
         }
 
         return $parameters;
+    }
+
+    /**
+     * Convert the reflection parameters to an array
+     *
+     * @param \ReflectionMethod $reflection
+     * @return array
+     */
+    public function getReflectionParameters($reflection)
+    {
+        return collect($reflection->getParameters())
+            ->map(function ($value) {
+                return $value->getName();
+            })
+            ->toArray();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Http/Controllers/NewsControllerTest.php
+++ b/tests/Unit/Http/Controllers/NewsControllerTest.php
@@ -34,7 +34,7 @@ class NewsControllerTest extends TestCase
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
         // Call the news listing
-        $view = $newsController->show(new Request(), $this->faker->numberBetween(1, 100));
+        $view = $newsController->show(new Request());
     }
 
     /**
@@ -63,7 +63,7 @@ class NewsControllerTest extends TestCase
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
         // Call the news listing
-        $view = $newsController->show(new Request(), $this->faker->numberBetween(1, 100));
+        $view = $newsController->show(new Request());
     }
 
     /**
@@ -91,7 +91,7 @@ class NewsControllerTest extends TestCase
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
         // Call the news listing
-        $redirect = $newsController->show(new Request(), $this->faker->numberBetween(1, 100));
+        $redirect = $newsController->show(new Request());
 
         // Make sure it redirected properly
         $this->assertEquals(302, $redirect->status());
@@ -136,7 +136,7 @@ class NewsControllerTest extends TestCase
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
         // Call the news listing
-        $view = $newsController->show($request, $this->faker->numberBetween(1, 100));
+        $view = $newsController->show($request);
 
         // Make sure the news title is the page title
         $this->assertEquals($view->getData()['news']['title'], $view->getData()['page']['title']);
@@ -159,7 +159,11 @@ class NewsControllerTest extends TestCase
         // Construct the news controller
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
+        $request = new Request();
+        $request->path = '/news';
+        $request->slug = 'invalid-category';
+
         // Call the news listing
-        $view = $newsController->index(new Request(), '/news', 'invalid-category');
+        $view = $newsController->index($request);
     }
 }


### PR DESCRIPTION
This fixes an issue with news and profiles not loading properly. Switching from lumen to laravel created a bug since the router behaves differently.

Since route matching requires all parameters to be passed to the controller in a specific order, we are changing to checking the request for these values instead. This allows more flexibility and we don't have to pass unused variables anymore to the controller.