### PR TITLE
hotfix/5.9.2

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -47,7 +47,7 @@ if [[ $stylelint == *"'stylelint' failed"* ]]; then
     printf ">> run: make stylelint\n\n"
 fi
 
-if [[ $phpunit == *"FAILURES!"* || $phpunit == *"ERRORS!"* ]]; then
+if [[ $phpunit == *"FAILURES!"* || $phpunit == *"ERRORS!"* || $phpunit == *"Fatal error"* ]]; then
     errors=true;
     printf "phpunit tests failed. Please fix them before committing.\n"
     printf ">> run: make runtests\n"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
If the app completely fails before running tests we should stop the pre-commit hook by checking for 'Fatal error'