### PR TITLE
Fix styleguide hero examples

### DIFF
--- a/styleguide/Http/Controllers/HeroFullController.php
+++ b/styleguide/Http/Controllers/HeroFullController.php
@@ -17,7 +17,10 @@ class HeroFullController extends Controller
     {
         $request->data['show_site_menu'] = false;
 
-        config(['base.hero_contained' => false]);
+        config([
+            'base.hero_contained' => false,
+            'base.hero_full_controllers' => ['HeroFullController'],
+        ]);
 
         return view('styleguide-childpage', merge($request->data));
     }

--- a/styleguide/Http/Controllers/HeroFullMenuController.php
+++ b/styleguide/Http/Controllers/HeroFullMenuController.php
@@ -15,7 +15,10 @@ class HeroFullMenuController extends Controller
      */
     public function index(Request $request)
     {
-        config(['base.hero_contained' => false]);
+        config([
+            'base.hero_contained' => false,
+            'base.hero_full_controllers' => ['HeroFullMenuController'],
+        ]);
 
         return view('styleguide-childpage', merge($request->data));
     }

--- a/styleguide/Http/Controllers/HeroFullTextLinkController.php
+++ b/styleguide/Http/Controllers/HeroFullTextLinkController.php
@@ -15,14 +15,15 @@ class HeroFullTextLinkController extends Controller
      */
     public function index(Request $request)
     {
+        $request->data['show_site_menu'] = false;
+
         // Set this controller in the allowed controllers list
         config([
             'base.hero_text_enabled' => true,
             'base.hero_text_controllers' => ['HeroFullTextLinkController'],
             'base.hero_contained' => false,
+            'base.hero_full_controllers' => ['HeroFullTextLinkController'],
         ]);
-
-        $request->data['show_site_menu'] = false;
 
         return view('styleguide-childpage', merge($request->data));
     }

--- a/styleguide/Pages/HeroFullMenu.php
+++ b/styleguide/Pages/HeroFullMenu.php
@@ -4,9 +4,6 @@ namespace Styleguide\Pages;
 
 class HeroFullMenu extends Page
 {
-    /** {@inheritdoc} **/
-    public $path = '/styleguide/hero/full/menu';
-
     /**
      * {@inheritdoc}
      */

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -284,7 +284,7 @@
                     "105100106": {
                         "menu_item_id": "105100106",
                         "is_active": "1",
-                        "page_id": null,
+                        "page_id": 3,
                         "target": "",
                         "display_name": "Full width (menu)",
                         "class_name": "",


### PR DESCRIPTION
Add the new config overrides to the styleguide pages. This was overlooked before when manual testing to the homepage was done.