### PR TITLE
hotfix/5.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -41,6 +41,62 @@
         }
     }
 
+    img {
+        display: block;
+        width: 100%;
+        margin: 10px auto;
+        padding: 0;
+
+        &[class^="float-"] {
+            float: none !important;
+        }
+
+        &.icon {
+            display: inline-block;
+            width: auto;
+        }
+
+        @screen mt {
+            padding: 10px;
+            width: auto;
+            margin: 0;
+            float: inherit;
+        }
+    }
+
+    figure {
+        width: 100%;
+        display: table;
+        margin: 15px auto;
+
+        @screen md {
+            margin: 25px;
+            width: auto;
+        }
+
+        &[style*="float:right"],
+        &.float-right {
+            margin-right: 0;
+        }
+
+        &[style*="float:left"],
+        &.float-left {
+            margin-left: 0;
+        }
+
+        img {
+            padding: 0;
+        }
+
+        figcaption {
+            padding-top: 0.5em;
+            font-size: 0.875rem;
+            font-style: italic;
+            display: table-caption;
+            caption-side: bottom;
+        }
+    }
+
     table {
         border: none;
         width: 100%;
@@ -104,6 +160,11 @@
                 @apply .bg-yellow-lightest;
             }
         }
+
+        img {
+            max-width: none;
+            width: auto;
+        }
     }
 
     &.footer-contact {
@@ -117,62 +178,6 @@
 
         &:hover {
             text-decoration: none;
-        }
-    }
-
-    img {
-        display: block;
-        width: 100%;
-        margin: 10px auto;
-        padding: 0;
-
-        &[class^="float-"] {
-            float: none !important;
-        }
-
-        &.icon {
-            display: inline-block;
-            width: auto;
-        }
-
-        @screen mt {
-            padding: 10px;
-            width: auto;
-            margin: 0;
-            float: inherit;
-        }
-    }
-
-    figure {
-        width: 100%;
-        display: table;
-        margin: 15px auto;
-
-        @screen md {
-            margin: 25px;
-            width: auto;
-        }
-
-        &[style*="float:right"],
-        &.float-right {
-            margin-right: 0;
-        }
-
-        &[style*="float:left"],
-        &.float-left {
-            margin-left: 0;
-        }
-
-        img {
-            padding: 0;
-        }
-
-        figcaption {
-            padding-top: 0.5em;
-            font-size: 0.875rem;
-            font-style: italic;
-            display: table-caption;
-            caption-side: bottom;
         }
     }
 }


### PR DESCRIPTION
Remove max-width and set width to be auto on images within tables. Otherwise the table column with the images will collapse if there is no width set on a `<td>` element

Move img and figure above the table section due to the stylelint `no-descending-specifity` rule
```
128:5  ✖  Expected selector ".content img" to come before selector ".content table img"   no-descending-specificity
```

version bump to 5.0.10