### PR TITLE
Alt attribute consistent on all images

### DIFF
--- a/resources/views/components/button-icon-dark.blade.php
+++ b/resources/views/components/button-icon-dark.blade.php
@@ -6,7 +6,7 @@
     <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-gradient-green hover:bg-gradient-green">
         <div class="min-w-full flex p-3 xl:p-4 @if(!empty($button['excerpt'])) items-top @else items-center @endif">
             <div class="w-1/6">
-                <img src="{{ $button['secondary_relative_url']}}" class="block" aria-hidden="true" alt="" role="presentation">
+                <img src="{{ $button['secondary_relative_url']}}" class="block" alt="">
             </div>
             <div class="w-5/6 pl-2 xl:pl-4">
                 <div class="block text-md xl:text-xl font-bold text-white leading-tight">{{ $button['title'] }}</div>

--- a/resources/views/components/button-icon-light.blade.php
+++ b/resources/views/components/button-icon-light.blade.php
@@ -6,7 +6,7 @@
     <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-grey-lighter hover:bg-grey-lightest overflow-hidden">
         <div class="min-w-full flex p-3 xl:p-4 @if(!empty($button['excerpt'])) items-top @else items-center @endif">
             <div class="w-1/6">
-                <img src="{{ $button['secondary_relative_url']}}" class="block" aria-hidden="true" alt="" role="presentation">
+                <img src="{{ $button['secondary_relative_url']}}" class="block" alt="">
             </div>
             <div class="w-5/6 pl-2 xl:pl-4">
                 <div class="block text-md xl:text-xl font-bold text-black leading-tight">{{ $button['title'] }}</div>

--- a/resources/views/components/image-lazy.blade.php
+++ b/resources/views/components/image-lazy.blade.php
@@ -1,1 +1,1 @@
-<img class="lazy {{ empty($class) ?  'min-w-full' : $class }}"  src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="{{ $src }}" alt="{{ $alt }}" />
+<img class="lazy {{ empty($class) ?  'min-w-full' : $class }}"  src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="{{ $src }}" alt="{{ $alt }}">

--- a/styleguide/Views/styleguide-fullwidth.blade.php
+++ b/styleguide/Views/styleguide-fullwidth.blade.php
@@ -1,7 +1,7 @@
 @extends('components.content-area')
 
 @section('content')
-    <img class="w-full block" src="/styleguide/image/1600x580?text=Full%20width%20image" />
+    <img class="w-full block" src="/styleguide/image/1600x580?text=Full%20width%20image" alt="">
 
     <div class="bg-grey-lightest mb-4">
         <div class="row py-4">

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -208,7 +208,7 @@
 
         <h2>Media</h2>
         <p>Any valid YouTube URL starting with <code>youtu.be</code> or <code>youtube.com/watch</code> will open a lightbox with the video.</p>
-        <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="View YouTube Video"></a></p>
+        <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="School of Medicine Commencement YouTube video"></a></p>
 
         <a href="#media-example" class="button" onclick="document.querySelector('pre.media-example').classList.toggle('hidden');">See media code</a>
 
@@ -216,7 +216,7 @@
         {!! htmlspecialchars('
 <p>
     <a href="//www.youtube.com/watch?v=guRgefesPXE">
-        <img src="//i.wayne.edu/youtube/guRgefesPXE">
+        <img src="//i.wayne.edu/youtube/guRgefesPXE" alt="Description of YouTube video">
     </a>
 </p>
         ') !!}


### PR DESCRIPTION
## Reason for change

*Source*  
https://my2.siteimprove.com/Inspector/590065/Accessibility/Page?pageId=14353917598&impmd=AIDMHMRAPIHJRRCNDCIC#/Criterion/1.1.1/Check/1

*Description*  
The image does not have an 'alt' attribute (alt="").

*How to fix it:*  
It’s important all images have the attribute for alternative text regardless of whether an alternative text is added.

A screen reader knows how to handle both an empty alt attribute and one with a text. If there is no attribute some screen readers will compensate and read the path to the image instead, which will often give no value to the end user.

If you are using a CMS (Content Management System), the default setting should be that an empty alt attribute is added to all images.

## Checklist

- [-] Provide TP3 link:
- [-] Provide CMS site link:
- [x] Read through the code diff to ensure accuracy
- [x] SiteImprove accessibility check
- [-] Verified each page looks good on each viewport size
- [-] Added an example to the styleguide if applicable
- [-] Added tests to prove my code works
- [-] Refactored foreach loops into more maintainable collection chaining
- [x] Screen shot or video of before/after

## Screenshots / Videos

(Left is new, right is old)

![screen shot 2018-10-14 at 5 55 58 pm](https://user-images.githubusercontent.com/37359/46947690-a4bf7180-d049-11e8-968e-f1e4e2aa4dfa.png)
