### PR TITLE
Content Area

### DIFF
--- a/resources/scss/components/_accordion.scss
+++ b/resources/scss/components/_accordion.scss
@@ -1,15 +1,13 @@
-.content {
-    ul.accordion {
-        margin-left: 0;
-    }
+ul.accordion {
+    margin-left: 0;
+}
 
-    a.accordion-title {
-        text-decoration: none;
-        font-size: $global-font-size;
-        font-weight: bold;
-    }
+a.accordion-title {
+    text-decoration: none;
+    font-size: $global-font-size;
+    font-weight: bold;
+}
 
-    .accordion-content p:last-of-type {
-        margin-bottom: 0;
-    }
+.accordion-content p:last-of-type {
+    margin-bottom: 0;
 }

--- a/resources/scss/components/_page-title.scss
+++ b/resources/scss/components/_page-title.scss
@@ -1,0 +1,3 @@
+h1.page-title {
+    margin: rem-calc(20) 0 $header-margin-bottom;
+}

--- a/resources/scss/components/_table-stack.scss
+++ b/resources/scss/components/_table-stack.scss
@@ -1,81 +1,79 @@
-.content {
-    table.table-stack {
+table.table-stack {
+    border-collapse: collapse;
+    width: 100%;
+
+    th,
+    td {
+        line-height: 1.5;
+        text-align: left;
+    }
+
+    // Header
+    thead tr {
         border-collapse: collapse;
-        width: 100%;
+        background: #00565c;
+    }
 
-        th,
-        td {
-            line-height: 1.5;
-            text-align: left;
-        }
+    tbody th {
+        padding: 10px;
+    }
 
-        // Header
+    /* Stack rows vertically on small screens */
+    @include breakpoint(medium down) {
+        /* Hide column labels */
         thead tr {
-            border-collapse: collapse;
-            background: #00565c;
+            position: absolute;
+            top: -9999em;
+            left: -9999em;
         }
 
-        tbody th {
-            padding: 10px;
-        }
+        tr {
+            border: 1px solid #eaeaea;
 
-        /* Stack rows vertically on small screens */
-        @include breakpoint(medium down) {
-            /* Hide column labels */
-            thead tr {
-                position: absolute;
-                top: -9999em;
-                left: -9999em;
-            }
-
-            tr {
-                border: 1px solid #eaeaea;
-
-                th::before {
-                    content: attr(data-label) ": ";
-                    display: inline;
-                    font-weight: bold;
-                    line-height: 1.5px;
-                }
-            }
-
-            /* Leave a space between table rows */
-            tr + tr {
-                margin-top: 1.5em;
-            }
-
-            /* Get table cells to act like rows */
-            tr,
-            td {
-                display: block;
-            }
-
-            td {
-                border: none;
-            }
-
-            /* Add data labels */
-            td::before {
-                content: attr(data-label) ":";
+            th::before {
+                content: attr(data-label) ": ";
                 display: inline;
                 font-weight: bold;
-                line-height: 1.5;
-                padding-right: 20px;
-                color: #00565c;
+                line-height: 1.5px;
             }
         }
 
-        /* Stack labels vertically on smaller screens */
-        @include breakpoint(medium down) {
-            td {
-                padding-left: 0.75em;
-            }
+        /* Leave a space between table rows */
+        tr + tr {
+            margin-top: 1.5em;
+        }
 
-            td::before {
-                display: block;
-                margin-bottom: 0.75em;
-                margin-left: 0;
-            }
+        /* Get table cells to act like rows */
+        tr,
+        td {
+            display: block;
+        }
+
+        td {
+            border: none;
+        }
+
+        /* Add data labels */
+        td::before {
+            content: attr(data-label) ":";
+            display: inline;
+            font-weight: bold;
+            line-height: 1.5;
+            padding-right: 20px;
+            color: #00565c;
+        }
+    }
+
+    /* Stack labels vertically on smaller screens */
+    @include breakpoint(medium down) {
+        td {
+            padding-left: 0.75em;
+        }
+
+        td::before {
+            display: block;
+            margin-bottom: 0.75em;
+            margin-left: 0;
         }
     }
 }

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -40,6 +40,7 @@
 @import "partials/menu-main";
 @import "partials/menu-top";
 @import "partials/menu-offcanvas";
+@import "partials/content-area";
 @import "partials/content";
 @import "partials/footer-social";
 @import "partials/footer-contact";
@@ -51,10 +52,12 @@
 @import "partials/profile-view";
 @import "partials/rotate";
 @import "partials/share";
+@import "partials/_anchors";
 
 // Reusable components
 @import "components/accordion";
 @import "components/formy";
 @import "components/hero";
 @import "components/mini-list";
+@import "components/page-title";
 @import "components/table-stack";

--- a/resources/scss/partials/_anchors.scss
+++ b/resources/scss/partials/_anchors.scss
@@ -1,0 +1,8 @@
+// Buffer for anchor tags
+*[id]:not([class*="accordion"])::before {
+    display: block;
+    content: " ";
+    margin-top: -$menu-height;
+    height: $menu-height;
+    visibility: hidden;
+}

--- a/resources/scss/partials/_content-area.scss
+++ b/resources/scss/partials/_content-area.scss
@@ -1,0 +1,7 @@
+.content-area {
+    // Forces the content area to be full width when the menu is hidden
+    @include breakpoint($menu-top-breakpoint down) {
+        width: 100%;
+        left: 0;
+    }
+}

--- a/resources/scss/partials/_content.scss
+++ b/resources/scss/partials/_content.scss
@@ -1,16 +1,5 @@
-/* Content Style */
 .content {
-    // Forces the content area to be full width when the menu is hidden
-    @include breakpoint($menu-top-breakpoint down) {
-        width: 100%;
-        left: 0;
-    }
-
-    h1.page-title {
-        margin: rem-calc(20) 0 $header-margin-bottom;
-    }
-
-    h1:not(.page-title),
+    h1,
     h2,
     h3,
     h4,

--- a/resources/scss/partials/_menu-top.scss
+++ b/resources/scss/partials/_menu-top.scss
@@ -1,12 +1,3 @@
-// Buffer for anchor tags
-.content *[id]:not([class*="accordion"])::before {
-    display: block;
-    content: " ";
-    margin-top: -$menu-height;
-    height: $menu-height;
-    visibility: hidden;
-}
-
 .menu-top-container {
     height: $menu-height;
 

--- a/resources/scss/partials/_profile-view.scss
+++ b/resources/scss/partials/_profile-view.scss
@@ -9,7 +9,7 @@
     }
 }
 
-.content .profile__img {
+.profile__img {
     display: block;
     width: auto;
     height: 270px;

--- a/resources/views/childpage.blade.php
+++ b/resources/views/childpage.blade.php
@@ -1,9 +1,11 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 
     @if(!empty($accordion_page))
         @include('components.accordion', ['items' => $accordion_page])

--- a/resources/views/components/page-title.blade.php
+++ b/resources/views/components/page-title.blade.php
@@ -1,0 +1,1 @@
+<h1 class="page-title{{ !empty($class) ? ' '.$class : '' }}">{{ $title }}</h1>

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -1,9 +1,11 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 
     @forelse($profiles as $key => $profiles)
         <h1>{{ $key }}</h1>

--- a/resources/views/homepage.blade.php
+++ b/resources/views/homepage.blade.php
@@ -1,7 +1,9 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 @endsection

--- a/resources/views/news-individual.blade.php
+++ b/resources/views/news-individual.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $news['title'] }}</h1>
+    @include('components.page-title', ['title' => $news['title']])
 
     <div class="news-item">
         <div class="addthis_share">Share</div>
@@ -9,7 +9,9 @@
 
         <time datetime="{{ $news['posted'] }}">{{ apdatetime(date('F j, Y', strtotime($news['posted']))) }}</time>
 
-        {!! $news['body'] !!}
+        <div class="content">
+            {!! $news['body'] !!}
+        </div>
 
         <p rel="back">
             <a rel="back" href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}news">Back to listing</a>

--- a/resources/views/news-listing.blade.php
+++ b/resources/views/news-listing.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="news-listing">
         <dl>

--- a/resources/views/partials/content-area.blade.php
+++ b/resources/views/partials/content-area.blade.php
@@ -32,7 +32,7 @@
             @endif
         </div>
 
-        <div class="small-12 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))medium-12 @else medium-9 @endif columns content" data-off-canvas-content>
+        <div class="small-12 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))medium-12 @else medium-9 @endif columns content-area" data-off-canvas-content>
 
             @if(!empty($hero) && ($site_menu['meta']['has_selected'] == true || config('app.hero_contained') === true))
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])

--- a/resources/views/profile-listing.blade.php
+++ b/resources/views/profile-listing.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     @if($hide_filtering == false)
         <form name="programs" method="get" class="filter">

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -17,7 +17,7 @@
                 <img src="/_resources/images/no-photo.svg" alt="{{ $page['title'] }}" class="profile__img">
             @endif
 
-            <h1 class="hide-for-large page-title">{{ $page['title'] }}</h1>
+            @include('components.page-title', ['title' => $page['title'], 'class' => 'hide-for-large'])
 
             <div class="profile--contact-info">
                 @if(isset($profile['data']['Title']))
@@ -55,7 +55,7 @@
         </div>
 
         <div class="small-12 large-8 columns">
-            <h1 class="page-title show-for-large">{{ $page['title'] }}</h1>
+            @include('components.page-title', ['title' => $page['title'], 'class' => 'show-for-large'])
 
             @foreach($profile['data'] as $field=>$data)
                 @if(!in_array($field, $contact_fields) && !in_array($field, $hidden_fields))

--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -1,9 +1,11 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 
     @if(!empty($accordion_page))
         @include('components.accordion', ['items' => $accordion_page])

--- a/styleguide/Views/styleguide-childpage.blade.php
+++ b/styleguide/Views/styleguide-childpage.blade.php
@@ -1,7 +1,9 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 @endsection

--- a/styleguide/Views/styleguide-forms.blade.php
+++ b/styleguide/Views/styleguide-forms.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="formy">
         <div class="form-description">

--- a/styleguide/Views/styleguide-imagelist.blade.php
+++ b/styleguide/Views/styleguide-imagelist.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="row">
         <div class="medium-6 columns">

--- a/styleguide/Views/styleguide-minievents.blade.php
+++ b/styleguide/Views/styleguide-minievents.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="row">
         <div class="small-12 large-6 columns">

--- a/styleguide/Views/styleguide-minilist.blade.php
+++ b/styleguide/Views/styleguide-minilist.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="row">
         <div class="small-12 large-6 columns">

--- a/styleguide/Views/styleguide-mininews.blade.php
+++ b/styleguide/Views/styleguide-mininews.blade.php
@@ -1,7 +1,7 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
     <div class="row">
         <div class="small-12 large-6 columns">

--- a/styleguide/Views/styleguide-tablestack.blade.php
+++ b/styleguide/Views/styleguide-tablestack.blade.php
@@ -1,9 +1,11 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    {!! $page['content']['main'] !!}
+    <div class="content">
+        {!! $page['content']['main'] !!}
+    </div>
 
     <table class="table-stack">
     	<thead>

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -1,62 +1,63 @@
 @extends('partials.content-area')
 
 @section('content')
-    <h1 class="page-title">{{ $page['title'] }}</h1>
+    @include('components.page-title', ['title' => $page['title']])
 
-    <hr>
+    <div class="content">
+        <hr>
 
-    <h2>2 Column Example</h2>
-    <div class="row">
-        <div class="small-12 large-6 columns">
-            <p>{{ $faker->paragraph }}</p>
+        <h2>2 Column Example</h2>
+        <div class="row">
+            <div class="small-12 large-6 columns">
+                <p>{{ $faker->paragraph }}</p>
+            </div>
+            <div class="small-12 large-6 columns">
+                <p>{{ $faker->paragraph }}</p>
+            </div>
         </div>
-        <div class="small-12 large-6 columns">
-            <p>{{ $faker->paragraph }}</p>
-        </div>
+
+        <a class="button" onclick="$('pre.columns-code').toggleClass('hide');">See Row/Columns Code</a>
+        <pre class="columns-code hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+            {{ htmlspecialchars('
+<div class="row">
+    <div class="small-12 large-6 columns">
+        <p>'.$faker->paragraph.'</p>
     </div>
+    <div class="small-12 large-6 columns">
+        <p>'.$faker->paragraph.'</p>
+    </div>
+</div>
+            ') }}
+        </pre>
 
-    <a class="button" onclick="$('pre.columns-code').toggleClass('hide');">See Row/Columns Code</a>
-    <pre class="columns-code hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <hr>
+
+        <h2>Table</h2>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Email</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                @for ($i = 0; $i < 10; $i++)
+                <tr>
+                    <td>{{ $faker->firstName }}</td>
+                    <td>{{ $faker->lastName }}</td>
+                    <td>{{ $faker->email }}</td>
+                </tr>
+                @endfor
+            </tbody>
+        </table>
+
+        <a class="button" onclick="$('pre.table-stack').toggleClass('hide');">See Table Code</a>
+
+        <pre class="table-stack hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
         {{ htmlspecialchars('
-    <div class="row">
-        <div class="small-12 large-6 columns">
-            <p>'.$faker->paragraph.'</p>
-        </div>
-        <div class="small-12 large-6 columns">
-            <p>'.$faker->paragraph.'</p>
-        </div>
-    </div>
-        ') }}
-    </pre>
-
-    <hr>
-
-    <h2>Table</h2>
-
-    <table>
-    	<thead>
-    		<tr>
-    			<th>First Name</th>
-    			<th>Last Name</th>
-    			<th>Email</th>
-    		</tr>
-    	</thead>
-
-    	<tbody>
-            @for ($i = 0; $i < 10; $i++)
-            <tr>
-                <td>{{ $faker->firstName }}</td>
-                <td>{{ $faker->lastName }}</td>
-                <td>{{ $faker->email }}</td>
-            </tr>
-            @endfor
-        </tbody>
-    </table>
-
-    <a class="button" onclick="$('pre.table-stack').toggleClass('hide');">See Table Code</a>
-
-    <pre class="table-stack hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
 <table>
     <thead>
         <tr>
@@ -74,232 +75,233 @@
         </tr>
     </tbody>
 </table>
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
-    <hr>
+        <hr>
 
-    <h2>Abbreviations</h2>
+        <h2>Abbreviations</h2>
 
-    <p><abbr title="Wayne State University">WSU</abbr></p>
+        <p><abbr title="Wayne State University">WSU</abbr></p>
 
-    <hr>
+        <hr>
 
-    <div class="row">
-        <div class="small-12 large-4 columns">
-            <h2>Unordered lists</h2>
+        <div class="row">
+            <div class="small-12 large-4 columns">
+                <h2>Unordered lists</h2>
 
-            <ul>
-                <li>First</li>
-                <li>Second</li>
-                <li>Third</li>
-            </ul>
+                <ul>
+                    <li>First</li>
+                    <li>Second</li>
+                    <li>Third</li>
+                </ul>
+            </div>
+
+            <div class="small-12 large-4 columns">
+                <h2>Ordered lists</h2>
+
+                <ol>
+                    <li>First</li>
+                    <li>Second</li>
+                    <li>Third</li>
+                </ol>
+            </div>
+
+            <div class="small-12 large-4 columns">
+                <h2>Data lists</h2>
+
+                <dl>
+                    <dt>First</dt>
+                    <dd>Description of first.</dd>
+                    <dt>Second</dt>
+                    <dd>Description of second.</dd>
+                    <dt>Third</dt>
+                    <dd>Description of third.</dd>
+                </dl>
+            </div>
         </div>
 
-        <div class="small-12 large-4 columns">
-            <h2>Ordered lists</h2>
+        <hr>
 
-            <ol>
-                <li>First</li>
-                <li>Second</li>
-                <li>Third</li>
-            </ol>
-        </div>
+        <h2>Blockquote</h2>
 
-        <div class="small-12 large-4 columns">
-            <h2>Data lists</h2>
+        <blockquote>
+            {{ $faker->paragraph(10) }}
+        </blockquote>
 
-            <dl>
-                <dt>First</dt>
-                <dd>Description of first.</dd>
-                <dt>Second</dt>
-                <dd>Description of second.</dd>
-                <dt>Third</dt>
-                <dd>Description of third.</dd>
-            </dl>
-        </div>
-    </div>
+        <a class="button" onclick="$('pre.blockquote').toggleClass('hide');">See blockquote code</a>
 
-    <hr>
-
-    <h2>Blockquote</h2>
-
-    <blockquote>
-        {{ $faker->paragraph(10) }}
-    </blockquote>
-
-    <a class="button" onclick="$('pre.blockquote').toggleClass('hide');">See blockquote code</a>
-
-    <pre class="blockquote hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
+        <pre class="blockquote hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        {{ htmlspecialchars('
 <blockquote>
     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 </blockquote>
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
 
-    <hr>
+        <hr>
 
-    <h2>Buttons</h2>
+        <h2>Buttons</h2>
 
-    <a href="#" class="button">Standard Button</a>
-    <a href="#" class="button expanded">Expanded Button</a>
+        <a href="#" class="button">Standard Button</a>
+        <a href="#" class="button expanded">Expanded Button</a>
 
-    <a class="button" onclick="$('pre.button-examples').toggleClass('hide');">See Button Code</a>
+        <a class="button" onclick="$('pre.button-examples').toggleClass('hide');">See Button Code</a>
 
-    <pre class="button-examples hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
+        <pre class="button-examples hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        {{ htmlspecialchars('
 <a href="#" class="button">Standard Button</a>
 <a href="#" class="button expanded">Expanded Button</a>
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
-    <hr>
+        <hr>
 
-    <h2>Headers</h2>
+        <h2>Headers</h2>
 
-    <h1>H1: {{ $faker->sentence }}</h1>
-    <h2>H2: {{ $faker->sentence }}</h2>
-    <h3>H3: {{ $faker->sentence }}</h3>
-    <h4>H4: {{ $faker->sentence }}</h4>
-    <h5>H5: {{ $faker->sentence }}</h5>
-    <h6>H6: {{ $faker->sentence }}</h6>
+        <h1>H1: {{ $faker->sentence }}</h1>
+        <h2>H2: {{ $faker->sentence }}</h2>
+        <h3>H3: {{ $faker->sentence }}</h3>
+        <h4>H4: {{ $faker->sentence }}</h4>
+        <h5>H5: {{ $faker->sentence }}</h5>
+        <h6>H6: {{ $faker->sentence }}</h6>
 
-    <hr>
+        <hr>
 
-    <h2>Image Icon</h2>
+        <h2>Image Icon</h2>
 
-    <p>Images default to span 100% of the container on small view. When using the <code>.icon</code> class you can override this behavior so it defaults to its real height/width.</p>
+        <p>Images default to span 100% of the container on small view. When using the <code>.icon</code> class you can override this behavior so it defaults to its real height/width.</p>
 
-    <p><img src="/styleguide/image/50x50?text=Icon" class="icon" alt="icon image"></p>
+        <p><img src="/styleguide/image/50x50?text=Icon" class="icon" alt="icon image"></p>
 
-    <a class="button" onclick="$('pre.image-icon').toggleClass('hide');">See Image Icon Code</a>
+        <a class="button" onclick="$('pre.image-icon').toggleClass('hide');">See Image Icon Code</a>
 
-    <pre class="image-icon hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
+        <pre class="image-icon hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        {{ htmlspecialchars('
 <img src="/styleguide/50x50?text=Icon" class="icon" alt="">
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
-    <hr>
+        <hr>
 
-    <h2>Maginific Pop-up</h2>
-    <p>Any valid YouTube URL starting with <code>youtu.be</code> or <code>youtube.com/watch</code> will open a lightbox with the video.</p>
-    <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="View YouTube Video"></a></p>
+        <h2>Maginific Pop-up</h2>
+        <p>Any valid YouTube URL starting with <code>youtu.be</code> or <code>youtube.com/watch</code> will open a lightbox with the video.</p>
+        <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="View YouTube Video"></a></p>
 
-    <a class="button" onclick="$('pre.maginific-popup-example').toggleClass('hide');">See Maginific Pop-up Code</a>
+        <a class="button" onclick="$('pre.maginific-popup-example').toggleClass('hide');">See Maginific Pop-up Code</a>
 
-    <pre class="maginific-popup-example hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
+        <pre class="maginific-popup-example hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        {{ htmlspecialchars('
 <p>
     <a href="//www.youtube.com/watch?v=guRgefesPXE">
         <img src="//i.wayne.edu/youtube/guRgefesPXE">
     </a>
 </p>
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
-    <hr>
+        <hr>
 
-    <h2>Responsive Embed</h2>
+        <h2>Responsive Embed</h2>
 
-    <p>To make sure embedded content maintains its aspect ratio as the width of the screen changes, wrap the <code>iframe</code>, <code>object</code>, <code>embed</code>, or <code>video</code> in a container with the <code>.responsive-embed</code> class.</p>
-    <div class="responsive-embed">
-        <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" frameborder="0" allowfullscreen></iframe>
-    </div>
+        <p>To make sure embedded content maintains its aspect ratio as the width of the screen changes, wrap the <code>iframe</code>, <code>object</code>, <code>embed</code>, or <code>video</code> in a container with the <code>.responsive-embed</code> class.</p>
+        <div class="responsive-embed">
+            <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" frameborder="0" allowfullscreen></iframe>
+        </div>
 
-    <a class="button" onclick="$('pre.responsive-embed-example').toggleClass('hide');">See Responsive Embed Code</a>
+        <a class="button" onclick="$('pre.responsive-embed-example').toggleClass('hide');">See Responsive Embed Code</a>
 
-    <pre class="responsive-embed-example hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-    {{ htmlspecialchars('
+        <pre class="responsive-embed-example hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        {{ htmlspecialchars('
 <div class="responsive-embed">
     <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" frameborder="0" allowfullscreen></iframe>
 </div>
-    ') }}
-    </pre>
+        ') }}
+        </pre>
 
-    <hr>
+        <hr>
 
-    <div class="row">
-        <div class="medium-3 columns">
-            <h2>Figure (left)</h2>
+        <div class="row">
+            <div class="medium-3 columns">
+                <h2>Figure (left)</h2>
 
-            <figure class="float-left" style="margin-top: 15px;">
-                <img src="/styleguide/image/150x150" alt="Placeholder">
-                <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-            </figure>
+                <figure class="float-left" style="margin-top: 15px;">
+                    <img src="/styleguide/image/150x150" alt="Placeholder">
+                    <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
+                </figure>
 
-            <a class="button" onclick="$('pre.fig-left').toggleClass('hide');">See Code</a>
+                <a class="button" onclick="$('pre.fig-left').toggleClass('hide');">See Code</a>
 
-            <pre class="fig-left hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-            {{ htmlspecialchars('
+                <pre class="fig-left hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                {{ htmlspecialchars('
 <figure class="float-left">
     <img src="/styleguide/image/150x150" alt="Placeholder">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
-            ') }}
-            </pre>
-        </div>
+                ') }}
+                </pre>
+            </div>
 
-        <div class="medium-3 columns">
-            <h2>Figure (center)</h2>
+            <div class="medium-3 columns">
+                <h2>Figure (center)</h2>
 
-            <figure class="text-center">
-                <img src="/styleguide/image/150x150" alt="Placeholder">
-                <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-            </figure>
+                <figure class="text-center">
+                    <img src="/styleguide/image/150x150" alt="Placeholder">
+                    <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
+                </figure>
 
-            <a class="button" onclick="$('pre.fig-center').toggleClass('hide');">See Code</a>
+                <a class="button" onclick="$('pre.fig-center').toggleClass('hide');">See Code</a>
 
-            <pre class="fig-center hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-            {{ htmlspecialchars('
+                <pre class="fig-center hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                {{ htmlspecialchars('
 <figure class="text-center">
     <img src="/styleguide/image/150x150" alt="Placeholder">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
-            ') }}
-            </pre>
-        </div>
+                ') }}
+                </pre>
+            </div>
 
-        <div class="medium-3 columns">
-            <h2>Figure</h2>
+            <div class="medium-3 columns">
+                <h2>Figure</h2>
 
-            <figure>
-                <img src="/styleguide/image/150x150" alt="Placeholder">
-                <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-            </figure>
+                <figure>
+                    <img src="/styleguide/image/150x150" alt="Placeholder">
+                    <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
+                </figure>
 
-            <a class="button" onclick="$('pre.fig-none').toggleClass('hide');">See Code</a>
+                <a class="button" onclick="$('pre.fig-none').toggleClass('hide');">See Code</a>
 
-            <pre class="fig-none hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-            {{ htmlspecialchars('
+                <pre class="fig-none hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                {{ htmlspecialchars('
 <figure>
     <img src="/styleguide/image/150x150" alt="Placeholder">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
-            ') }}
-            </pre>
-        </div>
+                ') }}
+                </pre>
+            </div>
 
-        <div class="medium-3 columns">
-            <h2>Figure (right)</h2>
+            <div class="medium-3 columns">
+                <h2>Figure (right)</h2>
 
-            <figure class="float-right" style="margin-top: 15px;">
-                <img src="/styleguide/image/150x150" alt="Placeholder">
-                <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-            </figure>
+                <figure class="float-right" style="margin-top: 15px;">
+                    <img src="/styleguide/image/150x150" alt="Placeholder">
+                    <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
+                </figure>
 
-            <a class="button clearfix" onclick="$('pre.fig-right').toggleClass('hide');">See Code</a>
+                <a class="button clearfix" onclick="$('pre.fig-right').toggleClass('hide');">See Code</a>
 
-            <pre class="fig-right hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-            {{ htmlspecialchars('
+                <pre class="fig-right hide" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                {{ htmlspecialchars('
 <figure class="float-right">
     <img src="/styleguide/image/150x150" alt="Placeholder">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
-            ') }}
-            </pre>
+                ') }}
+                </pre>
+            </div>
         </div>
     </div>
 @endsection


### PR DESCRIPTION
This wraps the CMS editor content around a `class="content"` so we can scope that CSS specifically. I removed all other instances of .content prefixes and moved the page title out into it's own component file.

I introduce a new `.content-area` class inside the `content-area` partial so we still have a container class to make the page full width or not (same functionality as before, just a new name).