### PR TITLE
All content included in landmarks

### DIFF
--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -11,7 +11,7 @@
 
     @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
         <div class="mt:w-1/4 mt:px-4 mt:block {{ $show_site_menu === false ? ' mt:hidden' : '' }}">
-            <nav id="menu" class="main-menu" role="navigation" aria-label="Page menu" tabindex="-1">
+            <nav id="menu" class="main-menu" aria-label="Page menu" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
                     <div class="offcanvas-main-menu mt:hidden">
                         <ul>
@@ -43,7 +43,7 @@
             </nav>
         </div>
 
-    <div class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" id="content" tabindex="-1">
+        <main class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" id="content" tabindex="-1">
             @if(!empty($hero) && !in_array($page['controller'], config('base.hero_full_controllers')))
                 @include('components.hero', ['images' => $hero])
 
@@ -55,7 +55,7 @@
             @endif
 
             @yield('content')
-        </div>
+        </main>
     @if(!in_array($page['controller'], config('base.full_width_controllers')))</div>@endif
 
     @yield('bottom')

--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -5,12 +5,12 @@
 <div class="mb-4 mt:mx-0{{ !empty($images) && count($images) > 1 ? ' rotate' : '' }}{{ !empty($show_site_menu) && $show_site_menu === true ? ' contained -mx-4' : ' full' }} bg-grey-lighter md:bg-transparent">
     @if(in_array($page['controller'], config('base.hero_text_controllers')))
         @foreach($images as $image)
-            <div class="w-full relative">
+            <div class="w-full relative" role="complementary" aria-labelledby="hero-image-{{ $loop->iteration }}">
                 <div class="pt-hero w-full bg-cover bg-green-darkest md:bg-gradient-dark md:overflow-hidden bg-top relative{{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $image['relative_url'] }}')" @else data-src="{{ $image['relative_url'] }}"@endif></div>
                 <div class="md:absolute md:pin-b md:pin-x md:text-white md:text-shadow-dark @if(count($images) > 1) p-6 @else py-4 @if(in_array($page['controller'], config('base.hero_full_controllers')))lg:pb-10 @endif @endif">
                     <div class="row">
                         <div class="mx-4">
-                            <h1 class="leading-tight text-2xl @if(in_array($page['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</h1>
+                            <h1 id="hero-image-{{ $loop->iteration }}" class="leading-tight text-2xl @if(in_array($page['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</h1>
                             @if(!empty($image['excerpt']))<p class="inline pr-2 md:text-lg">{{ $image['excerpt'] }}</p>@endif
                             @if(!empty($image['link']))<a href="{{ $image['link'] }}" class="underline font-bold hover:no-underline md:text-white md:text-lg">{{ config('base.hero_text_more') }}</a>@endif
                         </div>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -16,29 +16,33 @@
 
 @include('components.skip')
 
-@include('components.header')
+<header>
+    @include('components.header')
 
-@if(!empty($site))
-    @include('components.menu-top', ['site' => $site])
-@endif
+    @if(!empty($site))
+        @include('components.menu-top', ['site' => $site])
+    @endif
 
-@if(!empty($banner))
-    @include('components.banner', ['banner' => $banner])
-@endif
+    @if(!empty($banner))
+        @include('components.banner', ['banner' => $banner])
+    @endif
+</header>
 
-<main id="panel">
+<div id="panel">
     @yield('content-area')
-</main>
+</div>
 
-@if(!empty($social))
-    @include('components.footer-social', ['social' => $social])
-@endif
+<footer>
+    @if(!empty($social))
+        @include('components.footer-social', ['social' => $social])
+    @endif
 
-@if(!empty($contact))
-    @include('components.footer-contact', ['contact' => $contact])
-@endif
+    @if(!empty($contact))
+        @include('components.footer-contact', ['contact' => $contact])
+    @endif
 
-@include('components.footer')
+    @include('components.footer')
+</footer>
 
 <script src="{{ mix('_resources/js/main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Reason for change

Each main element off of body needs some type of role or landmark element.

*Source:*  
https://my2.siteimprove.com/Accessibility/590065/Pages/Issue?CheckId=127&CriterionChapter=1.3.1

*Description:*  
HTML5 or WAI-ARIA landmarks are used on the page, but not all content is included.

When using HTML5 or WAI-ARIA landmarks it is best practice to include all content on the page in landmarks. In this way users of assistive technologies can use the landmarks for navigating the page without losing track of content.

*How to fix it:*  
Make sure that all content on the page is included in HTML5 or WAI-ARIA landmarks.

## Checklist

- [x] Provide TP3 link: https://waynedotedu.tpondemand.com/entity/78914-accessibility-add-proper-landmarks
- [-] Provide CMS site link:
- [x] Read through the code diff to ensure accuracy
- [x] SiteImprove accessibility check
- [x] Verified each page looks good on each viewport size
- [-] Added an example to the styleguide if applicable
- [-] Added tests to prove my code works
- [-] Refactored foreach loops into more maintainable collection chaining
- [-] Screen shot or video of before/after

## Screenshots / Videos

(Left is after, right is before)

![screen shot 2018-10-14 at 5 07 41 pm](https://user-images.githubusercontent.com/37359/46947181-08e13600-d048-11e8-9856-21e4f76e4481.png)
