### PR TITLE
News listing page update, bolder text, excerpt doesn't look out of pl…

### DIFF
--- a/resources/views/news-listing.blade.php
+++ b/resources/views/news-listing.blade.php
@@ -3,44 +3,40 @@
 @section('content')
     @include('components.page-title', ['title' => $page['title']])
 
-    <div class="news-listing">
-        <dl>
-            @forelse($news as $news_item)
-                <dt class="mb-1">
-                    <a href="{{ $news_item['full_link'] }}">
-                        {{ $news_item['title'] }}
-                    </a>
-                </dt>
+    <ul class="list-reset">
+        @forelse($news as $news_item)
+            <li class="mb-3 pb-4 border-b border-grey-lighter">
+                <a href="{{ $news_item['full_link'] }}" class="font-bold text-lg block">
+                    {{ $news_item['title'] }}
+                </a>
+                @if(!empty($news_item['excerpt']))<div class="text-sm mt-1 mb-2 leading-tight">{{ $news_item['excerpt'] }}</div>@endif
+                <time class="block text-sm text-grey-darker mt-1 leading-tight" datetime="{{ $news_item['posted'] }}">{{ apdatetime(date('F j, Y', strtotime($news_item['posted']))) }}</time>
+            </li>
 
-                <dd class="mb-2 pb-2 border-b border-grey-lighter">
-                    <time class="block text-sm text-grey-darker" datetime="{{ $news_item['posted'] }}">{{ apdatetime(date('F j, Y', strtotime($news_item['posted']))) }}</time>
-                    {{ $news_item['excerpt'] }}
-                </dd>
-            @empty
-                <p>Currently there are no news items {{ !empty($selected_news_category['category']) ? ' for the category ' . strtolower($selected_news_category['category']) : '' }}.</p>
-            @endforelse
-        </dl>
+        @empty
+            <p>Currently there are no news items {{ !empty($selected_news_category['category']) ? ' for the category ' . strtolower($selected_news_category['category']) : '' }}.</p>
+        @endforelse
+    </ul>
 
-        @if(!empty($paging))
-            <div class="row flex -mx-4">
-                <div class="w-1/2 px-4">
-                    @if(count($news) == $paging['perPage'])
-                        <p>
-                            <a href="{{ app('request')->url() }}?page={{ $paging['page_number_previous'] }}">&larr; Previous</a>
-                        </p>
-                    @endif
-                </div>
-
-                <div class="w-1/2 px-4 text-right">
-                    @if($paging['page_number_next'] >= 0)
-                        <p>
-                            <a href="{{ app('request')->url() }}?page={{ $paging['page_number_next'] }}">Next &rarr;</a>
-                        </p>
-                    @endif
-                </div>
+    @if(!empty($paging))
+        <div class="row flex -mx-4">
+            <div class="w-1/2 px-4">
+                @if(count($news) == $paging['perPage'])
+                    <p>
+                        <a href="{{ app('request')->url() }}?page={{ $paging['page_number_previous'] }}">&larr; Previous</a>
+                    </p>
+                @endif
             </div>
-        @endif
-    </div>
+
+            <div class="w-1/2 px-4 text-right">
+                @if($paging['page_number_next'] >= 0)
+                    <p>
+                        <a href="{{ app('request')->url() }}?page={{ $paging['page_number_next'] }}">Next &rarr;</a>
+                    </p>
+                @endif
+            </div>
+        </div>
+    @endif
 @endsection
 
 @section('below_menu')


### PR DESCRIPTION
## News listing upgrade
* Changed from DL to UL 
* Bold title
* Excerpt moved above date
* Margin adjustment 
### No excerpt (normal)
![screencapture-base-wayne-local-styleguide-news-2018-11-16-15_09_57](https://user-images.githubusercontent.com/2616607/48644814-c9449b80-e9b1-11e8-8609-248bf951afd4.jpg)
### With excerpt
![screencapture-base-wayne-local-styleguide-news-2018-11-16-15_12_17](https://user-images.githubusercontent.com/2616607/48644926-16c10880-e9b2-11e8-893d-f63cbc7debcd.jpg)
