### PR TITLE
Allow image-list component to have images or buttons displayed depend…

### DIFF
--- a/factories/UnderMenu.php
+++ b/factories/UnderMenu.php
@@ -25,7 +25,7 @@ class UnderMenu implements FactoryContract
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
                 'link' => $this->faker->url,
-                'relative_url' => '/styleguide/image/360x131',
+                'relative_url' => $this->faker->boolean === true ? '/styleguide/image/360x131' : '',
                 'title' => $this->faker->sentence,
             ];
         }

--- a/resources/views/components/image-list.blade.php
+++ b/resources/views/components/image-list.blade.php
@@ -6,9 +6,13 @@
 
 @foreach($images as $image)
     <div>
-        @if($image['link'] != '')<a href="{{ $image['link'] }}">@endif
-            <img src="{{ $image['relative_url'] }}" alt="{{ $image['title'] }}" />
-        @if($image['link'] != '')</a>@endif
+        @if(!empty($image['link']))<a href="{{ $image['link'] }}"@if(empty($image['relative_url'])) class="button expanded" @endif>@endif
+            @if(!empty($image['relative_url']))
+                <img src="{{ $image['relative_url'] }}" alt="{{ $image['title'] }}" />
+            @else
+                {{ $image['title'] }}
+            @endif
+        @if(!empty($image['link']))</a>@endif
     </div>
 @endforeach
 


### PR DESCRIPTION
I need a vote on if we should rename the existing partial or make a copy and call it `image-button-list.blade.php` with this behavior. I'm ok with leaving it as is.

<img width="355" alt="screen shot 2018-04-05 at 12 03 39 pm" src="https://user-images.githubusercontent.com/634788/38377804-e74f6f72-38c9-11e8-8a2e-c43b0287f685.png">

