### PR TITLE
feature/top-menu-style

### DIFF
--- a/resources/scss/components/_menu-top.scss
+++ b/resources/scss/components/_menu-top.scss
@@ -3,9 +3,6 @@ ul.menu-top {
     padding: 0;
 
     li {
-        display: inline-block;
-        margin: 0 10px;
-
         a {
             @apply .text-white;
 
@@ -14,12 +11,17 @@ ul.menu-top {
             }
         }
 
-        &.selected a {
-            @apply .text-yellow .border-b .border-solid .border-yellow;
-        }
-
         &:last-child {
             margin-right: 0;
+        }
+
+        @screen mt {
+            display: inline-block;
+            margin: 0 10px;
+
+            &.selected a {
+                @apply .text-yellow .border-b .border-solid .border-yellow;
+            }
         }
     }
 }


### PR DESCRIPTION
On offcanvas the main menu style was incorrect. It was using the style you see before the hamburger icon shows.

## Before:
<img width="282" alt="screen shot 2018-08-24 at 1 55 21 pm" src="https://user-images.githubusercontent.com/634788/44599774-5f976580-a7a5-11e8-8495-ac5e33141f08.png">

## After:
<img width="298" alt="screen shot 2018-08-24 at 1 55 07 pm" src="https://user-images.githubusercontent.com/634788/44599787-68883700-a7a5-11e8-8a46-825b21129f0f.png">
