### PR TITLE
Feature/routes

### DIFF
--- a/app/Http/Middleware/DataMiddleware.php
+++ b/app/Http/Middleware/DataMiddleware.php
@@ -109,7 +109,7 @@ class DataMiddleware
     /**
      * Get the path from the request.
      *
-     * @param Request $request
+     * @param \Illuminate\Http\Request $request
      * @return string
      */
     public function getPathFromRequest(Request $request)

--- a/app/Http/Middleware/DataMiddleware.php
+++ b/app/Http/Middleware/DataMiddleware.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class DataMiddleware
@@ -24,37 +25,12 @@ class DataMiddleware
             $this->prefix = 'Styleguide';
         }
 
-        /*
-         * Set the route parameters to global data. These parameters are everything
-         * that was matched and captured from the routes file.
-         */
+        //Set the matched route parameters to global data
         $data['parameters'] = $request->route() !== null ? $request->route()->parameters : [];
 
-        /*
-         * If no path was matched then set the path to the current relative
-         * url from the request or the route uri. The path is used later
-         * to determine the page data and will 404 if the path isn't
-         * translated to a valid json file in the public folder.
-         */
+        // If no path was matched from the route parameters, get the path from the request
         if (! isset($data['parameters']['path']) || $data['parameters']['path'] == '') {
-            // When a request object is created manually that hasn't matched a route (ex: tests).
-            if ($request->route() === null) {
-                $data['parameters']['path'] = $request->path();
-            } else {
-                // Replace the any route parameter so we can get access to starting route to find the json file
-                $uri = str_replace('{any?}', '', $request->route()->uri);
-
-                // Check the route uri and trim off all parts that are route parameters.
-                $path = collect(explode('/', $uri))
-                    ->filter(function ($item) {
-                        if (! strstr($item, '{')) {
-                            return $item;
-                        }
-                    })
-                    ->implode('/');
-
-                $data['parameters']['path'] = isset($request->any) ? $request->any.$path : $path;
-            }
+            $data['parameters']['path'] = $this->getPathFromRequest($request);
         }
 
         // Set the current url
@@ -128,5 +104,33 @@ class DataMiddleware
     public function getPrefix()
     {
         return $this->prefix;
+    }
+
+    /**
+     * Get the path from the request.
+     *
+     * @param Request $request
+     * @return string
+     */
+    public function getPathFromRequest(Request $request)
+    {
+        // When a request object is created manually that hasn't matched a route (ex: tests).
+        if ($request->route() === null) {
+            return $request->path();
+        }
+
+        // Replace the any route parameter so we can get access to starting route to find the json file
+        $uri = str_replace('{any?}', '', $request->route()->uri);
+
+        // Check the route uri and trim off all parts that are route parameters.
+        $path = collect(explode('/', $uri))
+            ->filter(function ($item) {
+                if (! strstr($item, '{')) {
+                    return $item;
+                }
+            })
+            ->implode('/');
+
+        return isset($request->any) ? $request->any.$path : $path;
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,29 +12,23 @@
 */
 
 // Profile view
-Route::get('{path}/{accessid}', 'ProfileController@show')
-    ->where(['path' => '(?:.*\/|)profile', 'accessid' => '.+'])
+Route::get('{any?}profile/{accessid}', 'ProfileController@show')
+    ->where(['any' => '.*', 'accessid' => '.+'])
     ->middleware('data', 'formy');
 
 // News by category
-Route::get('{path}/category/{slug}', 'NewsController@index')
-    ->where(['path' => '(?:.*\/|)news', 'slug' => '.+'])
+Route::get('{any?}news/category/{slug}', 'NewsController@index')
+    ->where(['any' => '.*', 'slug' => '.+'])
     ->middleware('data', 'formy');
 
 // News view
-Route::get('{path}/{slug}-{id}', 'NewsController@show')
-    ->where(['path' => '(?:.*\/|)news', 'slug' => '.+', 'id' => '\d+'])
-    ->middleware('data', 'formy');
-
-// News listing
-Route::get('{path}', 'NewsController@index')
-    ->name('news')
-    ->where('path', '(?:.*\/|)news')
+Route::get('{any?}news/{slug}-{id}', 'NewsController@show')
+    ->where(['any' => '.*', 'slug' => '.+', 'id' => '\d+'])
     ->middleware('data', 'formy');
 
 // The wild card route is a catch all route that tries to resolve the requests path to a json file
-Route::match(['get', 'post'], '{any}', function (Illuminate\Http\Request $request) {
+Route::match(['get', 'post'], '{path}', function (Illuminate\Http\Request $request) {
         return app($request->controller)->index($request);
     })
-    ->where('any', '.*')
+    ->where('path', '.*')
     ->middleware('data', 'formy');


### PR DESCRIPTION
Complete overhaul of how we match routes.

## Problem

```
// Release Individual Show
Route::get('{path}/{slug}-{id}', 'ReleaseController@show')
    ->where(['path' => 'release', 'slug' => '[A-Za-z0-9-]+', 'id' => '\d+'])
    ->middleware('data', 'formy', 'spf');

// Mention Individual Show
Route::get('{path}/{slug}-{id}', 'MentionController@show')
    ->where(['path' => 'mention', 'slug' => '[A-Za-z0-9-]+', 'id' => '\d+'])
    ->middleware('data', 'formy', 'spf');
```

Since  both of these examples have the same `'{path}/{slug}-{id}'` they are conflicting with each other. Laravel caches these keyed by this value, so the later route is the one that actually exists. 

## Soultion

Since we need these to be unique we need to move the `'path' => 'release'` back into the route to make it unique. In doing so, the `dataMiddleware` needs updated to be able to parse back out the name that will match the JSON file for that page. Lets take a look at the new individual news route example.

```
// News view
Route::get('{any?}news/{slug}-{id}', 'NewsController@show')
    ->where(['any' => '.*', 'slug' => '.+', 'id' => '\d+'])
    ->middleware('data', 'formy');
```

The `dataMiddleware` will now parse out `news` as the path. If a subsite exists, say `styleguide/news/` it will also take into consideration that and return it in the path.