### PR TITLE
WCAG 2.0 AA updates

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -14,7 +14,7 @@ return [
      |
      */
 
-    'enabled' => env('DEBUGBAR_ENABLED', null),
+    'enabled' => env('DEBUGBAR_ENABLED', false),
     'except' => [
         //
     ],

--- a/resources/scss/components/_mini-list.scss
+++ b/resources/scss/components/_mini-list.scss
@@ -1,12 +1,19 @@
+ul.listing,
 dl.listing {
+    list-style: none;
+    padding: 0;
     margin: 0;
+}
 
-    dt {
+.listing {
+    dt,
+    li {
         margin: 0 0 rem-calc(15) 0;
         line-height: 1.5em;
     }
 
-    dt a {
+    dt a,
+    li a {
         font-weight: normal;
         text-decoration: underline;
 

--- a/resources/scss/partials/_utilities.scss
+++ b/resources/scss/partials/_utilities.scss
@@ -24,3 +24,32 @@
 .position-relative {
     position: relative;
 }
+
+.skip ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.skip a {
+    position: absolute;
+    left: -1000px;
+    height: 1px;
+    width: 1px;
+    text-align: left;
+    overflow: hidden;
+    color: #000;
+    background: #fff;
+    padding: 4px;
+}
+
+.skip a:active,
+.skip a:focus,
+.skip a:hover {
+    left: 0;
+    top: 0;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    z-index: 10000;
+}

--- a/resources/views/components/mini-list.blade.php
+++ b/resources/views/components/mini-list.blade.php
@@ -6,12 +6,12 @@
 --}}
 <h2>{{ $heading or 'Resources' }}</h2>
 
-<dl class="listing">
+<ul class="listing">
     @foreach($items as $item)
-        <dt>
+        <li>
             <a href="{{ $item['link'] }}">{{ $item['title'] }}</a>
-        </dt>
+        </li>
     @endforeach
-</dl>
+</ul>
 
 @if(isset($url))<a href="{{ $url }}" class="more-link">{{ $link_text or 'View more' }}</a>@endif

--- a/resources/views/components/mini-news.blade.php
+++ b/resources/views/components/mini-news.blade.php
@@ -7,14 +7,14 @@
 --}}
 <h2>{{ $heading or 'News' }}</h2>
 
-<dl class="listing">
+<ul class="listing">
     @foreach($news as $item)
-        <dt>
+        <li>
             <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}news/{{ $item['slug'] }}-{{ $item['news_id'] }}">
                 {{ $item['title'] }}
             </a>
-        </dt>
+        </li>
     @endforeach
-</dl>
+</ul>
 
 <a href="/{{ $url or 'news/' }}" class="more-link">{{ $link_text or 'More news' }}</a>

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -11,7 +11,9 @@
         <div class="row small-up-2 medium-up-3">
             @foreach($profiles as $profile)
                 <div class="column profile">
-                    <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}" class="profile-img" style="background-image: url('{{ $profile['data']['Picture']['url'] or '/_resources/images/no-photo.svg' }}');" alt="{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}"></a>
+                    <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}" class="profile-img" style="background-image: url('{{ $profile['data']['Picture']['url'] or '/_resources/images/no-photo.svg' }}');">
+                        <span class="visuallyhidden">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
+                    </a>
                     <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}profile/{{ $profile['data']['AccessID'] }}">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</a>
 
                     @if(isset($profile['data']['Title']))

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -22,6 +22,18 @@
 </head>
 <body>
 
+<nav aria-label="Skip navigation" class="skip">
+    <ul>
+        @if(config('app.top_menu_enabled') === true)
+            <li><a href="#top-menu">Skip to site menu</a></li>
+        @endif
+        @if(!empty($site_menu_output))
+            <li><a href="#page-menu">Skip to page menu</a></li>
+        @endif
+        <li><a href="#main">Skip to main content</a></li>
+    </ul>
+</nav>
+
 @include('partials.header')
 
 <div id="menu-top-section" class="header-menu">

--- a/resources/views/partials/breadcrumbs.blade.php
+++ b/resources/views/partials/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 {{--
     $breadcrumbs => array // [['display_name', 'relative_url']]
 --}}
-<nav role="navigation" class="breadcrumbs">
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
     <ul class="breadcrumbs">
         @foreach($breadcrumbs as $key=>$crumb)
             @if($key == 0)

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -12,7 +12,7 @@
     @endif
 
     <div class="row">
-        <div class="small-12 medium-3 columns main-menu @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) hide-for-menu-top-up @endif" id="mainMenu" data-off-canvas role="navigation">
+        <div class="small-12 medium-3 columns main-menu @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) hide-for-menu-top-up @endif" data-off-canvas id="page-menu" role="navigation"  aria-label="Page menu" tabindex="-1">
             @if(!empty($top_menu_output) && $site_menu !== $top_menu)
                 <div class="offcanvas-main-menu">
                     <ul>
@@ -46,7 +46,9 @@
                 @include('partials.breadcrumbs', ['breadcrumbs' => $breadcrumbs])
             @endif
 
-            @yield('content')
+            <main id="main" tabindex="-1">
+                @yield('content')
+            </main>
         </div>
     </div>
 

--- a/resources/views/partials/menu-top.blade.php
+++ b/resources/views/partials/menu-top.blade.php
@@ -23,9 +23,9 @@
                 <div class="float-right vertical-centering">
                     <div>
                         @if(config('app.top_menu_enabled') === true)
-                            <section id="top-menu">
+                            <nav id="top-menu" aria-label="Site menu" tabindex="-1">
                                 {!! $top_menu_output !!}
-                            </section>
+                            </nav>
                         @endif
 
                         <div>


### PR DESCRIPTION
This should take care of all the remaining aXe accessibility notices (except the contrast ones that require manual review).

A few highlights:

* Debugbar turned off by default to avoid issues with checker
* Minilist moved to `ul`/`li` format due to `dl` requiring both `dt` and `dd` as children (only the events listing passed this requirement)
* Skip links are variable depending if there is a top menu or not (there are three skip links if there is a top menu)
* Directory template had an `alt` attribute on an `a` element, which is invalid (these blocks should probably be refactored, right now it has double links to the same location with the same text)