### PR TITLE
hotfix/5.10.1

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -168,13 +168,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | News
+    | News Routes
     |--------------------------------------------------------------------------
     |
     | Here you can configure the news area. No ending slash for route paths.
-    | If you change a route path from the default value you will need to
-    | also change the CMS pages and styleguide menu path to coincide
-    | with your new path.
+    | If you change any of the route paths from the default value you will
+    | need to also change the CMS page, styleguide page, and styleguide
+    | menu path to coincide with your new path.
     |
     */
     'news_listing_route' => 'news',

--- a/factories/NewsItem.php
+++ b/factories/NewsItem.php
@@ -32,7 +32,7 @@ class NewsItem implements FactoryContract
                 'excerpt' => '',
                 'archive' => 1,
                 'link' => '',
-                'full_link' => '/styleguide/'.config('base.news_listing_route').'/item-1',
+                'full_link' => '/styleguide/'.config('base.news_view_route').'/item-1',
                 'body' => $this->faker->paragraph,
                 'filename' => '',
                 'categories' => null,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.10.0",
+  "version": "5.10.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/homepage.blade.php
+++ b/resources/views/homepage.blade.php
@@ -11,7 +11,7 @@
         <div class="row -mx-4 flex flex-wrap">
             @if(!empty($news))
                 <div class="w-full md:w-1/2 px-4">
-                    @include('components/mini-news', ['news' => $news, 'url' => ($site['subsite-folder'] !== null ? $site['subsite-folder'] : '').'news/'])
+                    @include('components/mini-news', ['news' => $news, 'url' => ($site['subsite-folder'] !== null ? $site['subsite-folder'] : '').config('base.news_listing_route').'/'])
                 </div>
             @endif
 

--- a/resources/views/news-individual.blade.php
+++ b/resources/views/news-individual.blade.php
@@ -14,7 +14,7 @@
         </div>
 
         <p rel="back" class="pt-4">
-            <a rel="back" href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}news">Back to listing</a>
+            <a rel="back" href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}">Back to listing</a>
         </p>
     </div>
 @endsection

--- a/tests/Unit/Http/Middleware/DataTest.php
+++ b/tests/Unit/Http/Middleware/DataTest.php
@@ -97,12 +97,12 @@ class DataTest extends TestCase
      */
     public function when_the_request_has_a_matched_route_the_path_should_have_no_route_parameters()
     {
-        $actual_path = 'news/slug-123';
+        $actual_path = config('base.news_view_route').'/slug-123';
 
         $request = new Request([], [], [], [], [], ['REQUEST_URI' => $actual_path]);
 
         $request->setRouteResolver(function () use ($request) {
-            return (new Route('GET', 'news/{slug}-{id}', []))->bind($request);
+            return (new Route('GET', config('base.news_view_route').'/{slug}-{id}', []))->bind($request);
         });
 
         $path = app('App\Http\Middleware\Data')->getPathFromRequest($request);

--- a/tests/Unit/Repositories/NewsRepositoryTest.php
+++ b/tests/Unit/Repositories/NewsRepositoryTest.php
@@ -125,6 +125,27 @@ class NewsRepositoryTest extends TestCase
     }
 
     /**
+     * @covers App\Repositories\NewsRepository::getNewsByDisplayOrder
+     * @test
+     */
+    public function getting_news_by_display_order_should_return_array_of_news()
+    {
+        // Fake return
+        $return = [
+            'news' => app('Factories\NewsItem')->create(5),
+        ];
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
+        $wsuApi->shouldReceive('sendRequest')->with('cms.news.listing', Mockery::type('array'))->once()->andReturn($return);
+
+        // Get the news
+        $news = app('App\Repositories\NewsRepository', ['wsuApi' => $wsuApi])->getNewsByDisplayOrder($this->faker->randomDigit);
+
+        $this->assertEquals($return, $news);
+    }
+
+    /**
      * @covers App\Repositories\NewsRepository::getNewsByPage
      * @test
      */
@@ -184,5 +205,27 @@ class NewsRepositoryTest extends TestCase
         $imageUrl = app('App\Repositories\NewsRepository')->getImageUrl($news);
 
         $this->assertEquals($image, $imageUrl);
+    }
+
+    /**
+     * @covers App\Repositories\NewsRepository::setNewsLink
+     * @test
+     */
+    public function setting_news_link_should_change_route_path()
+    {
+        $current_config = config('base.news_view_route');
+        $item = app('Factories\NewsItem')->create(1, true);
+
+        // Default news route path
+        $changed = app('App\Repositories\NewsRepository')->setNewsLink($item);
+        $this->assertEquals($item, $changed);
+
+        // Randomly changing the news view route path
+        $news_view_route = $this->faker->word;
+        config(['base.news_view_route' => $news_view_route]);
+        $changed = app('App\Repositories\NewsRepository')->setNewsLink($item);
+        $this->assertContains($news_view_route, $changed['full_link']);
+
+        config(['base.news_view_route' => $current_config]);
     }
 }


### PR DESCRIPTION
## Reason for change

Fixing somethings found in PR #236 while using it outside of the styleguide.

* Fixed the API return of full_link to be what the new route path is for the individual news.
* Fixed individual news item full_link path to use the view_route, it was using the incorrect news_listing_route path.
* Homepage more button and back to  listing now uses the config value as well.
* Updated the DataTest to curl against the correct individual news route.
* Add tests for setting the news route path based on the config value.