### PR TITLE
HTML validated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.12.0",
+  "version": "5.12.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -43,7 +43,7 @@
         @endif
 
         <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
-            <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-controls="menu" area-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
+            <button class="menu-toggle menu-icon text-white text-3xl mt:hidden" data-toggle="menu" aria-controls="menu" aria-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
         </div>
     </div>
 </div>

--- a/resources/views/news-individual.blade.php
+++ b/resources/views/news-individual.blade.php
@@ -13,8 +13,8 @@
             {!! $news['body'] !!}
         </div>
 
-        <p rel="back" class="pt-4">
-            <a rel="back" href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}">Back to listing</a>
+        <p class="pt-4">
+            <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}">Back to listing</a>
         </p>
     </div>
 @endsection


### PR DESCRIPTION
## Reason for change

Discovered invalid HTML in the templates. 

* One typo in `aria`
* `rel` not a valid attribute on `p` and `back` not a valid value for `rel`.

## Screenshots

| Before | After |
|--------|--------|
| ![screen shot 2018-11-18 at 7 28 57 am](https://user-images.githubusercontent.com/37359/48672428-cb1e7400-eb03-11e8-9ba7-fea49451bacc.png) | ![screen shot 2018-11-18 at 7 29 03 am](https://user-images.githubusercontent.com/37359/48672429-d07bbe80-eb03-11e8-8bce-bc08c22fe918.png) |
