### PR TITLE
Feature/table img refactor

### DIFF
--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -13,7 +13,7 @@
 
     <a href="#accordions" class="button" onclick="document.querySelector('pre.accordions').classList.toggle('hidden');">See accordion code</a>
 
-    <pre class="accordions hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+    <pre class="accordions hidden bg-grey-lightest overflow-scroll">
     {!! htmlspecialchars('
 <ul class="accordion">
     <li>

--- a/styleguide/Views/styleguide-figure.blade.php
+++ b/styleguide/Views/styleguide-figure.blade.php
@@ -15,7 +15,7 @@
 
         <a href="#fig-none" class="button" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See code</a>
 
-        <pre class="fig-none hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="fig-none hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <figure>
     <img src="/styleguide/image/400x300" alt="">
@@ -38,7 +38,7 @@
 
                 <a href="#fig-left" class="button" onclick="document.querySelector('pre.fig-left').classList.toggle('hidden');">See code</a>
 
-                <pre class="fig-left hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                <pre class="fig-left hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="float-left">
     <img src="/styleguide/image/400x300" alt="">
@@ -63,7 +63,7 @@
 
                 <a href="#fig-right" class="button" onclick="document.querySelector('pre.fig-right').classList.toggle('hidden');">See code</a>
 
-                <pre class="fig-right hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                <pre class="fig-right hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="float-right">
     <img src="/styleguide/image/400x300" alt="">
@@ -89,7 +89,7 @@
 
                 <a href="#fig-center" class="button" onclick="document.querySelector('pre.fig-center').classList.toggle('hidden');">See code</a>
 
-                <pre class="fig-center hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                <pre class="fig-center hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="text-center">
     <img src="/styleguide/image/800x450" alt="">

--- a/styleguide/Views/styleguide-figure.blade.php
+++ b/styleguide/Views/styleguide-figure.blade.php
@@ -9,7 +9,7 @@
         <p>Available classes for <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">&lt;figure&gt;</code> are <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.float-left</code>, <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.float-right</code>, and <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.text-center</code>.</p>
 
         <figure>
-            @image('/styleguide/image/400x300')
+            @image('/styleguide/image/400x300', '', 'p-2')
             <figcaption>{{ $faker->sentence }}</figcaption>
         </figure>
 
@@ -31,7 +31,7 @@
                 <h2>Float left</h2>
 
                 <figure class="float-left">
-                    @image('/styleguide/image/400x300')
+                    @image('/styleguide/image/400x300', '', 'p-2')
                     <figcaption>{{ $faker->sentence }}</figcaption>
                 </figure>
                 <p>{{ $faker->paragraph(38) }}</p>
@@ -56,7 +56,7 @@
                 <h2>Float right</h2>
 
                 <figure class="float-right">
-                    @image('/styleguide/image/400x300')
+                    @image('/styleguide/image/400x300', '', 'p-2')
                     <figcaption>{{ $faker->sentence }}</figcaption>
                 </figure>
                 <p>{{ $faker->paragraph(28) }}</p>
@@ -82,7 +82,7 @@
 
                 <p>{{ $faker->paragraph(12) }}</p>
                 <figure class="text-center">
-                    @image('/styleguide/image/800x450')
+                    @image('/styleguide/image/800x450', '', 'p-2')
                     <figcaption>{{ $faker->sentence }}</figcaption>
                 </figure>
                 <p>{{ $faker->paragraph(12) }}</p>
@@ -99,6 +99,4 @@
                 </pre>
             </div>
         </div>
-
-
 @endsection

--- a/styleguide/Views/styleguide-figure.blade.php
+++ b/styleguide/Views/styleguide-figure.blade.php
@@ -8,19 +8,17 @@
 
         <p>Available classes for <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">&lt;figure&gt;</code> are <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.float-left</code>, <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.float-right</code>, and <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">.text-center</code>.</p>
 
-        <div class="table">
-            <figure>
-                @image('/styleguide/image/400x300', 'Placeholder', 'p-10px')
-                <figcaption>{{ $faker->sentence }}</figcaption>
-            </figure>
-        </div>
+        <figure>
+            @image('/styleguide/image/400x300')
+            <figcaption>{{ $faker->sentence }}</figcaption>
+        </figure>
 
         <a href="#fig-none" class="button" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See code</a>
 
         <pre class="fig-none hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
         {!! htmlspecialchars('
 <figure>
-    <img src="/styleguide/image/400x300" alt="Placeholder">
+    <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
         ') !!}
@@ -32,20 +30,18 @@
             <div class="w-full px-4">
                 <h2>Float left</h2>
 
-                <div class="table">
-                    <figure class="float-left">
-                        <img src="/styleguide/image/400x300" style="padding: 10px" alt="">
-                        <figcaption>{{ $faker->sentence }}</figcaption>
-                    </figure>
-                    <p>{{ $faker->paragraph(38) }}</p>
-                </div>
+                <figure class="float-left">
+                    @image('/styleguide/image/400x300')
+                    <figcaption>{{ $faker->sentence }}</figcaption>
+                </figure>
+                <p>{{ $faker->paragraph(38) }}</p>
 
                 <a href="#fig-left" class="button" onclick="document.querySelector('pre.fig-left').classList.toggle('hidden');">See code</a>
 
                 <pre class="fig-left hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
                 {!! htmlspecialchars('
 <figure class="float-left">
-    <img src="/styleguide/image/400x300" alt="Placeholder">
+    <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
                 ') !!}
@@ -59,20 +55,18 @@
             <div class="w-full px-4">
                 <h2>Float right</h2>
 
-                <div class="table">
-                    <figure class="float-right">
-                        @image('/styleguide/image/400x300', 'Placeholder', 'p-10px')
-                        <figcaption>{{ $faker->sentence }}</figcaption>
-                    </figure>
-                    <p>{{ $faker->paragraph(28) }}</p>
-                </div>
+                <figure class="float-right">
+                    @image('/styleguide/image/400x300')
+                    <figcaption>{{ $faker->sentence }}</figcaption>
+                </figure>
+                <p>{{ $faker->paragraph(28) }}</p>
 
                 <a href="#fig-right" class="button" onclick="document.querySelector('pre.fig-right').classList.toggle('hidden');">See code</a>
 
                 <pre class="fig-right hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
                 {!! htmlspecialchars('
 <figure class="float-right">
-    <img src="/styleguide/image/400x300" alt="Placeholder">
+    <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
                 ') !!}
@@ -86,21 +80,19 @@
             <div class="w-full px-4">
                 <h2>Text center</h2>
 
-                <div class="table">
-                    <p>{{ $faker->paragraph(12) }}</p>
-                    <figure class="text-center">
-                        @image('/styleguide/image/800x450', 'Placeholder', 'p-10px')
-                        <figcaption>{{ $faker->sentence }}</figcaption>
-                    </figure>
-                    <p>{{ $faker->paragraph(12) }}</p>
-                </div>
+                <p>{{ $faker->paragraph(12) }}</p>
+                <figure class="text-center">
+                    @image('/styleguide/image/800x450')
+                    <figcaption>{{ $faker->sentence }}</figcaption>
+                </figure>
+                <p>{{ $faker->paragraph(12) }}</p>
 
                 <a href="#fig-center" class="button" onclick="document.querySelector('pre.fig-center').classList.toggle('hidden');">See code</a>
 
                 <pre class="fig-center hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
                 {!! htmlspecialchars('
 <figure class="text-center">
-    <img src="/styleguide/image/800x450" alt="Placeholder">
+    <img src="/styleguide/image/800x450" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
                 ') !!}

--- a/styleguide/Views/styleguide-tablestack.blade.php
+++ b/styleguide/Views/styleguide-tablestack.blade.php
@@ -28,7 +28,7 @@
 
         <a href="#table-stack" class="button" onclick="document.querySelector('pre.table-stack').classList.toggle('hidden');">See table code</a>
 
-        <pre class="table-stack hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="table-stack hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <table class="table-stack" aria-label="Example table">
     <thead>

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -84,7 +84,7 @@
             <tbody>
                 @for ($i = 0; $i < 4; $i++)
                 <tr>
-                    <td><img src="/styleguide/image/150x50?text=150x50" alt="" style="margin: 10px;">
+                    <td>@image('/styleguide/image/150x50?text=150x50', '', 'p-2')
                     <td>{{ $faker->firstName }}</td>
                     <td>{{ $faker->lastName }}</td>
                     <td><a href="mailto:{{ $faker->email }}">{{ $faker->email }}</a></td>
@@ -254,7 +254,7 @@
 
                 <div class="table">
                     <figure>
-                        @image('/styleguide/image/400x300')
+                        @image('/styleguide/image/400x300', '', 'p-2')
                         <figcaption>{{ $faker->sentence }}</figcaption>
                     </figure>
                 </div>

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -254,7 +254,7 @@
 
                 <div class="table">
                     <figure>
-                        @image('/styleguide/image/400x300', 'Placeholder', 'p-10px')
+                        @image('/styleguide/image/400x300')
                         <figcaption>{{ $faker->sentence }}</figcaption>
                     </figure>
                 </div>
@@ -265,7 +265,7 @@
                 <pre class="fig-none hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
                 {!! htmlspecialchars('
 <figure>
-    <img src="/styleguide/image/400x300" alt="Placeholder">
+    <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
 </figure>
                 ') !!}

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -19,7 +19,7 @@
         </div>
 
         <a href="#two-columns-code" class="button" onclick="document.querySelector('pre.two-columns-code').classList.toggle('hidden');">See row/columns code</a>
-        <pre class="two-columns-code hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="two-columns-code hidden bg-grey-lightest overflow-scroll">
             {!! htmlspecialchars('
 <div class="row -mx-4 md:flex">
     <div class="md:w-1/2 px-4">
@@ -51,7 +51,7 @@
         </div>
 
         <a href="#three-columns-code" class="button" onclick="document.querySelector('pre.three-columns-code').classList.toggle('hidden');">See row/columns code</a>
-        <pre class="three-columns-code hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="three-columns-code hidden bg-grey-lightest overflow-scroll">
             {!! htmlspecialchars('
 <div class="row -mx-4 lg:flex">
     <div class="lg:w-1/3 px-4">
@@ -95,7 +95,7 @@
 
         <a href="#table-stack" class="button" onclick="document.querySelector('pre.table-stack').classList.toggle('hidden');">See table code</a>
 
-        <pre class="table-stack hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="table-stack hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <table class="table-stack" aria-label="Example table">
     <thead>
@@ -170,7 +170,7 @@
 
         <a href="#blockquote" class="button" onclick="document.querySelector('pre.blockquote').classList.toggle('hidden');">See blockquote code</a>
 
-        <pre class="blockquote hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="blockquote hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <blockquote>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -190,7 +190,7 @@
         <br />
         <a href="#button-examples" class="button" onclick="document.querySelector('pre.button-examples').classList.toggle('hidden');">See button code</a>
 
-        <pre class="button-examples hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="button-examples hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <a href="#" class="button">Standard button</a>
 <a href="#" class="button bg-gradient-green text-white">Dark button</a>
@@ -217,7 +217,7 @@
 
         <a href="#media-example" class="button" onclick="document.querySelector('pre.media-example').classList.toggle('hidden');">See media code</a>
 
-        <pre class="media-example hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="media-example hidden">
         {!! htmlspecialchars('
 <p>
     <a href="//www.youtube.com/watch?v=guRgefesPXE">
@@ -238,7 +238,7 @@
 
         <a href="#responsive-embed-example" class="button" onclick="document.querySelector('pre.responsive-embed-example').classList.toggle('hidden');">See responsive embed code</a>
 
-        <pre class="responsive-embed-example hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+        <pre class="responsive-embed-example hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <div class="responsive-embed">
     <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" title="Responsive embed example" frameborder="0" allowfullscreen></iframe>
@@ -262,7 +262,7 @@
                 <a href="#fig-none" class="button mr-4" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See code</a>
                 <a href="/styleguide/figure" class="button">More options</a>
 
-                <pre class="fig-none hidden" style="background: #EAEAEA; margin-bottom: 10px; overflow: scroll;">
+                <pre class="fig-none hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure>
     <img src="/styleguide/image/400x300" alt="">

--- a/tailwind.js
+++ b/tailwind.js
@@ -604,7 +604,6 @@ module.exports = {
 
     padding: {
         'px': '1px',
-        '10px': '10px',
         '0': '0',
         '1': '0.25rem',
         '2': '0.5rem',


### PR DESCRIPTION
Hey @breakdancingcat I have some suggestions based on PR: https://github.com/waynestate/base-site/pull/240 that I thought would be easier to do a pull request to yours :)

* Removed the table class that surrounds the example figures. It's already applied with `@apply .table` in the SCSS file.
* Consistently used `@image()` across the code
* Added blank `alt=""` text since the caption (in most cases) describes the image)
* Removed the p-10px class since the example for someone to copy/paste doesn't have that class so seemed odd to me. Our CMS does inject inline style of 10px though so I see where you were going with it! I was thinking we shouldn't encourage that use of that padding throughout the rest of the codebase though. I ended up putting `p-2` instead since it's really close to 10px. Alternatively we could look at removing the automatic `min-w-full` being applied with @image when not using a class, then we wouldn't even have to put `p-2` because it looked good to me without it but i'm good with leaving it close to what the CMS inline style would be.
* I had a realization that we can now use tailwind classes for the `<pre>` tag to style it. It was inline because I didn't want to include that style into the main.css file that was generated. But now that we have tailwind these classes are easily available to us!

You can review the changes by switching to my branch and doing a `make build`. Let's work together today on merging this all in. Great job on it ! 👍 