### PR TITLE
Full width content area

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -154,6 +154,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Full Width Content Area
+    |--------------------------------------------------------------------------
+    |
+    | Here you can specify in an array which controllers should have a full
+    | width content area. This way you can have things that span
+    | horizontally across the whole site like a background
+    | color or image.
+    |
+    */
+    'full_width_controllers' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Global promotion group ids
     |--------------------------------------------------------------------------
     |

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -7,7 +7,7 @@
         @include('components.hero', ['images' => $hero])
     @endif
 
-    <div class="row mt:flex">
+    @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
         <div class="md:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) mt:hidden @endif">
             <nav id="menu" class="main-menu" role="navigation" aria-label="Page menu" aria-hidden="true" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
@@ -34,7 +34,7 @@
             </nav>
         </div>
 
-        <div class="w-full px-4 @if($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu)))md:w-full @else md:w-3/4 @endif content-area mb-8">
+        <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }}{{ ($site_menu['meta']['has_selected'] == false && ((isset($show_site_menu) && $show_site_menu != true) || !isset($show_site_menu))) ? '' : ' md:w-3/4'}} content-area mb-8">
             @if(!empty($hero) && ($site_menu['meta']['has_selected'] == true || config('base.hero_contained') === true))
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])
             @endif
@@ -45,7 +45,7 @@
 
             @yield('content')
         </div>
-    </div>
+    @if(!in_array($page['controller'], config('base.full_width_controllers')))</div>@endif
 
     @yield('bottom')
 @endsection


### PR DESCRIPTION
Allow the content area to be full width with no gutters to allow for background colors and images that span across the entire site