### PR TITLE
hotfix/5.4.1

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -102,7 +102,7 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
         }
 
         // If no menu is selected then hide the site menu
-        if ($menus['site_menu_output'] === null) {
+        if (empty($menus['site_menu_output'])) {
             $menus['show_site_menu'] = false;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/MenuRepositoryTest.php
+++ b/tests/Unit/Repositories/MenuRepositoryTest.php
@@ -612,4 +612,35 @@ class MenuRepositoryTest extends TestCase
 
         $this->assertFalse($menu['show_site_menu']);
     }
+
+    /**
+     * @covers App\Repositories\MenuRepository::getMenus
+     * @test
+     */
+    public function page_with_menu_and_no_submenu_items_with_top_menu_enabled_showsitemenu_should_be_false()
+    {
+        // Force enable top menu
+        config(['base.top_menu_enabled' => true]);
+
+        // Get a page with the HomepageController set
+        $page = app('Factories\Page')->create(
+            1,
+            true,
+            [
+                'page' => [
+                    'controller' => 'ChildpageController',
+                ],
+                'menu' => [
+                    'id' => 1,
+                ],
+            ]
+        );
+        // Get a menu and mimic as if there were multiple
+        $menu[$page['menu']['id']] = app('Factories\Menu')->create(5);
+
+        // Parse the site menu
+        $menus = app('App\Repositories\MenuRepository')->getMenus($page, $menu);
+
+        $this->assertFalse($menus['show_site_menu']);
+    }
 }


### PR DESCRIPTION
Fix for when a site is using the top menu but has no sub menu items, it should display as full width by setting the `['show_site_menu'] option as false.