### PR TITLE
Prepare for PHP 7.2 changes, count() warnings if null or not a countable type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 before_install:
   # Install nvm for nodejs

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -51,7 +51,7 @@ class NewsController extends Controller
         $request->data['hero'] = false;
 
         // Force the menu to be shown if categories are found
-        if (isset($categories['news_categories']) && count($categories['news_categories']) > 0) {
+        if (!empty($categories['news_categories'])) {
             $request->data['show_site_menu'] = true;
         }
 

--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -194,7 +194,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
     {
         // Trim first level based on path[0] - only if we are on the main website
         // or we aren't enabling top menu across all subsites
-        if (count($menu['meta']['path']) > 0 && ($parentId === null || $topMenuId === null) && config('app.top_menu_enabled') == true) {
+        if (!empty($menu['meta']['path']) && ($parentId === null || $topMenuId === null) && config('app.top_menu_enabled') == true) {
             foreach ($menu['menu'] as $key => $item) {
                 // If we are on the first path then grab that submenu
                 if ($item['menu_item_id'] == $menu['meta']['path'][0]) {
@@ -207,7 +207,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
 
             // Reset the selected state if there isn't a submenu found, that way
             // it will render a full width view
-            if (count($trim_menu) == 0) {
+            if (empty($trim_menu)) {
                 $menu['meta']['has_selected'] = false;
             }
         }
@@ -224,7 +224,7 @@ class MenuRepository implements DataRepositoryContract, MenuRepositoryContract
         $breadcrumbs = [];
 
         // Get the breadcrumbs from the selected path if it exists
-        if (count($menu['meta']['path']) > 0) {
+        if (!empty($menu['meta']['path'])) {
             $breadcrumbs = $this->parseMenu->getBreadCrumbs($menu);
 
             // If the subsite root isn't already within the breadcrumbs then add the subsite root crumb


### PR DESCRIPTION
Fixes breaking of tests when passing a null or undefined index to count() due to PHP 7.2 changes
http://php.net/manual/en/function.count.php#refsect1-function.count-changelog

Also adds PHP 7.2 to the testable PHPs for Travis-CI