### PR TITLE
Page ID added to getHomepagePromos

### DIFF
--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -36,14 +36,14 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
     /**
      * {@inheritdoc}
      */
-    public function getHomepagePromos()
+    public function getHomepagePromos(int $page_id = 0)
     {
         $group_reference = [
             123 => 'example',
         ];
 
         $group_config = [
-            'example' => 'first',
+            'example' => 'page_id:'.$page_id.'|randomize|first',
         ];
 
         $params = [

--- a/contracts/Repositories/PromoRepositoryContract.php
+++ b/contracts/Repositories/PromoRepositoryContract.php
@@ -9,5 +9,5 @@ interface PromoRepositoryContract
      *
      * @return array
      */
-    public function getHomepagePromos();
+    public function getHomepagePromos(int $page_id);
 }

--- a/styleguide/Repositories/PromoRepository.php
+++ b/styleguide/Repositories/PromoRepository.php
@@ -9,6 +9,17 @@ class PromoRepository extends Repository
     /**
      * {@inheritdoc}
      */
+    public function getHomepagePromos(int $page_id = null)
+    {
+        return [
+            // Example Group
+            //'key' => app('Factories\YourFactory')->create(5),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRequestData(array $data)
     {
         // Define the pages that have under menu promos: page_id => quanity
@@ -78,17 +89,6 @@ class PromoRepository extends Repository
 
             // Accordion child page
             'accordion_page' => $accordion,
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHomepagePromos()
-    {
-        return [
-            // Example Group
-            //'key' => app('Factories\YourFactory')->create(5),
         ];
     }
 }

--- a/tests/Unit/Repositories/PromoRepositoryTest.php
+++ b/tests/Unit/Repositories/PromoRepositoryTest.php
@@ -180,7 +180,7 @@ class PromoRepositoryTest extends TestCase
         $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn($return);
 
         // Get the promos
-        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getHomepagePromos();
+        $promos = app('App\Repositories\PromoRepository', ['wsuApi' => $wsuApi])->getHomepagePromos($this->faker->randomDigit);
 
         $this->assertTrue(is_array($promos));
     }


### PR DESCRIPTION
* Add page_id as a parameter to getHomepagePromos since its needed often.
* Move the getHomepagePromos method to the top of the styleguide repository file to mirror how the actual repository is.