### PR TITLE
Feature/test empty factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,10 @@ $menus = [
 
 1. Create repository contract: `contracts/Repositories`
 1. Create repository: `app/Repositories`
-    * implement the repository contract
+    * Implement the repository contract
+    * It's important to return a blank array for instances when no data is found. This way the view can consistantly check for `@if(!empty($item))` to hide areas on the page.
 1. Create fake repository: `styleguide/Repositories`
-    * implement the repository contract
+    * Implement the repository contract
     * Extend the real repository from `app/Repositories`.
     * Overload any methods necessary and use or create `factories/` to get fake data.
 1. Create controller

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -72,13 +72,13 @@ class ProfileController extends Controller
         // Get the profile information
         $profile = $this->profile->getProfile($site_id, $request->accessid);
 
-        // Get the fields to display
-        $fields = $this->profile->getFields();
-
         // Make sure the profile exists
-        if ($profile['profile'] === null) {
+        if (empty($profile['profile'])) {
             return abort('404');
         }
+
+        // Get the fields to display
+        $fields = $this->profile->getFields();
 
         // Change page title to profile name
         $request->data['page']['title'] = $this->profile->getPageTitleFromName($profile);

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -197,7 +197,7 @@ class ProfileRepository implements ProfileRepositoryContract
             return $this->wsuApi->sendRequest($params['method'], $params)['profiles'];
         });
 
-        $profile['profile'] = isset($profiles[$site_id]) ? $profiles[$site_id] : [];
+        $profile['profile'] = array_get($profiles, $site_id, []);
 
         return $profile;
     }

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -197,7 +197,7 @@ class ProfileRepository implements ProfileRepositoryContract
             return $this->wsuApi->sendRequest($params['method'], $params)['profiles'];
         });
 
-        $profile['profile'] = isset($profiles[$site_id]) ? $profiles[$site_id] : null;
+        $profile['profile'] = isset($profiles[$site_id]) ? $profiles[$site_id] : [];
 
         return $profile;
     }

--- a/tests/Feature/PageRepositoryTest.php
+++ b/tests/Feature/PageRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Styleguide\Repositories;
 
 use Tests\TestCase;
+use Mockery as Mockery;
 use Illuminate\Support\Facades\Storage;
 
 class PageRepositoryTest extends TestCase
@@ -18,18 +19,59 @@ class PageRepositoryTest extends TestCase
      */
     public function all_styleguide_routes_should_load_successfully()
     {
-        // Check all repository routes to ensure they load
-        collect(Storage::disk('base')->allFiles('styleguide/Pages'))
-        ->reject(function ($filename) {
-            return in_array(basename($filename), ['Page.php']);
-        })
-        ->each(function ($filename) {
-            $path = app('Styleguide\Pages\\'.basename($filename, '.php'))->getPath();
+        $this->getPageResponses()
+            ->each(function ($page) {
+                $this->assertTrue(is_string($page['path']), 'ERROR: Path to styleguide page not found. Make sure it exists in the styleguide menu. Optionally you can added public $path = \'/styleguide/path/to/page\' in your styleguide Page class.');
 
-            $response = $this->call('GET', $path);
+                $this->assertEquals(200, $page['response']->status(), 'Styleguide error at path: '.$page['path']);
+            });
+    }
 
-            $this->assertTrue(is_string($path), 'ERROR: Path to styleguide page not found. Make sure it exists in the styleguide menu. Optionally you can added public $path = \'/styleguide/path/to/page\' in your styleguide Page class.');
-            $this->assertEquals(200, $response->status(), 'Styleguide error at path: '.$path);
-        });
+    /**
+     * @test
+     */
+    public function all_styleguide_routes_with_no_data_should_load_successfully()
+    {
+        // Overload all styleguide repositories to only return a blank array
+        collect(Storage::disk('base')->allFiles('factories'))
+            ->reject(function ($filename) {
+                return in_array(basename($filename), ['Page.php']);
+            })
+            ->each(function ($filename) {
+                $class = 'Factories\\'.basename($filename, '.php');
+
+                $this->app->bind($class, function ($app) use ($class) {
+                    $factory = Mockery::mock($class)->makePartial();
+                    $factory->shouldReceive('create')->andReturn([]);
+
+                    return $factory;
+                });
+            });
+
+        $this->getPageResponses()
+            ->each(function ($page) {
+                $this->assertTrue(($page['response']->status() !== 500), '500 error in styleguide at path: '.$page['path'] . '. This is likely due to not accounting for a blank array coming back from the factory in your view.');
+            });
+    }
+
+    /**
+     * Get all styleguide page responses.
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function getPageResponses()
+    {
+        return collect(Storage::disk('base')->allFiles('styleguide/Pages'))
+            ->reject(function ($filename) {
+                return in_array(basename($filename), ['Page.php']);
+            })
+            ->map(function ($filename) {
+                $path = app('Styleguide\Pages\\'.basename($filename, '.php'))->getPath();
+
+                return [
+                    'path' => $path,
+                    'response' => $this->call('GET', $path),
+                ];
+            });
     }
 }

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -117,7 +117,7 @@ class ProfileRepositoryTest extends TestCase
      * @covers App\Repositories\ProfileRepository::getProfile
      * @test
      */
-    public function getting_profile_that_doesnt_exist_should_return_null()
+    public function getting_profile_that_doesnt_exist_should_return_blank_array()
     {
         $site_id = $this->faker->numberBetween(1, 10);
         $invalid_site_id = $this->faker->numberBetween(20, 30);
@@ -137,7 +137,7 @@ class ProfileRepositoryTest extends TestCase
 
         $profile = app('App\Repositories\ProfileRepository', ['wsuApi' => $wsuApi])->getProfile($site_id, $accessid);
 
-        $this->assertNull($profile['profile']);
+        $this->assertTrue(is_array($profile['profile']) && count($profile['profile']) == 0) ;
     }
 
     /**


### PR DESCRIPTION
The reason for this test is to ensure the views are properly checking for data that might not exist. Blank arrays should always be passed down to the view if a item is not found. The best check in the view is to use `@if(!empty($item))` before interacting with `$item`.