### PR TITLE
Feature/hero

### DIFF
--- a/app/Http/Middleware/Data.php
+++ b/app/Http/Middleware/Data.php
@@ -48,17 +48,22 @@ class Data
         }
 
         // Merge server and page data so global repositories can use them
-        $data = merge($data, $page);
+        $request->data = merge($data, $page);
 
-        // Merge global repository data and set it to the request
+        // Merge in global menus
         $request->data = merge(
-            $data,
-            app($this->getPrefix().'\Repositories\MenuRepository')->getRequestData($data),
-            app($this->getPrefix().'\Repositories\PromoRepository')->getRequestData($data)
+            $request->data,
+            app($this->getPrefix().'\Repositories\MenuRepository')->getRequestData($request->data)
+        );
+
+        // Merge in global promotions
+        $request->data = merge(
+            $request->data,
+            app($this->getPrefix().'\Repositories\PromoRepository')->getRequestData($request->data)
         );
 
         // Controller namespace path so it can be constructed in the routes file
-        $request->controller = $this->getControllerNamespace($data['page']['controller']);
+        $request->controller = $this->getControllerNamespace($request->data['page']['controller']);
 
         return $next($request);
     }

--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -84,16 +84,9 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             config('base.top_menu_id')
         );
 
-        // If top menu is enabled and this page is not in the menu then override it
+        // Override the menu so it doesn't show the same menu twice
         if (config('base.top_menu_enabled') === true && $site_menu['meta']['has_selected'] === false) {
             $site_menu['menu'] = [];
-        }
-
-        // If the page isn't found in the site menu then force it to be part of the full controllers list
-        if ($site_menu['meta']['has_selected'] === false) {
-            $controllers = config('base.hero_full_controllers');
-            array_push($controllers, $data['page']['controller']);
-            config(['base.hero_full_controllers' => $controllers]);
         }
 
         // Build the return
@@ -105,15 +98,15 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             'top_menu_output' => $this->getTopMenuOutput($top_menu['menu']),
         ];
 
-        // Show the menu by default
+        // Show the site menu by default
         $menus['show_site_menu'] = true;
 
-        // Force hide the menu if they specifically disable it
+        // Force hide the site menu if they specifically disable it
         if (config('base.homepage_menu_enabled') === false && $data['page']['controller'] == 'HomepageController') {
             $menus['show_site_menu'] = false;
         }
 
-        // If no menu is selected then hide the site menu
+        // If no site menu is selected then hide the site menu
         if (empty($menus['site_menu_output'])) {
             $menus['show_site_menu'] = false;
         }

--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -84,6 +84,18 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             config('base.top_menu_id')
         );
 
