### PR TITLE
Hotfix/5.3.1

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -93,10 +93,8 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             'top_menu_output' => $this->getTopMenuOutput($top_menu['menu']),
         ];
 
-        // Force left menu all the time if we aren't using top menu
-        if (config('base.top_menu_enabled') === false) {
-            $menus['show_site_menu'] = true;
-        }
+        // Show the menu by default
+        $menus['show_site_menu'] = true;
 
         // Force hide the menu if they specifically disable it
         if (config('base.homepage_menu_enabled') === false && $data['page']['controller'] == 'HomepageController') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -3,12 +3,12 @@
 @section('content-area')
     @yield('top')
 
-    @if(!empty($hero) && $site_menu['meta']['has_selected'] == false && config('base.hero_contained') === false)
+    @if(!empty($hero) && config('base.hero_contained') === false)
         @include('components.hero', ['images' => $hero])
     @endif
 
     @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
-        <div class="mt:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || empty($show_site_menu))) mt:hidden @endif">
+        <div class="mt:w-1/4 mt:px-4 mt:block {{ $show_site_menu === false ? ' mt:hidden' : '' }}">
             <nav id="menu" class="main-menu" role="navigation" aria-label="Page menu" aria-hidden="true" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
                     <div class="offcanvas-main-menu mt:hidden">
@@ -38,8 +38,8 @@
             </nav>
         </div>
 
-        <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }}{{ ($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !empty($show_site_menu))) ? '' : ' mt:w-3/4'}} content-area mb-8">
-            @if(!empty($hero) && ($site_menu['meta']['has_selected'] == true || config('base.hero_contained') === true))
+    <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8">
+            @if(!empty($hero) && config('base.hero_contained') === true)
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])
             @endif
 

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -8,7 +8,7 @@
     @endif
 
     @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
-        <div class="mt:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !!empty($show_site_menu))) mt:hidden @endif">
+        <div class="mt:w-1/4 mt:px-4 mt:block @if($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || empty($show_site_menu))) mt:hidden @endif">
             <nav id="menu" class="main-menu" role="navigation" aria-label="Page menu" aria-hidden="true" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
                     <div class="offcanvas-main-menu mt:hidden">
@@ -38,7 +38,7 @@
             </nav>
         </div>
 
-        <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }}{{ ($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !!empty($show_site_menu))) ? '' : ' mt:w-3/4'}} content-area mb-8">
+        <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }}{{ ($site_menu['meta']['has_selected'] == false && ((!empty($show_site_menu) && $show_site_menu != true) || !empty($show_site_menu))) ? '' : ' mt:w-3/4'}} content-area mb-8">
             @if(!empty($hero) && ($site_menu['meta']['has_selected'] == true || config('base.hero_contained') === true))
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])
             @endif


### PR DESCRIPTION
There were some bugs in configuring the hero image being full with showing a menu. I ripped out all the checks around `has_selected` so we're only checking one variable of `show_site_menu` now to simplify the conditions. This seems to satisfy all the cases within `/styleguide`. If any other issues come up after this, they should be easier to fix if we can keep the conditions to a minimum.