### PR TITLE
Fix an issue with top menu going to a new line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/partials/_menu-top.scss
+++ b/resources/scss/partials/_menu-top.scss
@@ -35,7 +35,7 @@
         }
 
         &.title-area {
-            @include breakpoint(small) {
+            @include breakpoint($menu-top-breakpoint down) {
                 width: 75%;
             }
         }


### PR DESCRIPTION
Example issue below. It's forcing 75% width on the header at all times right now.

<img width="1217" alt="screen shot 2018-02-19 at 11 16 16 am" src="https://user-images.githubusercontent.com/634788/36387233-583d387c-1566-11e8-8696-e866272baa53.png">
