### PR TITLE
Hotfix/5.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Starter repository for creating a new website. Live demo can be found at https:/
 
 ## Configure the site
 
-1. Open `/config/app.php`
+1. Open `/config/base.php`
 1. Edit the options to configure the site, some values are present in the `.env` file.
 1. Server specific configuration options come from the `.env` file which need to be manually created/updated on the servers the app is deployed to.
 

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "waynestate/parse-menu": "~1.2",
         "waynestate/parse-promos": "~2.0",
         "waynestate/waynestate-api": "~1.2",
-        "waynestate/image-faker": "~1.0",
-        "waynestate/parse-youtube-id": "~1.0"
+        "waynestate/image-faker": "~1.0"
     },
     "require-dev": {
         "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d84b186ad08f131a904213e6b214e7a8",
+    "content-hash": "f65b82afceb5ed9a275933adacc12c0e",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
-            "version": "v3.1.4",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/laravel-debugbar.git",
-                "reference": "7a91480cc6e597caed5117a3c5d685f06d35c5a1"
+                "reference": "d3cdca2ad6cc6e67735b4a63e7551c690a497f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/7a91480cc6e597caed5117a3c5d685f06d35c5a1",
-                "reference": "7a91480cc6e597caed5117a3c5d685f06d35c5a1",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/d3cdca2ad6cc6e67735b4a63e7551c690a497f5f",
+                "reference": "d3cdca2ad6cc6e67735b4a63e7551c690a497f5f",
                 "shasum": ""
             },
             "require": {
@@ -72,7 +72,7 @@
                 "profiler",
                 "webprofiler"
             ],
