### PR TITLE
Remove cache dir for WSU API Connector

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -134,7 +134,6 @@ echo '----';
 [ -d {{ $shared_dir }}/storage/debugbar ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/debugbar;
 [ -d {{ $shared_dir }}/storage/logs ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/logs;
 [ -d {{ $shared_dir }}/storage/app ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/app;
-[ -d {{ $shared_dir }}/storage/app/api ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/app/api;
 [ -d {{ $shared_dir }}/storage/app/public ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/app/public;
 [ -d {{ $shared_dir }}/storage/framework ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/framework;
 [ -d {{ $shared_dir }}/storage/framework/cache ] || mkdir -p -m 0770 {{ $shared_dir }}/storage/framework/cache;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -65,9 +65,6 @@ class AppServiceProvider extends ServiceProvider
                 config('base.wsu_api_key')
             );
 
-            // Set the Cache Directory for the WSU API
-            $api->cache_dir = storage_path().'/app/api/';
-
             return $api;
         });
 


### PR DESCRIPTION
Remove setting the cache for the WSU API Connector since we utilize the `Cache::remember` and laravel cache configuration