### PR TITLE
Simplifying image styles 

### DIFF
--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -41,26 +41,17 @@
         }
     }
 
-    img {
-        display: block;
-        width: 100%;
-        margin: 10px auto;
-        padding: 0;
+    // Images remain at their specified width
+    // Text appears above and below for small
+    @media (max-width: config('screens.mt')) {
+        img {
+            display: block;
+            margin: 0 auto;
 
-        &[class^="float-"] {
-            float: none !important;
-        }
-
-        &.icon {
-            display: inline-block;
-            width: auto;
-        }
-
-        @screen mt {
-            padding: 10px;
-            width: auto;
-            margin: 0;
-            float: inherit;
+            &[style*="float:right"],
+            &[style*="float:left"] {
+                float: none !important;
+            }
         }
     }
 

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -206,22 +206,6 @@
 
         <hr>
 
-        <h2>Image icon</h2>
-
-        <p>Images default to span 100% of the container on small view. When using the <code>.icon</code> class you can override this behavior so it defaults to its real height/width.</p>
-
-        <p>@image('/styleguide/image/50x50?text=Icon', 'icon image', 'icon')</p>
-
-        <a href="#image-icon" class="button" onclick="document.querySelector('pre.image-icon').classList.toggle('hidden');">See image icon code</a>
-
-        <pre class="image-icon hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
-        {!! htmlspecialchars('
-<img src="/styleguide/50x50?text=Icon" class="icon" alt="">
-        ') !!}
-        </pre>
-
-        <hr>
-
         <h2>Media</h2>
         <p>Any valid YouTube URL starting with <code>youtu.be</code> or <code>youtube.com/watch</code> will open a lightbox with the video.</p>
         <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="View YouTube Video"></a></p>


### PR DESCRIPTION
* Removing floats on small
* Keeping native sizes intact
* Removed "image icon" specific class, no longer needed 

![content-area-desktop](https://user-images.githubusercontent.com/2616607/46302494-37a2db00-c577-11e8-8901-8b45e5beba5e.jpg)
![content-area-mobile](https://user-images.githubusercontent.com/2616607/46302495-37a2db00-c577-11e8-8aa5-67b94da6504e.jpg)
