### PR TITLE
Remove the homepage from displaying hero text by default

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -80,7 +80,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hero Rotating Enabled
+    | Hero Rotating
     |--------------------------------------------------------------------------
     |
     | This enables the hero image to have arrows to rotate through them, if
@@ -94,16 +94,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hero Text Enabled
+    | Hero Text
     |--------------------------------------------------------------------------
     |
     | This enables the hero image to have excerpt text and a view more link.
     | You can also specify which controllers you want this to work on by
-    | adding to the array. By default only the homepage controller
-    | is allowed to have this functionality.
+    | adding to the array.
     |
     */
-    'hero_text_controllers' => ['HomepageController'],
+    'hero_text_controllers' => [],
     'hero_text_more' => 'View more',
 
     /*


### PR DESCRIPTION
I noticed text is showing up by default on http://base.wayne.edu/. Also, if you patch a site to the newest version it'll show the promo title by default now which is more than likely not desired.

<img width="1071" alt="screen shot 2018-09-25 at 8 08 36 am" src="https://user-images.githubusercontent.com/634788/46013751-251e3280-c09b-11e8-91ec-39d22f6f545a.png">

