### PR TITLE
Styleguide Pages

### DIFF
--- a/factories/Page.php
+++ b/factories/Page.php
@@ -22,20 +22,15 @@ class Page implements FactoryContract
      */
     public function create($limit = 1, $options = [])
     {
-        // Set default values that need to be the same for every page on this site
-        $site_id = $this->faker->randomDigit();
-        $title = $this->faker->sentence($this->faker->numberBetween(2, 4));
-        $menu_id = $this->faker->randomDigit();
-
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
                 'site' => [
-                    'id' => $site_id,
-                    'title' => $title,
+                    'id' => 2,
+                    'title' => 'Styleguide',
                     'keywords' => '',
-                    'subsite-folder' => null,
+                    'subsite-folder' => 'styleguide/',
                     'parent' => [
-                        'id' => null,
+                        'id' => 1,
                     ],
                 ],
                 'page' => [
@@ -50,7 +45,7 @@ class Page implements FactoryContract
                     'updated-at' => '',
                 ],
                 'menu' => [
-                    'id' => $menu_id,
+                    'id' => 1,
                 ],
                 'data' => [],
             ];

--- a/styleguide/Pages/Accordion.php
+++ b/styleguide/Pages/Accordion.php
@@ -20,9 +20,6 @@ class Accordion extends Page
                     <p>'.$this->faker->paragraph(8).'</p>',
                 ],
             ],
-            'menu' => [
-                'id' => 1,
-            ],
         ]);
     }
 }

--- a/styleguide/Pages/Banner.php
+++ b/styleguide/Pages/Banner.php
@@ -14,10 +14,6 @@ class Banner extends Page
                 'controller' => 'BannerController',
                 'title' => 'Banner',
                 'id' => 113100,
-                'content' => [],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Childpage.php
+++ b/styleguide/Pages/Childpage.php
@@ -20,9 +20,6 @@ class Childpage extends Page
                     <p>'.$this->faker->paragraph(8).'</p>',
                 ],
             ],
-            'menu' => [
-                'id' => 1,
-            ],
         ]);
     }
 }

--- a/styleguide/Pages/Components.php
+++ b/styleguide/Pages/Components.php
@@ -14,12 +14,6 @@ class Components extends Page
                 'controller' => 'ChildpageController',
                 'title' => 'Components',
                 'id' => 102,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Directory.php
+++ b/styleguide/Pages/Directory.php
@@ -14,15 +14,6 @@ class Directory extends Page
                 'controller' => 'DirectoryController',
                 'title' => 'Directory',
                 'id' => 101104,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/Error.php
+++ b/styleguide/Pages/Error.php
@@ -14,12 +14,6 @@ class Error extends Page
                 'controller' => 'ChildpageController',
                 'title' => 'Error Pages',
                 'id' => 106100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Error403.php
+++ b/styleguide/Pages/Error403.php
@@ -14,12 +14,6 @@ class Error403 extends Page
                 'controller' => 'Error403Controller',
                 'title' => '403 Page',
                 'id' => 106100100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Error404.php
+++ b/styleguide/Pages/Error404.php
@@ -14,12 +14,6 @@ class Error404 extends Page
                 'controller' => 'Error404Controller',
                 'title' => '404 Page',
                 'id' => 106100101,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Error500.php
+++ b/styleguide/Pages/Error500.php
@@ -14,12 +14,6 @@ class Error500 extends Page
                 'controller' => 'Error500Controller',
                 'title' => '500 Page',
                 'id' => 106100102,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/FooterContactOne.php
+++ b/styleguide/Pages/FooterContactOne.php
@@ -14,12 +14,6 @@ class FooterContactOne extends Page
                 'controller' => 'FooterContactOneController',
                 'title' => 'Footer Contact One Column',
                 'id' => 104100100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/FooterContactThree.php
+++ b/styleguide/Pages/FooterContactThree.php
@@ -14,12 +14,6 @@ class FooterContactThree extends Page
                 'controller' => 'FooterContactThreeController',
                 'title' => 'Footer Contact Three Column',
                 'id' => 104100102,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/FooterContactTwo.php
