### PR TITLE
fix setting the left menu based on the menu top breakpoint

### DIFF
--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -8,7 +8,7 @@
     @endif
 
     @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
-        <div class="md:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !!empty($show_site_menu))) mt:hidden @endif">
+        <div class="mt:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !!empty($show_site_menu))) mt:hidden @endif">
             <nav id="menu" class="main-menu" role="navigation" aria-label="Page menu" aria-hidden="true" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
                     <div class="offcanvas-main-menu mt:hidden">


### PR DESCRIPTION
Noticed that if you change the menu top breakpoint from 780 to anything else it wouldn't switch the content area to 100% wide properly. This fixes that issue.