### PR TITLE
Short title in search box for context

### DIFF
--- a/factories/Page.php
+++ b/factories/Page.php
@@ -26,7 +26,8 @@ class Page implements FactoryContract
             $data[$i] = [
                 'site' => [
                     'id' => 2,
-                    'title' => 'Styleguide',
+                    'title' => 'Site style guide',
+                    'short-title' => 'Styleguide',
                     'keywords' => '',
                     'subsite-folder' => null,
                     'parent' => [

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -4,6 +4,7 @@ import './polyfills/foreach';
 import './polyfills/prepend';
 
 // Modules
+import './modules/search';
 import './modules/table';
 import './modules/sticky';
 import './modules/formfilter';

--- a/resources/js/modules/search.js
+++ b/resources/js/modules/search.js
@@ -1,0 +1,13 @@
+(function() {
+    "use strict";
+
+    const short_title = document.querySelector("[data-short-title]");
+    const search_field = document.getElementById("q");
+
+    if (short_title && search_field && short_title.dataset.shortTitle !== "") {
+        search_field.setAttribute(
+            "placeholder",
+            "Search " + short_title.dataset.shortTitle.trim() + "..."
+        );
+    }
+})();

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,7 +4,7 @@
 --}}
 <div class="menu-top-container bg-green-dark">
     <div class="row flex">
-        <div class="flex-grow mx-4 py-2">
+        <div class="flex-grow mx-4 py-2" data-short-title="{{ $site['short-title'] !== null ? $site['short-title'] : ''}}">
             @if(config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null))
                 <h1 class="text-base mb-0 font-normal">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>


### PR DESCRIPTION
The quickest way to get a 'short' title in the university header if both elements exist. 

There are a number of ways to get this data in the DOM to be used for the header, the `data` attribute was used here for simplicity.

Since the `placeholder` attribute isn't read by screen readers, we could also manipulate the hidden search label to provide that context to a non-sighted user.

Will create styleguide examples of the on and off state if this is the direction we will go in.

## Result

![screen shot 2018-09-04 at 7 23 56 am](https://user-images.githubusercontent.com/37359/45028785-5d8a9d80-b014-11e8-8a76-18df45354d1c.png)