+++ b/styleguide/Pages/FooterContactTwo.php
@@ -14,12 +14,6 @@ class FooterContactTwo extends Page
                 'controller' => 'FooterContactTwoController',
                 'title' => 'Footer Contact Two Column',
                 'id' => 104100101,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Forms.php
+++ b/styleguide/Pages/Forms.php
@@ -14,12 +14,6 @@ class Forms extends Page
                 'controller' => 'FormsController',
                 'title' => 'Forms',
                 'id' => 112100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeaderTitleDouble.php
+++ b/styleguide/Pages/HeaderTitleDouble.php
@@ -14,12 +14,6 @@ class HeaderTitleDouble extends Page
                 'controller' => 'HeaderTitleDoubleController',
                 'title' => 'Header Title Double',
                 'id' => 102100101,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeaderTitleSingle.php
+++ b/styleguide/Pages/HeaderTitleSingle.php
@@ -14,12 +14,6 @@ class HeaderTitleSingle extends Page
                 'controller' => 'HeaderTitleSingleController',
                 'title' => 'Header Title Single',
                 'id' => 102100100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroContained.php
+++ b/styleguide/Pages/HeroContained.php
@@ -14,12 +14,6 @@ class HeroContained extends Page
                 'controller' => 'ChildpageController',
                 'title' => 'Hero Contained',
                 'id' => 105100100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroContainedRotate.php
+++ b/styleguide/Pages/HeroContainedRotate.php
@@ -14,12 +14,6 @@ class HeroContainedRotate extends Page
                 'controller' => 'ChildpageController',
                 'title' => 'Hero Contained With Rotate',
                 'id' => 105100101,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroContainedText.php
+++ b/styleguide/Pages/HeroContainedText.php
@@ -14,12 +14,6 @@ class HeroContainedText extends Page
                 'controller' => 'HeroContainedTextController',
                 'title' => 'Contained (Rotate With Text)',
                 'id' => 105100102,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroContainedTextLink.php
+++ b/styleguide/Pages/HeroContainedTextLink.php
@@ -14,12 +14,6 @@ class HeroContainedTextLink extends Page
                 'controller' => 'HeroContainedTextLinkController',
                 'title' => 'Contained (With Text/Link)',
                 'id' => 105100103,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroFull.php
+++ b/styleguide/Pages/HeroFull.php
@@ -17,12 +17,6 @@ class HeroFull extends Page
                 'controller' => 'HeroFullController',
                 'title' => 'Hero Full',
                 'id' => 1,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroFullMenu.php
+++ b/styleguide/Pages/HeroFullMenu.php
@@ -17,12 +17,6 @@ class HeroFullMenu extends Page
                 'controller' => 'HeroFullMenuController',
                 'title' => 'Hero Full (Menu)',
                 'id' => 3,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroFullRotate.php
+++ b/styleguide/Pages/HeroFullRotate.php
@@ -17,12 +17,6 @@ class HeroFullRotate extends Page
                 'controller' => 'HeroFullController',
                 'title' => 'Hero Full (Rotate)',
                 'id' => 2,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/HeroFullTextLink.php
+++ b/styleguide/Pages/HeroFullTextLink.php
@@ -17,12 +17,6 @@ class HeroFullTextLink extends Page
                 'controller' => 'HeroFullTextLinkController',
                 'title' => 'Hero Full (Text/Link)',
                 'id' => 105100107,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Homepage.php
+++ b/styleguide/Pages/Homepage.php
@@ -17,12 +17,6 @@ class Homepage extends Page
                'controller' => 'HomepageController',
                'title' => 'Homepage',
                'id' => 101101,
-               'content' => [
-                   'main' => '<p>'.$this->faker->paragraph(8).'</p>',
-               ],
-           ],
-           'menu' => [
-               'id' => 1,
            ],
        ]);
     }

--- a/styleguide/Pages/ImageList.php
+++ b/styleguide/Pages/ImageList.php
@@ -14,10 +14,6 @@ class ImageList extends Page
                 'controller' => 'ImageListController',
                 'title' => 'Image List',
                 'id' => 108100,
