### PR TITLE
Hotfix/4.4.1

### DIFF
--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -17,7 +17,7 @@ class PageRepository implements DataRepositoryContract, PageRepositoryContract
         $pageData = [];
 
         // Set the path
-        $path = isset($data['parameters']['path']) ? $data['parameters']['path'] : '/';
+        $path = isset($data['parameters']['path']) && $data['parameters']['path'] !== '' ? $data['parameters']['path'] : '/';
 
         // Get the filename
         $filename = $this->getFilename($path);

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "waynestate/error-500": "~1.1",
         "waynestate/formy-parser": "~1.0",
         "waynestate/parse-menu": "~1.2",
-        "waynestate/parse-promos": "~1.1",
+        "waynestate/parse-promos": "~1.2",
         "waynestate/waynestate-api": "~1.2",
         "waynestate/image-faker": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "laravel/envoy": "^1.1",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~6.0",
-        "php-coveralls/php-coveralls": "dev-master"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ef9c7e3f5ea2b18e61188d5198c8b56",
+    "content-hash": "8085d63d911f9c0e746b561e8ab67baf",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -3823,16 +3823,16 @@
         },
         {
             "name": "php-coveralls/php-coveralls",
-            "version": "dev-master",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-coveralls/php-coveralls.git",
-                "reference": "4f82a64e0c11575e4becdbca7889dff2b21f82f1"
+                "reference": "3eaf7eb689cdf6b86801a3843940d974dc657068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/4f82a64e0c11575e4becdbca7889dff2b21f82f1",
-                "reference": "4f82a64e0c11575e4becdbca7889dff2b21f82f1",
+                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/3eaf7eb689cdf6b86801a3843940d974dc657068",
+                "reference": "3eaf7eb689cdf6b86801a3843940d974dc657068",
                 "shasum": ""
             },
             "require": {
@@ -3902,7 +3902,7 @@
                 "github",
                 "test"
             ],
-            "time": "2017-12-11T11:06:38+00:00"
+            "time": "2017-12-08T14:28:16+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -5591,9 +5591,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "php-coveralls/php-coveralls": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d2c065f653b0053e61fdabb8f453155",
+    "content-hash": "6ef9c7e3f5ea2b18e61188d5198c8b56",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
-            "version": "v3.1.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/laravel-debugbar.git",
-                "reference": "f0018d359a2ad6968ad11b283283a925e017f3c9"
+                "reference": "59a7a08d84111a5b2407fb58b9d74af3ebe430e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/f0018d359a2ad6968ad11b283283a925e017f3c9",
-                "reference": "f0018d359a2ad6968ad11b283283a925e017f3c9",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/59a7a08d84111a5b2407fb58b9d74af3ebe430e7",
+                "reference": "59a7a08d84111a5b2407fb58b9d74af3ebe430e7",
                 "shasum": ""
             },
             "require": {
@@ -72,7 +72,7 @@
                 "profiler",
                 "webprofiler"
             ],
-            "time": "2018-02-07T08:29:09+00:00"
+            "time": "2018-02-07T19:51:45+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2776,16 +2776,16 @@
         },
         {
             "name": "waynestate/parse-promos",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waynestate/parse-promos.git",
-                "reference": "8734921ceda04797b64fba858526eb943320642f"
+                "reference": "4c6cf1f99016e097094a5e149a42135500bf8354"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waynestate/parse-promos/zipball/8734921ceda04797b64fba858526eb943320642f",
-                "reference": "8734921ceda04797b64fba858526eb943320642f",
+                "url": "https://api.github.com/repos/waynestate/parse-promos/zipball/4c6cf1f99016e097094a5e149a42135500bf8354",
+                "reference": "4c6cf1f99016e097094a5e149a42135500bf8354",
                 "shasum": ""
             },
             "require": {
@@ -2818,7 +2818,7 @@
                 "array",
                 "parse"
             ],
