### PR TITLE
Fix full hero controllers

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -111,6 +111,13 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             $menus['show_site_menu'] = false;
         }
 
+        // Add to full hero controllers list if the page has no site menu or its not being shown
+        if ((!empty($menus['site_menu']) && empty($menus['site_menu']['menu'])) || (!empty($menus['site_menu']['menu']) && $menus['show_site_menu'] === false)) {
+            $controllers = config('base.hero_full_controllers');
+            array_push($controllers, $data['page']['controller']);
+            config(['base.hero_full_controllers' => $controllers]);
+        }
+
         return $menus;
     }
 

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -138,13 +138,6 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
             $group_config = str_replace('|limit:1', '|limit:'.config('base.hero_rotating_limit'), $group_config);
         }
 
-        // Add to full hero controllers list if the page has no site menu or its not being shown
-        if ((!empty($data['site_menu']) && empty($data['site_menu']['menu'])) || (!empty($data['site_menu']['menu']) && $data['show_site_menu'] === false)) {
-            $controllers = config('base.hero_full_controllers');
-            array_push($controllers, $data['page']['controller']);
-            config(['base.hero_full_controllers' => $controllers]);
-        }
-
         // Parsed promotions
         $promos = $this->parsePromos->parse($promos, $group_reference, $group_config);
 

--- a/tests/Unit/Repositories/MenuRepositoryTest.php
+++ b/tests/Unit/Repositories/MenuRepositoryTest.php
@@ -643,4 +643,66 @@ class MenuRepositoryTest extends TestCase
 
         $this->assertFalse($menus['show_site_menu']);
     }
+
+    /**
+     * @covers App\Repositories\MenuRepository::getMenus
+     * @test
+     */
+    public function page_should_show_full_width_hero_with_no_site_menu()
+    {
+        // Create a fake data request
+        $page = app('Factories\Page')->create(
+            1,
+            true,
+            [
+                'page' => [
+                    'controller' => 'ExampleController',
+                ],
+                'menu' => [
+                    'id' => 1,
+                ],
+            ]
+        );
+
+        // Fake a site menu with no menu
+        $menu[$page['menu']['id']] = [];
+
+        // Parse the site menu
+        app('App\Repositories\MenuRepository')->getMenus($page, $menu);
+
+        $this->assertTrue(in_array('ExampleController', config('base.hero_full_controllers')));
+    }
+
+    /**
+     * @covers App\Repositories\MenuRepository::getMenus
+     * @test
+     */
+    public function page_should_show_full_width_hero_with_site_menu_but_menu_is_hidden()
+    {
+        // Create a fake data request
+        $page = app('Factories\Page')->create(
+            1,
+            true,
+            [
+                'page' => [
+                    'controller' => 'HomepageController',
+                ],
+                'menu' => [
+                    'id' => 1,
+                ],
+            ]
+        );
+
+        // Set default config values
+        config(['base.hero_full_controllers' => []]);
+        config(['base.homepage_menu_enabled' => false]);
+
+        // Fake a site menu
+        $menu[$page['menu']['id']] = app('Factories\Menu')->create(5);
+
+        // Parse the site menu
+        app('App\Repositories\MenuRepository')->getMenus($page, $menu);
+
+        $this->assertTrue(in_array('HomepageController', config('base.hero_full_controllers')));
+    }
 }

--- a/tests/Unit/Repositories/PromoRepositoryTest.php
+++ b/tests/Unit/Repositories/PromoRepositoryTest.php
@@ -165,62 +165,6 @@ class PromoRepositoryTest extends TestCase
     }
 
     /**
-     * @covers App\Repositories\PromoRepository::getRequestData
-     * @test
-     */
-    public function page_should_show_full_width_hero_with_no_site_menu()
-    {
-        // Create a fake data request
-        $data = app('Factories\Page')->create(1, true, [
-            'page' => [
-                'controller' => 'ExampleController',
-            ],
-        ]);
-
-        // Fake a site menu with no menu
-        $data['site_menu']['menu'] = [];
-
-        // Mock the connector and set the return
-        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
-        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn([]);
-
-        // Get the promos
-        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getRequestData($data);
-
-        $this->assertTrue(in_array('ExampleController', config('base.hero_full_controllers')));
-    }
-
-    /**
-     * @covers App\Repositories\PromoRepository::getRequestData
-     * @test
-     */
-    public function page_should_show_full_width_hero_with_site_menu_but_menu_is_hidden()
-    {
-        // Create a fake data request
-        $data = app('Factories\Page')->create(1, true, [
-            'page' => [
-                'controller' => 'ExampleController',
-            ],
-        ]);
-
-        // Force this to false
-        //config(['base.homepage_menu_enabled' => false]);
-
-        // Fake a site menu
-        $data['site_menu']['menu'] = app('Factories\Menu')->create();
-        $data['show_site_menu'] = false;
-
-        // Mock the connector and set the return
-        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
-        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn([]);
-
-        // Get the promos
-        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getRequestData($data);
-
-        $this->assertTrue(in_array('ExampleController', config('base.hero_full_controllers')));
-    }
-
-    /**
      * @covers App\Repositories\PromoRepository::getHomepagePromos
      * @test
      */


### PR DESCRIPTION
### Problem 

This code was in the promo getRequestData method which is overloaded in the styleguide. So it wasn't properly making the homepage go full width for the hero image.

### Solution

Move this code into the MenuRepository since that code isn't overloaded in the styleguide. It's also closer to the data that its relevant to.