### PR TITLE
feature/fix-watch

### DIFF
--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -1,6 +1,10 @@
 // Combination of normalize and tailwind resets
 @tailwind preflight;
 
+@import "~mediabox/dist/mediabox";
+@import "~flickity/dist/flickity";
+@import "~@waynestate/wsuheader/dist/header";
+@import "~@waynestate/wsufooter/dist/footer";
 @import "components/global";
 @import "components/accordion";
 @import "components/banner";

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -52,13 +52,6 @@ mix.copy([
 // Compile assets and setup browersync
 mix.js('resources/js/main.js', 'public/_resources/js')
    .sass('resources/scss/main.scss', 'public/_resources/css/main.css')
-   .styles([
-       'node_modules/mediabox/dist/mediabox.css',
-       'node_modules/flickity/dist/flickity.css',
-       'node_modules/@waynestate/wsuheader/dist/header.css',
-       'node_modules/@waynestate/wsufooter/dist/footer.css',
-       'public/_resources/css/main.css',
-   ], 'public/_resources/css/main.css')
    .purgeCss({
         globs: [
             path.join(__dirname, "resources/views/**/*.blade.php"),
@@ -149,7 +142,7 @@ config = {
         ])
     ],
     devtool: 'source-map'
-}
+};
 
 if (mix.inProduction()) {
     // Version the CSS for cache busting


### PR DESCRIPTION
Using sass and styles call makes an infinite loop with make watch running. Fix it by moving the styles back as imports in SCSS and we'll just deal with the deprecation warnings (since they plan to actually remove them and keep the feature in the next release).