### PR TITLE
Fixes for Profile Repository

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -194,10 +194,10 @@ class ProfileRepository implements ProfileRepositoryContract
         $profiles = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
-            return $this->wsuApi->sendRequest($params['method'], $params)['profiles'];
+            return $this->wsuApi->sendRequest($params['method'], $params);
         });
 
-        $profile['profile'] = array_get($profiles, $site_id, []);
+        $profile['profile'] = empty($profiles['error']) ? array_get($profiles['profiles'], $site_id, []) : [];
 
         return $profile;
     }

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -50,7 +50,7 @@ class ProfileRepository implements ProfileRepositoryContract
         });
 
         // Make sure the return is an array
-        $profiles['profiles'] = ! !empty($profile_listing['error']) ? $profile_listing : [];
+        $profiles['profiles'] = empty($profile_listing['error']) ? $profile_listing : [];
 
         return $profiles;
     }

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -123,7 +123,6 @@ class ProfileRepositoryTest extends TestCase
     public function getting_profile_that_doesnt_exist_should_return_blank_array()
     {
         $site_id = $this->faker->numberBetween(1, 10);
-        $invalid_site_id = $this->faker->numberBetween(20, 30);
         $accessid = $this->faker->word;
 
         // Fake return

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -127,11 +127,7 @@ class ProfileRepositoryTest extends TestCase
         $accessid = $this->faker->word;
 
         // Fake return
-        $return = [
-            'profiles' => [
-                $invalid_site_id => app('Factories\Profile')->create(1, true),
-            ],
-        ];
+        $return = app('Factories\ApiError')->create(1, true);
 
         // Mock the Connector and set the return
         $wsuApi = Mockery::mock('Waynestate\Api\Connector');


### PR DESCRIPTION
- Remove double !! from `getProfiles` since it negates itself
- Fix test and method `getProfile` to work with the correct error returned from the API, if the profile is not found