### PR TITLE
Feature/fix anchor scrolling

### DIFF
--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -52,7 +52,6 @@
 @import "partials/profile-view";
 @import "partials/rotate";
 @import "partials/share";
-@import "partials/_anchors";
 
 // Reusable components
 @import "components/accordion";

--- a/resources/scss/partials/_anchors.scss
+++ b/resources/scss/partials/_anchors.scss
@@ -1,5 +1,5 @@
 // Buffer for anchor tags
-*[id]:not([class*="accordion"])::before {
+.content-area *[id]:not([class*="accordion"])::before {
     display: block;
     content: " ";
     margin-top: -$menu-height;

--- a/resources/scss/partials/_anchors.scss
+++ b/resources/scss/partials/_anchors.scss
@@ -1,8 +1,0 @@
-// Buffer for anchor tags
-.content-area *[id]:not([class*="accordion"])::before {
-    display: block;
-    content: " ";
-    margin-top: -$menu-height;
-    height: $menu-height;
-    visibility: hidden;
-}

--- a/resources/scss/partials/_content-area.scss
+++ b/resources/scss/partials/_content-area.scss
@@ -4,4 +4,12 @@
         width: 100%;
         left: 0;
     }
+
+    *[id]:not([class*="accordion"])::before {
+        display: block;
+        content: " ";
+        margin-top: -$menu-height;
+        height: $menu-height;
+        visibility: hidden;
+    }
 }


### PR DESCRIPTION
Noticed an issue in the develop branch (never made it to production yet). When you scrolled it would move the content down farther and farther because we were targeting the header IDs by mistake with this commit: https://github.com/waynestate/base-site/commit/2e094014035f291c263709235d7dfc81c5c0bd7e