-            "time": "2018-03-06T08:35:31+00:00"
+            "time": "2018-05-03T18:27:04+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -573,16 +573,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.6.22",
+            "version": "v5.6.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "637fd797a6dde8d24a9f07da77e375ec251c5d24"
+                "reference": "f547f0a71a12763d1adb8493237d541c9e3a5d10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/637fd797a6dde8d24a9f07da77e375ec251c5d24",
-                "reference": "637fd797a6dde8d24a9f07da77e375ec251c5d24",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/f547f0a71a12763d1adb8493237d541c9e3a5d10",
+                "reference": "f547f0a71a12763d1adb8493237d541c9e3a5d10",
                 "shasum": ""
             },
             "require": {
@@ -708,7 +708,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2018-05-15T13:34:20+00:00"
+            "time": "2018-05-22T14:55:57+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1344,16 +1344,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.3",
+            "version": "v0.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "79c280013cf0b30fa23f3ba8bd3649218075adf4"
+                "reference": "4d969a0e08e1e05e7207c07cb4207017ecc9a331"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/79c280013cf0b30fa23f3ba8bd3649218075adf4",
-                "reference": "79c280013cf0b30fa23f3ba8bd3649218075adf4",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4d969a0e08e1e05e7207c07cb4207017ecc9a331",
+                "reference": "4d969a0e08e1e05e7207c07cb4207017ecc9a331",
                 "shasum": ""
             },
             "require": {
@@ -1365,9 +1365,9 @@
                 "symfony/var-dumper": "~2.7|~3.0|~4.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
                 "hoa/console": "~2.15|~3.16",
-                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0",
-                "symfony/finder": "~2.1|~3.0|~4.0"
+                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0"
             },
             "suggest": {
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
@@ -1412,7 +1412,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-04-18T12:32:50+00:00"
+            "time": "2018-05-22T06:48:07+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1551,16 +1551,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3e820bc2c520a87ca209ad8fa961c97f42e0b4ae"
+                "reference": "058f120b8e06ebcd7b211de5ffae07b2db00fbdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3e820bc2c520a87ca209ad8fa961c97f42e0b4ae",
-                "reference": "3e820bc2c520a87ca209ad8fa961c97f42e0b4ae",
+                "url": "https://api.github.com/repos/symfony/console/zipball/058f120b8e06ebcd7b211de5ffae07b2db00fbdd",
+                "reference": "058f120b8e06ebcd7b211de5ffae07b2db00fbdd",
                 "shasum": ""
             },
             "require": {
@@ -1615,20 +1615,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T01:23:47+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "03f965583147957f1ecbad7ea1c9d6fd5e525ec2"
+                "reference": "0383a1a4eb1ffcac28719975d3e01bfa14be8ab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/03f965583147957f1ecbad7ea1c9d6fd5e525ec2",
-                "reference": "03f965583147957f1ecbad7ea1c9d6fd5e525ec2",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0383a1a4eb1ffcac28719975d3e01bfa14be8ab3",
+                "reference": "0383a1a4eb1ffcac28719975d3e01bfa14be8ab3",
                 "shasum": ""
             },
             "require": {
@@ -1668,20 +1668,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-03-19T22:35:49+00:00"
+            "time": "2018-05-11T15:58:37+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e1d57cdb357e5b10f5fdacbb0b86689c0a435e6e"
+                "reference": "4e7c98de67cc4171d4c986554e09a511da40f3d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e1d57cdb357e5b10f5fdacbb0b86689c0a435e6e",
-                "reference": "e1d57cdb357e5b10f5fdacbb0b86689c0a435e6e",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/4e7c98de67cc4171d4c986554e09a511da40f3d8",
+                "reference": "4e7c98de67cc4171d4c986554e09a511da40f3d8",
                 "shasum": ""
             },
             "require": {
@@ -1724,11 +1724,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T16:59:37+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -1791,16 +1791,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49"
+                "reference": "8c633f5a815903a1fe6e3fc135f207267a8a79af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
-                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8c633f5a815903a1fe6e3fc135f207267a8a79af",
+                "reference": "8c633f5a815903a1fe6e3fc135f207267a8a79af",
                 "shasum": ""
             },
             "require": {
@@ -1836,20 +1836,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-04T05:10:37+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "014487772c22d893168e5d628a13e882009fea29"
+                "reference": "277b757a2d3960170d99d372e171a8a18916467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/014487772c22d893168e5d628a13e882009fea29",
-                "reference": "014487772c22d893168e5d628a13e882009fea29",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/277b757a2d3960170d99d372e171a8a18916467a",
+                "reference": "277b757a2d3960170d99d372e171a8a18916467a",
                 "shasum": ""
             },
             "require": {
@@ -1889,20 +1889,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T01:05:59+00:00"
+            "time": "2018-05-25T11:08:56+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "8333264b6de323ea27a08627d5396aa564fb9c25"
+                "reference": "450a1bda817f2dce25a9e13f0f011336743f2a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8333264b6de323ea27a08627d5396aa564fb9c25",
-                "reference": "8333264b6de323ea27a08627d5396aa564fb9c25",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/450a1bda817f2dce25a9e13f0f011336743f2a48",
+                "reference": "450a1bda817f2dce25a9e13f0f011336743f2a48",
                 "shasum": ""
             },
             "require": {
@@ -1910,7 +1910,8 @@
                 "psr/log": "~1.0",
                 "symfony/debug": "~3.4|~4.0",
                 "symfony/event-dispatcher": "~3.4|~4.0",
-                "symfony/http-foundation": "~3.4.4|~4.0.4"
+                "symfony/http-foundation": "~3.4.4|~4.0.4",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/config": "<3.4",
@@ -1975,7 +1976,62 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T19:45:57+00:00"
+            "time": "2018-05-25T13:32:52+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2093,16 +2149,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25"
+                "reference": "3621fa74d0576a6f89d63bc44fabd376711bd0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
-                "reference": "d7dc1ee5dfe9f732cb1bba7310f5b99f2b7a6d25",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3621fa74d0576a6f89d63bc44fabd376711bd0b0",
+                "reference": "3621fa74d0576a6f89d63bc44fabd376711bd0b0",
                 "shasum": ""
             },
             "require": {
@@ -2138,20 +2194,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:24:00+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "1dfbfdf060bbc80da8dedc062050052e694cd027"
+                "reference": "e8833b64b139926cbe1610d53722185e55c18e44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/1dfbfdf060bbc80da8dedc062050052e694cd027",
-                "reference": "1dfbfdf060bbc80da8dedc062050052e694cd027",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/e8833b64b139926cbe1610d53722185e55c18e44",
+                "reference": "e8833b64b139926cbe1610d53722185e55c18e44",
                 "shasum": ""
             },
             "require": {
@@ -2216,20 +2272,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-04-20T06:20:23+00:00"
+            "time": "2018-05-16T14:21:07+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "ad3abf08eb3450491d8d76513100ef58194cd13e"
+                "reference": "e1f5863d0a9e79cfec7f031421ced3fe1d403e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/ad3abf08eb3450491d8d76513100ef58194cd13e",
-                "reference": "ad3abf08eb3450491d8d76513100ef58194cd13e",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e1f5863d0a9e79cfec7f031421ced3fe1d403e66",
+                "reference": "e1f5863d0a9e79cfec7f031421ced3fe1d403e66",
                 "shasum": ""
             },
             "require": {
@@ -2284,11 +2340,11 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T01:23:47+00:00"
+            "time": "2018-05-21T10:09:47+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
@@ -3899,16 +3955,16 @@
         },
         {
             "name": "php-coveralls/php-coveralls",
-            "version": "v2.0.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-coveralls/php-coveralls.git",
-                "reference": "3eaf7eb689cdf6b86801a3843940d974dc657068"
+                "reference": "3b00c229726f892bfdadeaf01ea430ffd04a939d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/3eaf7eb689cdf6b86801a3843940d974dc657068",
-                "reference": "3eaf7eb689cdf6b86801a3843940d974dc657068",
+                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/3b00c229726f892bfdadeaf01ea430ffd04a939d",
+                "reference": "3b00c229726f892bfdadeaf01ea430ffd04a939d",
                 "shasum": ""
             },
             "require": {
@@ -3934,7 +3990,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -3978,7 +4034,7 @@
                 "github",
                 "test"
             ],
