### PR TITLE
Hotfix/5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 {{--
     $breadcrumbs => array // [['display_name', 'relative_url']]
 --}}
-<nav class="mt-6" aria-label="Breadcrumbs">
+<nav class="mt-6 mb-2" aria-label="Breadcrumbs">
     <ul class="list-reset text-sm">
         @foreach($breadcrumbs as $key=>$crumb)
             @if($key == 0)

--- a/resources/views/components/page-title.blade.php
+++ b/resources/views/components/page-title.blade.php
@@ -1,1 +1,1 @@
-<h1 class="{{ !empty($class) ? ' '.$class : '' }}">{{ $title }}</h1>
+<h1 class="mt-4{{ !empty($class) ? ' '.$class : '' }}">{{ $title }}</h1>


### PR DESCRIPTION
Correct the header spacing when no hero image or no breadcrumbs exist on the page