### PR TITLE
Feature/anchors

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -6,6 +6,7 @@ import './modules/formfilter';
 import './modules/slick';
 import './modules/magnific-popup';
 import './modules/share';
+import './modules/anchor';
 
 // Foundation Modules
 import './modules/accordion';

--- a/resources/js/modules/anchor.js
+++ b/resources/js/modules/anchor.js
@@ -1,0 +1,42 @@
+import jQuery from 'jquery';
+
+(function($) {
+    "use strict";
+
+    /**
+     * Anchor module.
+     */
+    class Anchor {
+        constructor() {
+            this._init();
+        }
+
+        /**
+         * Initialize
+         */
+        _init() {
+            // Wait until the page finishes loading so the animate scrollTop doesn't bounce to the top of the page
+            $(window).on('load', function (){
+                this.WayneState.modules.anchor.scrollToHash();
+            });
+
+            // Anytime the hash changes after the page is loaded scroll the user to that hash
+            if ("onhashchange" in window) {
+                window.onhashchange = this.scrollToHash;
+            }
+        }
+
+        scrollToHash() {
+            var hash = window.location.hash.substring(1);
+
+            if(hash !== '' && document.getElementById(hash)) {
+                $('html,body').animate({
+                    scrollTop: $('#' + hash).offset().top - $('.menu-top-container').outerHeight()
+                }, 100);
+            }
+        }
+    }
+
+    // Register this module
+    window.WayneState.register('anchor', new Anchor());
+})(jQuery);

--- a/resources/js/modules/sticky.js
+++ b/resources/js/modules/sticky.js
@@ -19,11 +19,9 @@ import jQuery from 'jquery';
 
             // Scroll the user to the right spot, offseted by the sticky menu top
             if(hash !== '' && document.getElementById(hash)) {
-                window.setTimeout(function() {
-                    $('html,body').animate({
-                        scrollTop: $('#' + hash).offset().top - $('.menu-top-container').outerHeight()
-                    }, 1);
-                }, 1000);
+                $('html,body').animate({
+                    scrollTop: $('#' + hash).offset().top - $('.menu-top-container').outerHeight()
+                }, 100);
             }
         }
     }

--- a/resources/js/modules/sticky.js
+++ b/resources/js/modules/sticky.js
@@ -3,32 +3,6 @@ import jQuery from 'jquery';
 (function($) {
     "use strict";
 
-    /**
-     * Sticky module.
-     */
-    class Sticky {
-        constructor() {
-            this._init();
-        }
-
-        /**
-         * Initialize
-         */
-        _init() {
-            var hash = window.location.hash.substring(1);
-
-            // Scroll the user to the right spot, offseted by the sticky menu top
-            if(hash !== '' && document.getElementById(hash)) {
-                $('html,body').animate({
-                    scrollTop: $('#' + hash).offset().top - $('.menu-top-container').outerHeight()
-                }, 100);
-            }
-        }
-    }
-
-    // Register this module
-    window.WayneState.register('sticky', new Sticky());
-
     window.addEventListener('scroll', function() {
         if ($(document).scrollTop() >= $('.wsuheader').outerHeight()) {
             $('.menu-top-placeholder').css('height', $('.header-menu').outerHeight());


### PR DESCRIPTION
I realized there was one aspect of this that wasn't working from https://github.com/waynestate/base-site/pull/116 (which it probably never did in the past either).

If you are on a page with a hash in the URL and you refresh the page at the top, it won't scroll the user down.

This new code removes the need for the `setTimeOut` and relies on the page loading completely first. It also uses `window.onhashchange` to fire the code anytime a hash changes after the page is finished loading.

This works for all these cases:
* Going to a page directly with a hash in the URL
* Refreshing the page anywhere with a has in the URL
* Once the page is loaded and you type in a new hash
* Clicking a link to a new hash