-            "time": "2017-12-05T13:50:32+00:00"
+            "time": "2018-02-14T14:49:23+00:00"
         },
         {
             "name": "waynestate/string-middleware",
@@ -4109,16 +4109,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
+                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
                 "shasum": ""
             },
             "require": {
@@ -4130,7 +4130,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -4168,7 +4168,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-11T18:49:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/resources/scss/_settings.scss
+++ b/resources/scss/_settings.scss
@@ -81,9 +81,9 @@ $print-transparent-backgrounds: true;
 
 $breakpoints: (
     small: 0,
-    medium: 780px,
-    large: 990px,
-    xlarge: 1200px,
+    medium: 420px,
+    large: 780px,
+    xlarge: 990px,
     offcanvas: 780px, // Change this value based on the length of the top menu
 );
 $breakpoint-classes: (small medium large xlarge offcanvas);

--- a/resources/scss/components/_table-stack.scss
+++ b/resources/scss/components/_table-stack.scss
@@ -20,7 +20,7 @@
         }
 
         /* Stack rows vertically on small screens */
-        @include breakpoint(small only) {
+        @include breakpoint(medium down) {
             /* Hide column labels */
             thead tr {
                 position: absolute;
@@ -66,7 +66,7 @@
         }
 
         /* Stack labels vertically on smaller screens */
-        @include breakpoint(small only) {
+        @include breakpoint(medium down) {
             td {
                 padding-left: 0.75em;
             }

--- a/resources/scss/partials/_footer-social.scss
+++ b/resources/scss/partials/_footer-social.scss
@@ -72,7 +72,7 @@
             color: white;
         }
 
-        @include breakpoint(medium) {
+        @include breakpoint(large) {
             font-size: rem-calc(30);
             height: rem-calc(55);
             width: rem-calc(55);

--- a/resources/scss/partials/_profile-view.scss
+++ b/resources/scss/partials/_profile-view.scss
@@ -16,7 +16,7 @@
     margin: rem-calc(40) auto 1em;
     padding: 0;
 
-    @include breakpoint(medium up) {
+    @include breakpoint(large up) {
         margin-top: rem-calc(20);
         width: 100%;
         height: auto;

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -36,7 +36,7 @@
             @endif
         </div>
 
-        <div class="small-12 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))large-12 medium-12 @else medium-9 @endif columns content" data-off-canvas-content>
+        <div class="small-12 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))medium-12 @else medium-9 @endif columns content" data-off-canvas-content>
 
             @if(isset($hero) && $hero != false && $site_menu['meta']['has_selected'] == true || config('app.hero_contained') === true)
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])

--- a/resources/views/partials/footer-contact.blade.php
+++ b/resources/views/partials/footer-contact.blade.php
@@ -20,7 +20,7 @@
         @else
             <div class="row" data-equalizer>
                 @foreach($contact as $info)
-                    <div class="columns small-12 medium-4{{ ($info == end($contact)) ? ' end' : '' }}" data-equalizer-watch>
+                    <div class="columns small-12 medium-4 {{ ($info == end($contact)) ? ' end' : '' }}" data-equalizer-watch>
                         {!! $info['description'] !!}
 
                         <hr />

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -10,14 +10,14 @@
     @endif
 
     <div class="row profile__block">
-        <div class="small-12 medium-4 columns">
+        <div class="small-12 large-4 columns">
             @if(isset($profile['data']['Picture']['url']))
                 <img src="{{ $profile['data']['Picture']['url'] }}" alt="{{ $page['title'] }}" class="profile__img">
             @else
                 <img src="/_resources/images/no-photo.svg" alt="{{ $page['title'] }}" class="profile__img">
             @endif
 
-            <h1 class="hide-for-medium page-title">{{ $page['title'] }}</h1>
+            <h1 class="hide-for-large page-title">{{ $page['title'] }}</h1>
 
             <div class="profile--contact-info">
                 @if(isset($profile['data']['Title']))
@@ -54,8 +54,8 @@
              </div>
         </div>
 
-        <div class="small-12 medium-8 columns">
-            <h1 class="page-title show-for-medium">{{ $page['title'] }}</h1>
+        <div class="small-12 large-8 columns">
+            <h1 class="page-title show-for-large">{{ $page['title'] }}</h1>
 
             @foreach($profile['data'] as $field=>$data)
                 @if(!in_array($field, $contact_fields) && !in_array($field, $hidden_fields))

--- a/styleguide/Repositories/PromoRepository.php
+++ b/styleguide/Repositories/PromoRepository.php
@@ -36,7 +36,7 @@ class PromoRepository extends Repository
         $hero = isset($hero_page_ids[$data['page']['id']]) ? app('Factories\HeroImage')->create($hero_page_ids[$data['page']['id']]) : null;
 
         $accordion_page_ids = [
-            108100 => 5,
+            107100 => 5,
         ];
 
         // Only pull accordion for childpage template

--- a/styleguide/Views/styleguide-minievents.blade.php
+++ b/styleguide/Views/styleguide-minievents.blade.php
@@ -4,7 +4,7 @@
     <h1 class="page-title">{{ $page['title'] }}</h1>
 
     <div class="row">
-        <div class="medium-6 columns">
+        <div class="small-12 large-6 columns">
             @if(isset($events))
                 @include('components.mini-events', ['events' => $events])
             @endif

--- a/styleguide/Views/styleguide-minilist.blade.php
+++ b/styleguide/Views/styleguide-minilist.blade.php
@@ -4,7 +4,7 @@
     <h1 class="page-title">{{ $page['title'] }}</h1>
 
     <div class="row">
-        <div class="medium-6 columns">
+        <div class="small-12 large-6 columns">
             @if(isset($minilist))
                 @include('components.mini-list', ['items' => $minilist, 'url' => 'https://wayne.edu/', 'heading' => 'Heading'])
             @endif

--- a/styleguide/Views/styleguide-mininews.blade.php
+++ b/styleguide/Views/styleguide-mininews.blade.php
@@ -4,7 +4,7 @@
     <h1 class="page-title">{{ $page['title'] }}</h1>
 
     <div class="row">
-        <div class="medium-6 columns">
+        <div class="small-12 large-6 columns">
             @if(isset($news))
                 @include('components.mini-news', ['news' => $news, 'url' => $site['subsite-folder'].'news'])
             @endif

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -222,7 +222,7 @@
     <hr>
 
     <div class="row">
-        <div class="large-3 columns">
+        <div class="medium-3 columns">
             <h2>Figure (left)</h2>
 
             <figure class="float-left" style="margin-top: 15px;">
@@ -242,7 +242,7 @@
             </pre>
         </div>
 
-        <div class="large-3 columns">
+        <div class="medium-3 columns">
             <h2>Figure (center)</h2>
 
             <figure class="text-center">
@@ -262,7 +262,7 @@
             </pre>
         </div>
 
-        <div class="large-3 columns">
+        <div class="medium-3 columns">
             <h2>Figure</h2>
 
             <figure>
@@ -282,7 +282,7 @@
             </pre>
         </div>
 
-        <div class="large-3 columns">
+        <div class="medium-3 columns">
             <h2>Figure (right)</h2>
 
             <figure class="float-right" style="margin-top: 15px;">


### PR DESCRIPTION
* Fixed an issue of the homepage not loading due to the path always existing. It wouldn't resolve the index.json file
* Fixed an issue of php coveralls referring to a branch that no longer exists
* Fixed the styleguide accordion page to pull the proper page id since it was changed when SPF was removed.
* Updated the breakpoints to introduce 420 for small and updated the html references to reflect the change.
* Updated parse promos to the newest version which resolves an issue of returing `false` instead of a blank array when using the `first` config value
