### PR TITLE
Feature/remove youtube parse package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "waynestate/parse-menu": "~1.2",
         "waynestate/parse-promos": "~2.0",
         "waynestate/waynestate-api": "~1.2",
-        "waynestate/image-faker": "~1.0",
-        "waynestate/parse-youtube-id": "~1.0"
+        "waynestate/image-faker": "~1.0"
     },
     "require-dev": {
         "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d84b186ad08f131a904213e6b214e7a8",
+    "content-hash": "f65b82afceb5ed9a275933adacc12c0e",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",


### PR DESCRIPTION
Looks like this package was needed at one point but since it's being installed with the waynestate/parse-promos package at https://github.com/waynestate/parse-promos/blob/2.0.0/composer.json#L26

It should be left up to the package to install it.