### PR TITLE
Hotfix/4.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/js/modules/offcanvas.js
+++ b/resources/js/modules/offcanvas.js
@@ -29,21 +29,21 @@ import 'foundation-sites/js/foundation.offcanvas';
             // Toggle the appropriate classes for offCanvas
             if ($('.menu-button .menu-toggle').is(":visible") === false) {
                 // Remove classes so the menu is accessible on large screens
-                $('#mainMenu').removeClass('position-right');
-                $('#mainMenu').removeClass('off-canvas-absolute');
+                $('#page-menu').removeClass('position-right');
+                $('#page-menu').removeClass('off-canvas-absolute');
             }else{
                 // Disable CSS transitions
-                $('#mainMenu').addClass('notransition');
+                $('#page-menu').addClass('notransition');
 
                 // Position the menu properly so offcanvas works
-                $('#mainMenu').addClass('position-right');
-                $('#mainMenu').addClass('off-canvas-absolute');
+                $('#page-menu').addClass('position-right');
+                $('#page-menu').addClass('off-canvas-absolute');
 
                 // Trigger a reflow, flushing the CSS changes
-                $('#mainMenu')[0].offsetHeight;
+                $('#page-menu')[0].offsetHeight;
 
                 // Remove the class so transitions are enabled
-                $('#mainMenu').removeClass('notransition');
+                $('#page-menu').removeClass('notransition');
             }
         }
 
@@ -92,7 +92,7 @@ import 'foundation-sites/js/foundation.offcanvas';
          * Initialize
          */
         _init() {
-            // Make the click link for offcanvas button do nothing, this way #mainMenu doesn't append to the URL
+            // Make the click link for offcanvas button do nothing, this way #page-menu doesn't append to the URL
             $('.menu-top-container .menu-toggle').attr('href', 'javascript:void(0);');
 
             // Initialize offcanvas classes

--- a/resources/views/partials/menu-top.blade.php
+++ b/resources/views/partials/menu-top.blade.php
@@ -30,7 +30,7 @@
 
                         <div>
                             <ul class="menu-top menu-button hide-for-menu-top-up">
-                                <li><a href="#mainMenu" class="menu-toggle menu-icon" data-toggle="mainMenu"><span class="visuallyhidden">Menu</span></a></li>
+                                <li><a href="#page-menu" class="menu-toggle menu-icon" data-toggle="page-menu"><span class="visuallyhidden">Menu</span></a></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Due to this change of "WCAG 2.0 AA updates" it broke the offcanvas on small https://github.com/waynestate/base-site/commit/a1d3c4c9450b98e58e36f01f49a3d29fa05b53fc#diff-6c5ffea69a81c37dece190e77d368792L15 . 

Fixing it so all references to #mainMenu are now #page-menu