+        // If top menu is enabled and this page is not in the menu then override it
+        if (config('base.top_menu_enabled') === true && $site_menu['meta']['has_selected'] === false) {
+            $site_menu['menu'] = [];
+        }
+
+        // If the page isn't found in the site menu then force it to be part of the full controllers list
+        if ($site_menu['meta']['has_selected'] === false) {
+            $controllers = config('base.hero_full_controllers');
+            array_push($controllers, $data['page']['controller']);
+            config(['base.hero_full_controllers' => $controllers]);
+        }
+
         // Build the return
         $menus = [
             'site_menu' => $site_menu,
@@ -192,7 +204,7 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
     {
         // Trim first level based on path[0] - only if we are on the main website
         // or we aren't enabling top menu across all subsites
-        if (!empty($menu['meta']['path']) && ($parentId === null || $topMenuId === null) && config('base.top_menu_enabled') == true) {
+        if (!empty($menu['meta']['path']) && ($parentId === null || $topMenuId === null) && config('base.top_menu_enabled') === true) {
             foreach ($menu['menu'] as $key => $item) {
                 // If we are on the first path then grab that submenu
                 if ($item['menu_item_id'] == $menu['meta']['path'][0]) {

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -139,7 +139,7 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
         }
 
         // Add to full hero controllers list if the page has no site menu or its not being shown
-        if (!empty($data['site_menu']) && empty($data['site_menu']['menu']) || (!empty($data['site_menu']['menu']) && config('base.homepage_menu_enabled') === false && $data['show_site_menu'] === false)) {
+        if ((!empty($data['site_menu']) && empty($data['site_menu']['menu'])) || (!empty($data['site_menu']['menu']) && $data['show_site_menu'] === false)) {
             $controllers = config('base.hero_full_controllers');
             array_push($controllers, $data['page']['controller']);
             config(['base.hero_full_controllers' => $controllers]);

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -138,8 +138,8 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
             $group_config = str_replace('|limit:1', '|limit:'.config('base.hero_rotating_limit'), $group_config);
         }
 
-        // Add to full hero controllers list if the page has no site menu
-        if (!empty($data['site_menu']) && empty($data['site_menu']['menu'])) {
+        // Add to full hero controllers list if the page has no site menu or its not being shown
+        if (!empty($data['site_menu']) && empty($data['site_menu']['menu']) || (!empty($data['site_menu']['menu']) && config('base.homepage_menu_enabled') === false)) {
             $controllers = config('base.hero_full_controllers');
             array_push($controllers, $data['page']['controller']);
             config(['base.hero_full_controllers' => $controllers]);

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -139,7 +139,7 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
         }
 
         // Add to full hero controllers list if the page has no site menu or its not being shown
-        if (!empty($data['site_menu']) && empty($data['site_menu']['menu']) || (!empty($data['site_menu']['menu']) && config('base.homepage_menu_enabled') === false)) {
+        if (!empty($data['site_menu']) && empty($data['site_menu']['menu']) || (!empty($data['site_menu']['menu']) && config('base.homepage_menu_enabled') === false && $data['show_site_menu'] === false)) {
             $controllers = config('base.hero_full_controllers');
             array_push($controllers, $data['page']['controller']);
             config(['base.hero_full_controllers' => $controllers]);

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -138,6 +138,13 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
             $group_config = str_replace('|limit:1', '|limit:'.config('base.hero_rotating_limit'), $group_config);
         }
 
+        // Add to full hero controllers list if the page has no site menu
+        if (!empty($data['site_menu']) && empty($data['site_menu']['menu'])) {
+            $controllers = config('base.hero_full_controllers');
+            array_push($controllers, $data['page']['controller']);
+            config(['base.hero_full_controllers' => $controllers]);
+        }
+
         // Parsed promotions
         $promos = $this->parsePromos->parse($promos, $group_reference, $group_config);
 

--- a/config/base.php
+++ b/config/base.php
@@ -65,15 +65,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hero Contained
+    | Hero Full Width
     |--------------------------------------------------------------------------
     |
-    | Force the hero image to be contained within the content area of the page.
-    | If set to false the hero image will expand 100% across the top of the
-    | site if it is not found in the menu.
+    | This enables hero images to span 100% across the top of the site. You
+    | can specify which controllers you want this to work on by adding to
+    | the array. If a controller is not listed it will be contained
+    | within the content-area.
     |
     */
-    'hero_contained' => true,
+    'hero_full_controllers' => [],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/base.php
+++ b/config/base.php
@@ -37,7 +37,7 @@ return [
     | top bar of the site.
     |
     */
-    'top_menu_enabled' => false,
+    'top_menu_enabled' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -71,7 +71,9 @@ return [
     | This enables hero images to span 100% across the top of the site. You
     | can specify which controllers you want this to work on by adding to
     | the array. If a controller is not listed it will be contained
-    | within the content-area.
+    | within the content-area. If a page isn't in the menu and top
+    | menu is enabled then the controller will automatically act
+    | as if it was in this array.
     |
     */
     'hero_full_controllers' => [],

--- a/config/base.php
+++ b/config/base.php
@@ -37,7 +37,7 @@ return [
     | top bar of the site.
     |
     */
-    'top_menu_enabled' => true,
+    'top_menu_enabled' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -3,7 +3,7 @@
 @section('content-area')
     @yield('top')
 
-    @if(!empty($hero) && config('base.hero_contained') === false)
+    @if(!empty($hero) && in_array($page['controller'], config('base.hero_full_controllers')))
         @include('components.hero', ['images' => $hero])
     @endif
 
@@ -39,7 +39,7 @@
         </div>
 
     <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8">
-            @if(!empty($hero) && config('base.hero_contained') === true)
+            @if(!empty($hero) && !in_array($page['controller'], config('base.hero_full_controllers')))
                 @include('components.hero', ['images' => $hero, 'class' => 'hero--childpage'])
             @endif
 

--- a/tests/Unit/Repositories/PromoRepositoryTest.php
+++ b/tests/Unit/Repositories/PromoRepositoryTest.php
@@ -165,6 +165,62 @@ class PromoRepositoryTest extends TestCase
     }
 
     /**
+     * @covers App\Repositories\PromoRepository::getRequestData
+     * @test
+     */
+    public function page_should_show_full_width_hero_with_no_site_menu()
+    {
+        // Create a fake data request
+        $data = app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'ExampleController',
+            ],
+        ]);
+
+        // Fake a site menu with no menu
+        $data['site_menu']['menu'] = [];
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn([]);
+
+        // Get the promos
+        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getRequestData($data);
+
+        $this->assertTrue(in_array('ExampleController', config('base.hero_full_controllers')));
+    }
+
+    /**
+     * @covers App\Repositories\PromoRepository::getRequestData
+     * @test
+     */
+    public function page_should_show_full_width_hero_with_site_menu_but_menu_is_hidden()
+    {
+        // Create a fake data request
+        $data = app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'ExampleController',
+            ],
+        ]);
+
+        // Force this to false
+        //config(['base.homepage_menu_enabled' => false]);
+
+        // Fake a site menu
+        $data['site_menu']['menu'] = app('Factories\Menu')->create();
+        $data['show_site_menu'] = false;
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn([]);
+
+        // Get the promos
+        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getRequestData($data);
+
+        $this->assertTrue(in_array('ExampleController', config('base.hero_full_controllers')));
+    }
+
+    /**
      * @covers App\Repositories\PromoRepository::getHomepagePromos
      * @test
      */


### PR DESCRIPTION
We didn't have the ability to have a homepage hero full while the child page heros are contained. The true/false would do it for the whole site.

This PR adds better functionality by specifying a list of controllers you want to be full hero images. By default everything will be contained. 

Another way a hero image can be full width is if top menu is enabled and the page doesn't exist in the menu. This will result in automatically adding it to this array. The reason for this is the site looks odd when the hero image is contained to row width (1200px), so we're going to force it full width in this case.