### PR TITLE
Feature/news categories

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -37,7 +37,7 @@ class NewsController extends Controller
         $categories = $this->news->setSelectedCategory($categories, $request->slug);
 
         // 404 the page since the category doens't exist or is inactive
-        if ($request->slug !== null && $categories['selected_news_category']['category_id'] === null) {
+        if ($request->slug !== null && empty($categories['selected_news_category']['category_id'])) {
             return abort('404');
         }
 

--- a/resources/views/news-listing.blade.php
+++ b/resources/views/news-listing.blade.php
@@ -7,7 +7,6 @@
         <dl>
             @forelse($news as $news_item)
                 <dt>
-
                     <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}news/{{ $news_item['slug'] }}-{{ $news_item['news_id'] }}">
                         {{ $news_item['title'] }}
                     </a>
@@ -22,26 +21,30 @@
             @endforelse
         </dl>
 
-        <div class="row">
-            <div class="small-6 columns">
-                @if(count($news) == $paging['perPage'])
-                    <p>
-                        <a href="{{ app('request')->url() }}?page={{ $paging['page_number_previous'] }}">&larr; Previous</a>
-                    </p>
-                @endif
-            </div>
+        @if(!empty($paging))
+            <div class="row">
+                <div class="small-6 columns">
+                    @if(count($news) == $paging['perPage'])
+                        <p>
+                            <a href="{{ app('request')->url() }}?page={{ $paging['page_number_previous'] }}">&larr; Previous</a>
+                        </p>
+                    @endif
+                </div>
 
-            <div class="small-6 columns text-right">
-                @if($paging['page_number_next'] >= 0)
-                    <p>
-                        <a href="{{ app('request')->url() }}?page={{ $paging['page_number_next'] }}">Next &rarr;</a>
-                    </p>
-                @endif
+                <div class="small-6 columns text-right">
+                    @if($paging['page_number_next'] >= 0)
+                        <p>
+                            <a href="{{ app('request')->url() }}?page={{ $paging['page_number_next'] }}">Next &rarr;</a>
+                        </p>
+                    @endif
+                </div>
             </div>
-        </div>
+        @endif
     </div>
 @endsection
 
 @section('below_menu')
-    @include('components.news-categories', ['categories' => $news_categories, 'selected_category' => $selected_news_category])
+    @if(!empty($news_categories))
+        @include('components.news-categories', ['categories' => $news_categories, 'selected_category' => $selected_news_category])
+    @endif
 @endsection

--- a/styleguide/Pages/NewsCategory.php
+++ b/styleguide/Pages/NewsCategory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class NewsCategory extends Page
+{
+    /** {@inheritdoc} **/
+    public $path = '/styleguide/news/category/est-quisquam';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, [
+            'page' => [
+                'controller' => 'NewsController',
+                'title' => 'News by Category',
+                'id' => null,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/PageRepositoryTest.php
+++ b/tests/Feature/PageRepositoryTest.php
@@ -50,7 +50,7 @@ class PageRepositoryTest extends TestCase
 
         $this->getPageResponses()
             ->each(function ($page) {
-                $this->assertTrue(($page['response']->status() !== 500), '500 error in styleguide at path: '.$page['path'] . '. This is likely due to not accounting for a blank array coming back from the factory in your view.');
+                $this->assertTrue(($page['response']->status() !== 500), $page['response']->content()."\n".'500 error in styleguide at path: '.$page['path'] . '. View the error output above to solve the issue.');
             });
     }
 


### PR DESCRIPTION
* Output the error response from the `all_styleguide_routes_with_no_data_should_load_successfully` test. This way you can see the exact error rather than a generic message.

* Fix the category heading showing if there aren't any categories

* Add the News Category page to the styleguide so it is tested. The prefered way to get categories to work for a CMS site is to add a relative page called `news/category` pointed to the `NewsController`.