### PR TITLE
Figure styleguide page updated with link text and destination

### DIFF
--- a/styleguide/Views/styleguide-figure.blade.php
+++ b/styleguide/Views/styleguide-figure.blade.php
@@ -13,9 +13,9 @@
             <figcaption>{{ $faker->sentence }}</figcaption>
         </figure>
 
-        <a href="#fig-none" class="button" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See code</a>
+        <a href="#fig-none" class="button" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See figure code</a>
 
-        <pre class="fig-none hidden bg-grey-lightest overflow-scroll">
+        <pre id="fig-none" class="fig-none hidden bg-grey-lightest overflow-scroll">
         {!! htmlspecialchars('
 <figure>
     <img src="/styleguide/image/400x300" alt="">
@@ -36,9 +36,9 @@
                 </figure>
                 <p>{{ $faker->paragraph(38) }}</p>
 
-                <a href="#fig-left" class="button" onclick="document.querySelector('pre.fig-left').classList.toggle('hidden');">See code</a>
+                <a href="#fig-left" class="button" onclick="document.querySelector('pre.fig-left').classList.toggle('hidden');">See float left code</a>
 
-                <pre class="fig-left hidden bg-grey-lightest overflow-scroll">
+                <pre id="fig-left" class="fig-left hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="float-left">
     <img src="/styleguide/image/400x300" alt="">
@@ -61,9 +61,9 @@
                 </figure>
                 <p>{{ $faker->paragraph(28) }}</p>
 
-                <a href="#fig-right" class="button" onclick="document.querySelector('pre.fig-right').classList.toggle('hidden');">See code</a>
+                <a href="#fig-right" class="button" onclick="document.querySelector('pre.fig-right').classList.toggle('hidden');">See float right code</a>
 
-                <pre class="fig-right hidden bg-grey-lightest overflow-scroll">
+                <pre id="fig-right" class="fig-right hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="float-right">
     <img src="/styleguide/image/400x300" alt="">
@@ -87,9 +87,9 @@
                 </figure>
                 <p>{{ $faker->paragraph(12) }}</p>
 
-                <a href="#fig-center" class="button" onclick="document.querySelector('pre.fig-center').classList.toggle('hidden');">See code</a>
+                <a href="#fig-center" class="button" onclick="document.querySelector('pre.fig-center').classList.toggle('hidden');">See center image code</a>
 
-                <pre class="fig-center hidden bg-grey-lightest overflow-scroll">
+                <pre id="fig-center" class="fig-center hidden bg-grey-lightest overflow-scroll">
                 {!! htmlspecialchars('
 <figure class="text-center">
     <img src="/styleguide/image/800x450" alt="">


### PR DESCRIPTION
## Reason for change

This page was missed in the last round of accessibility updates since it wasn't on `master` when the tests were run.

## Screenshots

| Before | After |
|--------|--------|
| <img width="328" alt="screen shot 2018-10-24 at 10 54 09 am" src="https://user-images.githubusercontent.com/37359/47440216-b4426700-d77b-11e8-936d-77fc29e3038f.png"> | <img width="318" alt="screen shot 2018-10-24 at 10 54 44 am" src="https://user-images.githubusercontent.com/37359/47440229-bad0de80-d77b-11e8-82a6-6790e291e2ba.png"> |
