### PR TITLE
Make news configurable since the values are all over the codebase

### DIFF
--- a/app/Repositories/NewsRepository.php
+++ b/app/Repositories/NewsRepository.php
@@ -147,8 +147,8 @@ class NewsRepository implements NewsRepositoryContract
             $categories['news_categories'] = collect($categories['news_categories'])->prepend([
                     'category_id' => null,
                     'slug' => null,
-                    'category' => 'All categories',
-                    'link' => '/news/',
+                    'category' => config('base.news_all_text'),
+                    'link' => '/'.config('base.news_listing_route').'/',
             ])->toArray();
         }
 

--- a/config/base.php
+++ b/config/base.php
@@ -168,6 +168,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | News
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure the news area. No ending slash for route paths.
+    | If you change a route path from the default value you will need to
+    | also change the CMS pages and styleguide menu path to coincide
+    | with your new path.
+    |
+    */
+    'news_listing_route' => 'news',
+    'news_view_route' => 'news',
+    'news_category_route' => 'category',
+    'news_all_text' => 'All categories',
+
+    /*
+    |--------------------------------------------------------------------------
     | Global Promotion Groups
     |--------------------------------------------------------------------------
     |

--- a/factories/NewsCategory.php
+++ b/factories/NewsCategory.php
@@ -33,7 +33,7 @@ class NewsCategory implements FactoryContract
                 'is_active' => 1,
                 'category' => $category,
                 'slug' => 'example',
-                'link' => '/styleguide/news/category/example',
+                'link' => '/styleguide/'.config('base.news_listing_route').'/'.config('base.news_category_route').'/example',
             ];
 
             $data[$i] = array_replace_recursive($data[$i], $options);

--- a/factories/NewsItem.php
+++ b/factories/NewsItem.php
@@ -32,7 +32,7 @@ class NewsItem implements FactoryContract
                 'excerpt' => '',
                 'archive' => 1,
                 'link' => '',
-                'full_link' => '/styleguide/news/item-1',
+                'full_link' => '/styleguide/'.config('base.news_listing_route').'/item-1',
                 'body' => $this->faker->paragraph,
                 'filename' => '',
                 'categories' => null,

--- a/resources/views/components/mini-news.blade.php
+++ b/resources/views/components/mini-news.blade.php
@@ -2,7 +2,7 @@
     $news => array // [['news_id', 'slug', 'title']]
     $site => array // ['subsite-folder']
     $heading => string // 'News'
-    $url => string '/news.php'
+    $url => string '/news/'
     $link_text => string // 'More news'
 --}}
 <h2>{{ $heading ?? 'News' }}</h2>
@@ -17,4 +17,4 @@
     @endforeach
 </ul>
 
-<a href="/{{ $url ?? 'news/' }}" class="block my-4 underline hover:no-underline">{{ $link_text ?? 'More news' }}</a>
+<a href="/{{ $url ?? config('base.news_listing_route').'/' }}" class="block my-4 underline hover:no-underline">{{ $link_text ?? 'More news' }}</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,11 +16,11 @@ Route::get('{any?}profile/{accessid}', 'ProfileController@show')
     ->where(['any' => '.*', 'accessid' => '.+']);
 
 // News by category
-Route::get('{any?}news/category/{slug}', 'NewsController@index')
+Route::get('{any?}'.config('base.news_listing_route').'/'.config('base.news_category_route').'/{slug}', 'NewsController@index')
     ->where(['any' => '.*', 'slug' => '.+']);
 
 // News view
-Route::get('{any?}news/{slug}-{id}', 'NewsController@show')
+Route::get('{any?}'.config('base.news_view_route').'/{slug}-{id}', 'NewsController@show')
     ->where(['any' => '.*', 'slug' => '.+', 'id' => '\d+']);
 
 // The wild card route is a catch all route that tries to resolve the requests path to a json file

--- a/styleguide/Pages/NewsCategory.php
+++ b/styleguide/Pages/NewsCategory.php
@@ -5,13 +5,15 @@ namespace Styleguide\Pages;
 class NewsCategory extends Page
 {
     /** {@inheritdoc} **/
-    public $path = '/styleguide/news/category/est-quisquam';
+    public $path;
 
     /**
      * {@inheritdoc}
      */
     public function getPageData()
     {
+        $this->path = '/styleguide/'.config('base.news_listing_route').'/'.config('base.news_category_route').'/est-quisquam';
+
         return app('Factories\Page')->create(1, true, [
             'page' => [
                 'controller' => 'NewsController',

--- a/styleguide/Repositories/NewsRepository.php
+++ b/styleguide/Repositories/NewsRepository.php
@@ -58,8 +58,8 @@ class NewsRepository extends Repository
             $categories['news_categories'] = collect($categories['news_categories'])->prepend([
                     'category_id' => null,
                     'slug' => null,
-                    'category' => 'All categories',
-                    'link' => '/styleguide/news/',
+                    'category' => config('base.news_all_text'),
+                    'link' => '/styleguide/'.config('base.news_listing_route').'/',
             ])->toArray();
         }
 

--- a/tests/Unit/Http/Controllers/NewsControllerTest.php
+++ b/tests/Unit/Http/Controllers/NewsControllerTest.php
@@ -113,7 +113,7 @@ class NewsControllerTest extends TestCase
         $newsController = app('App\Http\Controllers\NewsController', ['news' => $newsRepository]);
 
         $request = new Request();
-        $request->path = '/news';
+        $request->path = '/'.config('base.news_listing_route').'/'.config('base.news_category_route');
         $request->slug = 'invalid-category';
 
         // Call the news listing

--- a/tests/Unit/Repositories/NewsRepositoryTest.php
+++ b/tests/Unit/Repositories/NewsRepositoryTest.php
@@ -79,7 +79,7 @@ class NewsRepositoryTest extends TestCase
         $categories = app('App\Repositories\NewsRepository', ['wsuApi' => $wsuApi])->getCategories($this->faker->randomDigit, 'styleguide/', true);
 
         // Make sure it was prepended
-        $this->assertEquals($categories['news_categories'][0]['category'], 'All categories');
+        $this->assertEquals($categories['news_categories'][0]['category'], config('base.news_all_text'));
     }
 
     /**


### PR DESCRIPTION
In doing this PR: https://github.com/waynestate/base-site/pull/232

I noticed that the values are all over the codebase and hard to keep track of. This brings them to the config so they could be changed easily in one spot. One of our sites had an actual need to call this area "impact" instead of news and the categories were called "priorities". So this would work well for those situations.

Let me know your thoughts on this :)