### PR TITLE
Fix slick dots

### DIFF
--- a/resources/js/modules/sticky.js
+++ b/resources/js/modules/sticky.js
@@ -20,7 +20,7 @@ import jQuery from 'jquery';
             // Scroll the user to the right spot, offseted by the sticky menu top
             if(hash !== '' && document.getElementById(hash)) {
                 window.setTimeout(function() {
-                    $('body').animate({
+                    $('html,body').animate({
                         scrollTop: $('#' + hash).offset().top - $('.menu-top-container').outerHeight()
                     }, 1);
                 }, 1000);

--- a/resources/scss/partials/_content-area.scss
+++ b/resources/scss/partials/_content-area.scss
@@ -4,12 +4,4 @@
         width: 100%;
         left: 0;
     }
-
-    *[id]:not([class*="accordion"])::before {
-        display: block;
-        content: " ";
-        margin-top: -$menu-height;
-        height: $menu-height;
-        visibility: hidden;
-    }
 }


### PR DESCRIPTION
Do the anchoring in javascript only and fix it by adding html selector.

This fixes the issue of all IDs having a blank before content which messes up slick dots