### PR TITLE
Add an All categories option to the news listing page

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -31,7 +31,7 @@ class NewsController extends Controller
     public function index(Request $request)
     {
         // Get the news categories
-        $categories = $this->news->getCategories($request->data['site']['id'], $request->data['site']['subsite-folder']);
+        $categories = $this->news->getCategories($request->data['site']['id'], $request->data['site']['subsite-folder'], true);
 
         // Set the selected category
         $categories = $this->news->setSelectedCategory($categories, $request->slug);

--- a/app/Repositories/NewsRepository.php
+++ b/app/Repositories/NewsRepository.php
@@ -125,7 +125,7 @@ class NewsRepository implements NewsRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getCategories($site_id, $subsite=null)
+    public function getCategories($site_id, $subsite=null, $prepend=false)
     {
         $params = [
             'method' => 'cms.news.categories',
@@ -143,6 +143,15 @@ class NewsRepository implements NewsRepositoryContract
             return $item;
         })->toArray();
 
+        if ($prepend === true) {
+            $categories['news_categories'] = collect($categories['news_categories'])->prepend([
+                    'category_id' => null,
+                    'slug' => null,
+                    'category' => 'All categories',
+                    'link' => '/news/',
+            ])->toArray();
+        }
+
         return $categories;
     }
 
@@ -154,7 +163,7 @@ class NewsRepository implements NewsRepositoryContract
         $categories['selected_news_category']['category_id'] = null;
 
         foreach ($categories['news_categories'] as $key => $category) {
-            if ($category['slug'] == $slug) {
+            if (!empty($slug) && $category['slug'] == $slug) {
                 $categories['selected_news_category'] = $category;
             }
         }

--- a/resources/views/components/news-categories.blade.php
+++ b/resources/views/components/news-categories.blade.php
@@ -6,6 +6,6 @@
 
 <ul>
     @foreach($categories as $category)
-        <li{!! $selected_category['category_id'] == $category['category_id'] ? ' class="selected"': '' !!}><a href="{{ $category['link'] }}">{{ $category['category'] }}</a></li>
+        <li{!! !empty($selected_category['category_id']) && $selected_category['category_id'] == $category['category_id'] ? ' class="selected"': '' !!}><a href="{{ $category['link'] }}">{{ $category['category'] }}</a></li>
     @endforeach
 </ul>

--- a/styleguide/Repositories/NewsRepository.php
+++ b/styleguide/Repositories/NewsRepository.php
@@ -42,16 +42,25 @@ class NewsRepository extends Repository
     /**
      * {@inheritdoc}
      */
-    public function getCategories($site_id, $subsite=null)
+    public function getCategories($site_id, $subsite=null, $prepend=false)
     {
         $categories['news_categories'] = app('Factories\NewsCategory')->create(5);
 
         $route = app('request')->route();
 
-        // Change the first random category to be the one they selected
+        // Change the last random category to be the one they selected
         if (!empty($route->parameters['slug'])) {
-            $categories['news_categories'][1]['slug'] = $route->parameters['slug'];
-            $categories['news_categories'][1]['category'] = str_replace('-', ' ', $route->parameters['slug']);
+            $categories['news_categories'][5]['slug'] = $route->parameters['slug'];
+            $categories['news_categories'][5]['category'] = str_replace('-', ' ', $route->parameters['slug']);
+        }
+
+        if ($prepend === true) {
+            $categories['news_categories'] = collect($categories['news_categories'])->prepend([
+                    'category_id' => null,
+                    'slug' => null,
+                    'category' => 'All categories',
+                    'link' => '/styleguide/news/',
+            ])->toArray();
         }
 
         return $categories;

--- a/tests/Unit/Repositories/NewsRepositoryTest.php
+++ b/tests/Unit/Repositories/NewsRepositoryTest.php
@@ -68,11 +68,18 @@ class NewsRepositoryTest extends TestCase
         $wsuApi = Mockery::mock('Waynestate\Api\Connector');
         $wsuApi->shouldReceive('sendRequest')->with('cms.news.categories', Mockery::type('array'))->once()->andReturn($return);
 
-        // Get the news categories
-        $categories = app('App\Repositories\NewsRepository', ['wsuApi' => $wsuApi])->getCategories($this->faker->randomDigit, 'styleguide/');
+        // Get the news categories without prepending all categories
+        $categories = app('App\Repositories\NewsRepository', ['wsuApi' => $wsuApi])->getCategories($this->faker->randomDigit, 'styleguide/', false);
 
         // Make sure they are the same as the ones we created
         $this->assertEquals($return, $categories);
+
+        // Get the news categories with prepending all categories
+        $wsuApi->shouldReceive('sendRequest')->with('cms.news.categories', Mockery::type('array'))->once()->andReturn($return);
+        $categories = app('App\Repositories\NewsRepository', ['wsuApi' => $wsuApi])->getCategories($this->faker->randomDigit, 'styleguide/', true);
+
+        // Make sure it was prepended
+        $this->assertEquals($categories['news_categories'][0]['category'], 'All categories');
     }
 
     /**


### PR DESCRIPTION
This allows prepending All Categories to the category listing. This way you can get back to the full news listing page easily if there isn't a menu.

<img width="316" alt="screen shot 2018-10-11 at 10 24 14 am" src="https://user-images.githubusercontent.com/634788/46810988-d4b3ff80-cd3f-11e8-86b1-dcf5fcc19dbf.png">
