### PR TITLE
Youtube embeds related videos now limited to our channel

### DIFF
--- a/resources/js/modules/media.js
+++ b/resources/js/modules/media.js
@@ -1,7 +1,7 @@
-import Mediabox from 'mediabox';
+import Mediabox from "mediabox";
 
 (function(Mediabox) {
     "use strict";
 
-    Mediabox('a[href*="youtu.be"], a[href*="youtube.com/watch"]');
+    Mediabox('a[href*="youtu.be"], a[href*="youtube.com/watch"]', { rel: 0 });
 })(Mediabox);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5252,9 +5252,9 @@ media-typer@0.3.0:
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 mediabox@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/mediabox/-/mediabox-1.1.2.tgz#6214fd5e76ee816790b9b42d25055c2274cb59b9"
-  integrity sha1-YhT9XnbugWeQubQtJQVcInTLWbk=
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/mediabox/-/mediabox-1.1.3.tgz#48f7e4a2052439a60a443bc0d2e5cb8d2828defb"
+  integrity sha512-lD31Sw02JPe7a3vpUHYZkx0TCIMywMfsb8r32Eije2h6sS+EwgUb4Roi3wgF+kRs2d1kVPCgEdnyRvQmAUh2AA==
 
 mem@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Reason for change

With [recent changes to the YouTube related videos display](https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018) after a video is complete the related videos should be from our channel only.

| Before | After |
|--------|--------|
| ![screen shot 2018-11-30 at 8 27 21 am](https://user-images.githubusercontent.com/37359/49292135-6efc0e00-f47a-11e8-9dbb-7ed62a5835e2.png) | ![screen shot 2018-11-30 at 8 26 56 am](https://user-images.githubusercontent.com/37359/49292138-71f6fe80-f47a-11e8-8cce-149537a90575.png) |