-                'content' => [],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/MenuLeft.php
+++ b/styleguide/Pages/MenuLeft.php
@@ -14,12 +14,6 @@ class Menuleft extends Page
                 'controller' => 'MenuLeftController',
                 'title' => 'Menu Left',
                 'id' => 103100100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/MenuTop.php
+++ b/styleguide/Pages/MenuTop.php
@@ -14,12 +14,6 @@ class MenuTop extends Page
                 'controller' => 'MenuTopController',
                 'title' => 'Menu Top',
                 'id' => 103100101,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Minievents.php
+++ b/styleguide/Pages/Minievents.php
@@ -14,13 +14,6 @@ class Minievents extends Page
                 'controller' => 'MiniEventsController',
                 'title' => 'Mini Events',
                 'id' => 110100,
-                'content' => [],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/Minilist.php
+++ b/styleguide/Pages/Minilist.php
@@ -14,13 +14,6 @@ class Minilist extends Page
                 'controller' => 'MiniListController',
                 'title' => 'Mini List',
                 'id' => 111100,
-                'content' => [],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/Mininews.php
+++ b/styleguide/Pages/Mininews.php
@@ -14,13 +14,6 @@ class Mininews extends Page
                 'controller' => 'MiniNewsController',
                 'title' => 'Mini News',
                 'id' => 109100,
-                'content' => [],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/News.php
+++ b/styleguide/Pages/News.php
@@ -10,19 +10,10 @@ class News extends Page
     public function getPageData()
     {
         return app('Factories\Page')->create(1, [
-            'site' => [
-                'subsite-folder' => 'styleguide/',
-            ],
             'page' => [
                 'controller' => 'NewsController',
                 'title' => 'News Listing',
                 'id' => 101102,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/NoMenu.php
+++ b/styleguide/Pages/NoMenu.php
@@ -23,9 +23,6 @@ class NoMenu extends Page
                     <p>'.$this->faker->paragraph(8).'</p>',
                 ],
             ],
-            'menu' => [
-                'id' => null,
-            ],
         ]);
     }
 }

--- a/styleguide/Pages/NotInMenu.php
+++ b/styleguide/Pages/NotInMenu.php
@@ -23,9 +23,6 @@ class NotInMenu extends Page
                     <p>'.$this->faker->paragraph(8).'</p>',
                 ],
             ],
-            'menu' => [
-                'id' => 1,
-            ],
         ]);
     }
 }

--- a/styleguide/Pages/Page.php
+++ b/styleguide/Pages/Page.php
@@ -31,12 +31,6 @@ class Page implements StyleguidePageContract
                 'controller' => 'ChildpageController',
                 'title' => 'Childpage',
                 'id' => 1,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Profile.php
+++ b/styleguide/Pages/Profile.php
@@ -17,12 +17,6 @@ class Profile extends Page
                 'controller' => 'ProfileController',
                 'title' => 'Profile View',
                 'id' => null,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }

--- a/styleguide/Pages/Profiles.php
+++ b/styleguide/Pages/Profiles.php
@@ -14,15 +14,6 @@ class Profiles extends Page
                 'controller' => 'ProfileController',
                 'title' => 'Profile Listing',
                 'id' => 101103,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/Styleguide.php
+++ b/styleguide/Pages/Styleguide.php
@@ -14,15 +14,6 @@ class Styleguide extends Page
                 'controller' => 'StyleGuideController',
                 'title' => 'Content Area',
                 'id' => 100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
-            ],
-            'site' => [
-                'subsite-folder' => 'styleguide/',
             ],
         ]);
     }

--- a/styleguide/Pages/Tablestack.php
+++ b/styleguide/Pages/Tablestack.php
@@ -14,12 +14,6 @@ class Tablestack extends Page
                 'controller' => 'TableStackController',
                 'title' => 'Table Stack',
                 'id' => 114100,
-                'content' => [
-                    'main' => '',
-                ],
-            ],
-            'menu' => [
-                'id' => 1,
             ],
         ]);
     }


### PR DESCRIPTION
Since page repository is used specifically for the styleguide, I moved the subsite and menu id into the factory itself to simplify every page. I also removed content area from them when its not needed. 

This will help in cases where you want to reference the subsite folder in your view to prepend /stylegudie to a URL. You don't have to think about adding it to your Page Class anymore.