### PR TITLE
Short title used for mobile header display and search context

### DIFF
--- a/factories/Page.php
+++ b/factories/Page.php
@@ -26,7 +26,8 @@ class Page implements FactoryContract
             $data[$i] = [
                 'site' => [
                     'id' => 2,
-                    'title' => 'Styleguide',
+                    'title' => 'Site style guide',
+                    'short-title' => 'Styleguide',
                     'keywords' => '',
                     'subsite-folder' => null,
                     'parent' => [

--- a/factories/Page.php
+++ b/factories/Page.php
@@ -26,8 +26,8 @@ class Page implements FactoryContract
             $data[$i] = [
                 'site' => [
                     'id' => 2,
-                    'title' => 'Site style guide',
-                    'short-title' => 'Styleguide',
+                    'title' => 'Style guide',
+                    'short-title' => '',
                     'keywords' => '',
                     'subsite-folder' => null,
                     'parent' => [

--- a/factories/Page.php
+++ b/factories/Page.php
@@ -26,7 +26,7 @@ class Page implements FactoryContract
             $data[$i] = [
                 'site' => [
                     'id' => 2,
-                    'title' => 'Style guide',
+                    'title' => 'Site style guide',
                     'short-title' => '',
                     'keywords' => '',
                     'subsite-folder' => null,

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -4,6 +4,7 @@ import './polyfills/foreach';
 import './polyfills/prepend';
 
 // Modules
+import './modules/search';
 import './modules/table';
 import './modules/sticky';
 import './modules/formfilter';

--- a/resources/js/modules/search.js
+++ b/resources/js/modules/search.js
@@ -1,0 +1,13 @@
+(function() {
+    "use strict";
+
+    const short_title = document.querySelector("h1.short-title");
+    const search_field = document.getElementById("q");
+
+    if (short_title && search_field) {
+        search_field.setAttribute(
+            "placeholder",
+            "Search " + short_title.textContent.trim() + "..."
+        );
+    }
+})();

--- a/resources/js/modules/search.js
+++ b/resources/js/modules/search.js
@@ -1,13 +1,14 @@
 (function() {
     "use strict";
 
-    const short_title = document.querySelector("h1.short-title");
+    const short_title = document.querySelector("[data-short-title]");
+    const search_label = document.querySelector("label[for='q']");
     const search_field = document.getElementById("q");
 
-    if (short_title && search_field) {
-        search_field.setAttribute(
-            "placeholder",
-            "Search " + short_title.textContent.trim() + "..."
-        );
+    if (short_title && search_field && search_label) {
+        const search_text = "Search " + short_title.dataset.shortTitle.trim();
+
+        search_label.textContent = search_text.trim();
+        search_field.setAttribute("placeholder", search_text.trim() + "...");
     }
 })();

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,7 +4,7 @@
 --}}
 <div class="menu-top-container bg-green-dark">
     <div class="row flex">
-        <div class="hidden mt:inline-flex mt:flex-grow mx-4 py-2">
+        <div class="hidden mt:block mt:flex-grow mx-4 py-2">
             @if(config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null))
                 <h1 class="text-base mb-0 font-normal">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,7 +4,7 @@
 --}}
 <div class="menu-top-container bg-green-dark">
     <div class="row flex">
-        <div class="flex-grow mx-4 py-2">
+        <div class="hidden mt:inline-flex mt:flex-grow mx-4 py-2">
             @if(config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null))
                 <h1 class="text-base mb-0 font-normal">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>
@@ -14,6 +14,14 @@
             @else
                 <h1 class="font-normal text-2xl leading-none py-3"><a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a></h1>
             @endif
+        </div>
+
+        <div class="flex-grow mx-4 py-2 mt:hidden">
+            <h1 class="short-title font-normal text-2xl leading-none py-3">
+                <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">
+                    {{ $site['short-title'] !== '' ? $site['short-title'] : $site['title'] }}
+                </a>
+            </h1>
         </div>
 
         @if(config('base.top_menu_enabled') === true)

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,24 +4,34 @@
 --}}
 <div class="menu-top-container bg-green-dark">
     <div class="row flex">
-        <div class="hidden mt:block mt:flex-grow mx-4 py-2">
+        <div class="flex-grow mx-4 py-2" data-short-title="{{ $site['short-title'] }}">
             @if(config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null))
                 <h1 class="text-base mb-0 font-normal">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white">{{ config('base.surtitle') }}</a>
                 </h1>
 
-                <h2 class="font-normal text-2xl leading-none"><a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a></h2>
+                <h2 class="font-normal text-2xl leading-none">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">
+                        @if($site['short-title'] !== '')
+                            <span class="mt:hidden">{{ $site['short-title'] }}</span>
+                            <span class="hidden mt:inline">{{ $site['title'] }}</span>
+                        @else
+                            {{ $site['title'] }}
+                        @endif
+                    </a>
+                </h2>
             @else
