### PR TITLE
Skip to content fix

### DIFF
--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -43,7 +43,7 @@
             </nav>
         </div>
 
-    <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" id="content">
+    <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" id="content" tabindex="-1">
             @if(!empty($hero) && !in_array($page['controller'], config('base.hero_full_controllers')))
                 @include('components.hero', ['images' => $hero])
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -26,7 +26,7 @@
     @include('components.banner', ['banner' => $banner])
 @endif
 
-<main id="panel" tabindex="-1">
+<main id="panel">
     @yield('content-area')
 </main>
 


### PR DESCRIPTION
Per: https://github.com/waynestate/base-site/pull/222#discussion_r223024594

Add tabindex to the content landmark to make it focusable. Remove it from the previous landmark that we were trying to skip to.