-            "time": "2017-12-08T14:28:16+00:00"
+            "time": "2018-05-22T23:11:08+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -4248,16 +4304,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.4",
+            "version": "6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca"
+                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/52187754b0eed0b8159f62a6fa30073327e8c2ca",
-                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
+                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
                 "shasum": ""
             },
             "require": {
@@ -4307,7 +4363,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-29T14:59:09+00:00"
+            "time": "2018-05-28T11:49:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4577,16 +4633,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.1",
+            "version": "6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157"
+                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
+                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
                 "shasum": ""
             },
             "require": {
@@ -4629,7 +4685,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-04-11T04:50:36+00:00"
+            "time": "2018-05-29T13:54:20+00:00"
         },
         {
             "name": "psr/http-message",
@@ -5246,21 +5302,22 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7c19370ab04e9ac05b74a504198e165f5ccf6dd8"
+                "reference": "aaef656e99c5396d6118970abd1ceb11fa74551d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7c19370ab04e9ac05b74a504198e165f5ccf6dd8",
-                "reference": "7c19370ab04e9ac05b74a504198e165f5ccf6dd8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/aaef656e99c5396d6118970abd1ceb11fa74551d",
+                "reference": "aaef656e99c5396d6118970abd1ceb11fa74551d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/filesystem": "~3.4|~4.0"
+                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/finder": "<3.4"
@@ -5304,24 +5361,25 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-03-19T22:35:49+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21"
+                "reference": "7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
-                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04",
+                "reference": "7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
@@ -5353,20 +5411,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-22T10:50:29+00:00"
+            "time": "2018-05-16T09:05:32+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "371532a2cfe932f7a3766dd4c45364566def1dd0"
+                "reference": "ac1c3a814ddcad9d0cc2d0382e215d3bff8ae2d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/371532a2cfe932f7a3766dd4c45364566def1dd0",
-                "reference": "371532a2cfe932f7a3766dd4c45364566def1dd0",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ac1c3a814ddcad9d0cc2d0382e215d3bff8ae2d2",
+                "reference": "ac1c3a814ddcad9d0cc2d0382e215d3bff8ae2d2",
                 "shasum": ""
             },
             "require": {
@@ -5407,7 +5465,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-01-18T22:19:33+00:00"
+            "time": "2018-05-11T15:58:37+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -5470,7 +5528,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -5519,20 +5577,21 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.0.9",
+            "version": "v4.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "275ad099e4cbe612a2acbca14a16dd1c5311324d"
+                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/275ad099e4cbe612a2acbca14a16dd1c5311324d",
-                "reference": "275ad099e4cbe612a2acbca14a16dd1c5311324d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/048b1be5fb96e73ff1d065f5e7e23f84415ac907",
+                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -5573,7 +5632,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-08T08:49:08+00:00"
+            "time": "2018-05-07T07:12:24+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/base.php
+++ b/config/base.php
@@ -57,7 +57,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This enables the first level of the menu to show on the homepage. If the
-    | config option app.top_menu_enabled is true, then the homepage menu
+    | config option base.top_menu_enabled is true, then the homepage menu
     | will automatically be hidden.
     |
     */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -57,7 +57,7 @@ import Slideout from 'slideout/dist/slideout.js';
 
     // Toggle the appropriate classes for slideout based on the menu icon's visibility state
     var toggleSlideout = function () {
-        if(document.querySelector('.menu-button .menu-toggle').offsetParent === null) {
+        if(document.querySelector('.menu-toggle').offsetParent === null) {
             document.querySelector('#menu').classList.remove('slideout-menu');
             document.querySelector('#menu').classList.remove('slideout-menu-right');
         } else {

--- a/resources/js/modules/sticky.js
+++ b/resources/js/modules/sticky.js
@@ -3,10 +3,8 @@
 
     window.addEventListener('scroll', function() {
         if (window.pageYOffset >= document.querySelector('.wsuheader').offsetHeight) {
-            document.querySelector('.menu-top-placeholder').style.height = document.querySelector('div.menu-top').offsetHeight;
             document.querySelector('.menu-top-container').classList.add('w-full', 'fixed', 'pin-t', 'z-10');
         } else if(window.pageYOffset < document.querySelector('.wsuheader').offsetHeight) {
-            document.querySelector('.menu-top-placeholder').style.height = '0px';
             document.querySelector('.menu-top-container').classList.remove('w-full', 'fixed', 'pin-t', 'z-10');
         }
     });

--- a/resources/scss/components/_menu-top.scss
+++ b/resources/scss/components/_menu-top.scss
@@ -1,118 +1,27 @@
-.menu-top-container {
-    height: 65px;
+ul.menu-top {
+    margin: 0;
+    padding: 0;
 
-    .row {
-        height: 100%;
-    }
-
-    .title-area {
+    li {
         display: inline-block;
-    }
-
-    // Center vertically
-    .vertical-centering {
-        display: inline-block;
-        height: 100%;
-
-        > * {
-            display: table;
-            height: 100%;
-        }
-
-        > * > * {
-            display: table-cell;
-            vertical-align: middle;
-
-            // Hide & show the top menu
-            &.top-menu {
-                display: none;
-
-                @screen mt {
-                    display: table-cell;
-                }
-            }
-        }
-
-        &.title-area {
-            width: 75%;
-
-            @screen mt {
-                width: auto;
-            }
-        }
-    }
-
-    h1,
-    h2 {
-        @apply .text-white;
-
-        display: table;
-        font-size: 1.625rem;
-        font-weight: normal;
-        line-height: 1em;
-        margin: 0;
-        padding-bottom: 0;
+        margin: 0 10px;
 
         a {
             @apply .text-white;
-        }
-    }
 
-    h1.surtitle {
-        font-size: 1em;
-        line-height: 1em;
-        margin-top: 10px;
-        margin-bottom: 0;
-        font-weight: normal;
+            font-size: 16px;
 
-        a {
-            @apply .text-white;
-        }
-    }
-
-    ul.menu-top {
-        margin: 0;
-        padding: 0;
-
-        li {
-            display: inline-block;
-            margin: 0 10px;
-
-            a {
-                @apply .text-white;
-
-                font-size: 16px;
-
-                &:hover {
-                    @apply .text-yellow;
-                }
-            }
-
-            &.selected a {
-                @apply .text-yellow .border-b .border-solid .border-yellow;
-            }
-
-            &:last-child {
-                margin-right: 0;
+            &:hover {
+                @apply .text-yellow;
             }
         }
 
-        // Vertically center menu button on small
-        &.menu-button {
-            line-height: 0;
+        &.selected a {
+            @apply .text-yellow .border-b .border-solid .border-yellow;
         }
 
-        .menu-toggle {
-            padding: 0;
-            font-size: 2em;
-        }
-
-        .icon-cancel {
-            @apply .text-white;
-        }
-
-        .icon-cancel::before {
-            text-align: right;
+        &:last-child {
+            margin-right: 0;
         }
     }
 }

--- a/resources/scss/components/_menu-top.scss
+++ b/resources/scss/components/_menu-top.scss
@@ -9,8 +9,6 @@ ul.menu-top {
         a {
             @apply .text-white;
 
-            font-size: 16px;
-
             &:hover {
                 @apply .text-yellow;
             }

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,40 +4,24 @@
 --}}
 <div class="menu-top">
     <div class="menu-top-container bg-green-dark">
-        <div class="row relative px-4">
-            <div class="title-area{{ config('base.surtitle') === null ? ' vertical-centering' : '' }}">
+        <div class="row flex">
+            <div class="w-5/6 ml-4 py-2">
                 @if(config('base.surtitle') !== null)
-                    <h1 class="surtitle">
+                    <h1 class="text-base mb-0 font-normal">
                         @if($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true || $site['parent']['id'] !== null)
-                            <a href="{{ config('base.surtitle_url') }}">{{ config('base.surtitle') }}</a>
+                            <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>
                         @endif
                     </h1>
                 @endif
 
-                {!! config('base.surtitle') !== null ? '<h2>' : '<h1>' !!}
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}">{{ $site['title'] }}</a>
+                {!! config('base.surtitle') !== null ? '<h2 class="font-normal text-2xl leading-none">' : '<h1 class="font-normal text-2xl leading-none py-3">' !!}
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a>
                 {!! config('base.surtitle') !== null ? '</h2>' : '</h1>' !!}
             </div>
 
-            <div class="float-right vertical-centering">
-                <div>
-                    @if(config('base.top_menu_enabled') === true)
-                        <nav id="top-menu" class="top-menu" aria-label="Site menu" tabindex="-1">
-                            {!! $top_menu_output !!}
-                        </nav>
-                    @endif  
-
-                    <div>
-                        <ul class="menu-top menu-button mt:hidden">
-                            <li><button class="menu-toggle menu-icon" data-toggle="menu" aria-expanded="false" aria-controls="menu" tabindex="0"><span class="visually-hidden">Menu</span></button></li>
-                        </ul>
-                    </div>
-                </div>
+            <div class="w-1/6 flex justify-end items-center mr-4">
+                <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-expanded="false" aria-controls="menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
             </div>
-
-            @if(!empty($banner))
-                @include('components.banner', ['banner' => $banner])
-            @endif
         </div>
     </div>
 

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -5,7 +5,7 @@
 <div class="menu-top">
     <div class="menu-top-container bg-green-dark">
         <div class="row flex">
-            <div class="w-5/6 ml-4 py-2">
+            <div class="flex-grow mx-4 py-2">
                 @if(config('base.surtitle') !== null)
                     <h1 class="text-base mb-0 font-normal">
                         @if($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true || $site['parent']['id'] !== null)
@@ -19,7 +19,15 @@
                 {!! config('base.surtitle') !== null ? '</h2>' : '</h1>' !!}
             </div>
 
-            <div class="w-1/6 flex justify-end items-center mr-4">
+            <div class="hidden mx-4 mt:flex mt:flex-no-shrink mt:justify-end mt:items-center">
+                @if(config('base.top_menu_enabled') === true)
+                    <nav id="top-menu" aria-label="Site menu" tabindex="-1">
+                        {!! $top_menu_output !!}
+                    </nav>
+                @endif
+            </div>
+
+            <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
                 <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-expanded="false" aria-controls="menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
             </div>
         </div>

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -2,36 +2,32 @@
     $site => array // ['title']
     $top_menu_output => string // '<ul></ul>'
 --}}
-<div class="menu-top">
-    <div class="menu-top-container bg-green-dark">
-        <div class="row flex">
-            <div class="flex-grow mx-4 py-2">
-                @if(config('base.surtitle') !== null)
-                    <h1 class="text-base mb-0 font-normal">
-                        @if($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true || $site['parent']['id'] !== null)
-                            <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>
-                        @endif
-                    </h1>
-                @endif
+<div class="menu-top-container bg-green-dark">
+    <div class="row flex">
+        <div class="flex-grow mx-4 py-2">
+            @if(config('base.surtitle') !== null)
+                <h1 class="text-base mb-0 font-normal">
+                    @if($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true || $site['parent']['id'] !== null)
+                        <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>
+                    @endif
+                </h1>
+            @endif
 
-                {!! config('base.surtitle') !== null ? '<h2 class="font-normal text-2xl leading-none">' : '<h1 class="font-normal text-2xl leading-none py-3">' !!}
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a>
-                {!! config('base.surtitle') !== null ? '</h2>' : '</h1>' !!}
-            </div>
+            {!! config('base.surtitle') !== null ? '<h2 class="font-normal text-2xl leading-none">' : '<h1 class="font-normal text-2xl leading-none py-3">' !!}
+                <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a>
+            {!! config('base.surtitle') !== null ? '</h2>' : '</h1>' !!}
+        </div>
 
-            <div class="hidden mx-4 mt:flex mt:flex-no-shrink mt:justify-end mt:items-center">
-                @if(config('base.top_menu_enabled') === true)
-                    <nav id="top-menu" aria-label="Site menu" tabindex="-1">
-                        {!! $top_menu_output !!}
-                    </nav>
-                @endif
-            </div>
+        <div class="hidden mx-4 mt:flex mt:flex-no-shrink mt:justify-end mt:items-center">
+            @if(config('base.top_menu_enabled') === true)
+                <nav id="top-menu" aria-label="Site menu" tabindex="-1">
+                    {!! $top_menu_output !!}
+                </nav>
+            @endif
+        </div>
 
-            <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
-                <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-expanded="false" aria-controls="menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
-            </div>
+        <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
+            <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-expanded="false" aria-controls="menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
         </div>
     </div>
-
-    <div class="menu-top-placeholder"></div>
 </div>

--- a/styleguide/Http/Controllers/FullWidthController.php
+++ b/styleguide/Http/Controllers/FullWidthController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class FullWidthController extends Controller
+{
+    /**
+     * Display the full width hero view.
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        $request->data['show_site_menu'] = false;
+
+        config([
+            'base.full_width_controllers' => ['FullWidthController'],
+            'base.top_menu_enabled' => true,
+        ]);
+
+        // Center the page heading
+        $class['pageTitleClass'] = 'row px-4';
+
+        return view('styleguide-childpage', merge($request->data, $class));
+    }
+}

--- a/styleguide/Http/Controllers/HeaderTitleDoubleController.php
+++ b/styleguide/Http/Controllers/HeaderTitleDoubleController.php
@@ -27,9 +27,9 @@ class HeaderTitleDoubleController extends Controller
     public function index(Request $request)
     {
         config([
-            'app.surtitle' => $this->faker->sentence($this->faker->numberBetween(2, 4)),
-            'app.surtitle_main_site_enabled' => true,
-            'app.top_menu_enabled' => true,
+            'base.surtitle' => $this->faker->sentence($this->faker->numberBetween(2, 4)),
+            'base.surtitle_main_site_enabled' => true,
+            'base.top_menu_enabled' => true,
         ]);
 
         return view('styleguide-childpage', merge($request->data));

--- a/styleguide/Http/Controllers/HeaderTitleSingleController.php
+++ b/styleguide/Http/Controllers/HeaderTitleSingleController.php
@@ -17,6 +17,7 @@ class HeaderTitleSingleController extends Controller
     {
         config([
             'base.surtitle' => null,
+            'base.surtitle_main_site_enabled' => false,
             'base.top_menu_enabled' => true,
         ]);
 

--- a/styleguide/Http/Controllers/HeaderTitleSingleController.php
+++ b/styleguide/Http/Controllers/HeaderTitleSingleController.php
@@ -16,8 +16,8 @@ class HeaderTitleSingleController extends Controller
     public function index(Request $request)
     {
         config([
-            'app.surtitle' => null,
-            'app.top_menu_enabled' => true,
+            'base.surtitle' => null,
+            'base.top_menu_enabled' => true,
         ]);
 
         return view('styleguide-childpage', merge($request->data));

--- a/styleguide/Http/Controllers/HeroContainedTextController.php
+++ b/styleguide/Http/Controllers/HeroContainedTextController.php
@@ -17,8 +17,8 @@ class HeroContainedTextController extends Controller
     {
         // Set this controller in the allowed controllers list
         config([
-            'app.hero_text_enabled' => true,
-            'app.hero_text_controllers' => ['HeroContainedTextController'],
+            'base.hero_text_enabled' => true,
+            'base.hero_text_controllers' => ['HeroContainedTextController'],
         ]);
 
         // Remove the link from hero images

--- a/styleguide/Http/Controllers/HeroContainedTextLinkController.php
+++ b/styleguide/Http/Controllers/HeroContainedTextLinkController.php
@@ -17,8 +17,8 @@ class HeroContainedTextLinkController extends Controller
     {
         // Set this controller in the allowed controllers list
         config([
-            'app.hero_text_enabled' => true,
-            'app.hero_text_controllers' => ['HeroContainedTextLinkController'],
+            'base.hero_text_enabled' => true,
+            'base.hero_text_controllers' => ['HeroContainedTextLinkController'],
         ]);
 
         return view('styleguide-childpage', merge($request->data));

--- a/styleguide/Http/Controllers/HeroFullTextLinkController.php
+++ b/styleguide/Http/Controllers/HeroFullTextLinkController.php
@@ -17,9 +17,9 @@ class HeroFullTextLinkController extends Controller
     {
         // Set this controller in the allowed controllers list
         config([
-            'app.hero_text_enabled' => true,
-            'app.hero_text_controllers' => ['HeroFullTextLinkController'],
-            'app.hero_contained' => false,
+            'base.hero_text_enabled' => true,
+            'base.hero_text_controllers' => ['HeroFullTextLinkController'],
+            'base.hero_contained' => false,
         ]);
 
         $request->data['show_site_menu'] = false;

--- a/styleguide/Pages/Fullwidth.php
+++ b/styleguide/Pages/Fullwidth.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class Fullwidth extends Page
+{
+    /** {@inheritdoc} **/
+    public $path = '/styleguide/fullwidth';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, [
+            'page' => [
+                'controller' => 'FullWidthController',
+                'title' => 'Full Width',
+                'id' => 101105,
+                'content' => [
+                    'main' => '<div class="bg-grey-lighter"><div class="row p-4">'.
+                        '<p>'.$this->faker->paragraph(5).'</p>'.
+                        '<p>'.$this->faker->paragraph(5).'</p>'.
+                        '<p>'.$this->faker->paragraph(5).'</p>'.
+                    '</div></div>',
+                ],
+            ],
+        ]);
+    }
+}

--- a/styleguide/Repositories/MenuRepository.php
+++ b/styleguide/Repositories/MenuRepository.php
@@ -85,6 +85,16 @@ class MenuRepository extends Repository
                             'relative_url' => '/styleguide/directory',
                             'submenu' => [],
                         ],
+                        101105 => [
+                            'menu_item_id' => '101105',
+                            'is_active' => '1',
+                            'page_id' => null,
+                            'target' => '',
+                            'display_name' => 'Full Width Content Area',
+                            'class_name' => '',
+                            'relative_url' => '/styleguide/fullwidth',
+                            'submenu' => [],
+                        ],
                     ],
                 ],
                 102 => [

--- a/styleguide/Views/styleguide-childpage.blade.php
+++ b/styleguide/Views/styleguide-childpage.blade.php
@@ -1,7 +1,7 @@
 @extends('components.content-area')
 
 @section('content')
-    @include('components.page-title', ['title' => $page['title']])
+    @include('components.page-title', ['title' => $page['title'], 'class' => $pageTitleClass ?? ''])
 
     <div class="content">
         {!! $page['content']['main'] !!}


### PR DESCRIPTION
* Fix references for configs from `app.` to `base.` since the filename changed.
* Remove `waynestate/parse-youtube-id` package since base itself doesn't use it, we'll add it back whenever its actually used.
* Change the top menu area over to flexbox to fix sizing issues and to simplify the area.
* Remove unnecessary classes and html from menu top
* Add a styleguide page for full width content area template since we added it as a feature but never exposed it.