-                <h1 class="font-normal text-2xl leading-none py-3"><a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">{{ $site['title'] }}</a></h1>
+                <h1 class="font-normal text-2xl leading-none py-3">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">
+                        @if($site['short-title'] !== '')
+                            <span class="mt:hidden">{{ $site['short-title'] }}</span>
+                            <span class="hidden mt:inline">{{ $site['title'] }}</span>
+                        @else
+                            {{ $site['title'] }}
+                        @endif
+                    </a>
+                </h1>
             @endif
-        </div>
-
-        <div class="flex-grow mx-4 py-2 mt:hidden">
-            <h1 class="short-title font-normal text-2xl leading-none py-3">
-                <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white">
-                    {{ $site['short-title'] !== '' ? $site['short-title'] : $site['title'] }}
-                </a>
-            </h1>
         </div>
 
         @if(config('base.top_menu_enabled') === true)

--- a/styleguide/Http/Controllers/HeaderShortTitleDoubleController.php
+++ b/styleguide/Http/Controllers/HeaderShortTitleDoubleController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Faker\Factory;
+
+class HeaderShortTitleDoubleController extends Controller
+{
+    /**
+     * Construct the controller.
+     *
+     * @param Factory $faker
+     */
+    public function __construct(Factory $faker)
+    {
+        $this->faker = $faker->create();
+    }
+
+    /**
+     * Display the double header view with a custom short title
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        config([
+            'base.surtitle' => $this->faker->sentence($this->faker->numberBetween(2, 4)),
+            'base.surtitle_main_site_enabled' => true,
+            'base.top_menu_enabled' => true,
+        ]);
+
+        $request->data['site']['short-title'] = $this->faker->sentence(2);
+
+        return view('styleguide-childpage', merge($request->data));
+    }
+}

--- a/styleguide/Http/Controllers/HeaderShortTitleSingleController.php
+++ b/styleguide/Http/Controllers/HeaderShortTitleSingleController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Faker\Factory;
+
+class HeaderShortTitleSingleController extends Controller
+{
+    /**
+     * Construct the controller.
+     *
+     * @param Factory $faker
+     */
+    public function __construct(Factory $faker)
+    {
+        $this->faker = $faker->create();
+    }
+
+    /**
+     * Display single header view with a custom short title
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        config([
+            'base.surtitle' => null,
+            'base.surtitle_main_site_enabled' => false,
+            'base.top_menu_enabled' => true,
+        ]);
+
+        $request->data['site']['short-title'] = $this->faker->sentence(2);
+
+        return view('styleguide-childpage', merge($request->data));
+    }
+}

--- a/styleguide/Pages/HeaderShortTitleDouble.php
+++ b/styleguide/Pages/HeaderShortTitleDouble.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class HeaderShortTitleDouble extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'HeaderShortTitleDoubleController',
+                'title' => 'Header title double w/short title',
+                'id' => 102100104,
+            ],
+        ]);
+    }
+}

--- a/styleguide/Pages/HeaderShortTitleDouble.php
+++ b/styleguide/Pages/HeaderShortTitleDouble.php
@@ -13,7 +13,7 @@ class HeaderShortTitleDouble extends Page
             'page' => [
                 'controller' => 'HeaderShortTitleDoubleController',
                 'title' => 'Header title double w/short title',
-                'id' => 102100104,
+                'id' => 102100103,
             ],
         ]);
     }

--- a/styleguide/Pages/HeaderShortTitleSingle.php
+++ b/styleguide/Pages/HeaderShortTitleSingle.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class HeaderShortTitleSingle extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'HeaderShortTitleSingleController',
+                'title' => 'Header title single w/short title',
+                'id' => 102100102,
+            ],
+        ]);
+    }
+}

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -117,6 +117,26 @@
                         "class_name": "",
                         "relative_url": "/styleguide/header/title/double/",
                         "submenu": []
+                    },
+                    "102100102": {
+                        "menu_item_id": "102100102",
+                        "is_active": "1",
+                        "page_id": "102100102",
+                        "target": "",
+                        "display_name": "Header title single w/short title",
+                        "class_name": "",
+                        "relative_url": "/styleguide/header/shorttitle/single",
+                        "submenu": []
+                    },
+                    "102100103": {
+                        "menu_item_id": "102100103",
+                        "is_active": "1",
+                        "page_id": "102100103",
+                        "target": "",
+                        "display_name": "Header title double w/short title",
+                        "class_name": "",
+                        "relative_url": "/styleguide/header/shorttitle/double/",
+                        "submenu": []
                     }
                 }
             },


### PR DESCRIPTION
Using the 'short-title' field for both the search context and to be displayed visually when the top bar shrinks.

This allows for "Housing & Residential Life" to be shortened to "Housing" when space is constrained.

Not a huge fan of the duplicate HTML in the header but it does work correctly on VoiceOver for Mac, haven't tested it on others. 

Since the `placeholder` attribute isn't read by screen readers, we could also manipulate the hidden search label to provide that context to a non-sighted user.

Will create styleguide examples of the on and off state if this is the direction we will go in.

## Result

![search](https://user-images.githubusercontent.com/37359/45029023-47c9a800-b015-11e8-8e69-d4529c4afd57.gif)
