### PR TITLE
Footer contact content more in line with multi-column implementation

### DIFF
--- a/factories/FooterContact.php
+++ b/factories/FooterContact.php
@@ -23,17 +23,25 @@ class FooterContact implements FactoryContract
     public function create($limit = 1, $flatten = false, $options = [])
     {
         for ($i = 1; $i <= $limit; $i++) {
+            $title = '';
+
+            if ($i == 2) {
+                $title = '<h2><a href="'.$this->faker->url.'">'.$this->faker->words(3, true).'</a></h2>';
+            } elseif ($i == 3) {
+                $title = '<h2>'.$this->faker->words(3, true).'</h2>';
+            }
+
             $data[$i] = [
                 'link' => '/',
                 'title' => $this->faker->sentence,
-                'description' => '
-                    <p>
+                'description' =>
+                    $title.
+                    '<p>
                         ' .$this->faker->name.'<br />
                         ' .$this->faker->streetAddress.'<br />
                         ' .$this->faker->city.', '.$this->faker->state.' '.$this->faker->postcode.'<br />
-                        <a href="' .$this->faker->url. '">Map</a>
-                    </p>
-                ',
+                        <a href="'.$this->faker->url.'">'.$this->faker->word.'</a>
+                    </p>',
             ];
 
             $data[$i] = array_replace_recursive($data[$i], $options);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.13.1",
+  "version": "5.13.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
## Reason for change

Updated FooterContact factory to better mirror how it is being used. This also ensures style changes account for each variation.

### Primarily changes

- Added a header to a multi-column footer
- Added a header+link to a multi-column footer
- Left the description only header in a multi-column footer
- Link in the description with variable text (to meet [WCAG 2.4.4 - Link text used for multiple different destinations](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html))
  - "The same link text is used for links going to different destinations. Users might not know the difference if they are not somehow explained."

## Checklist

- [x] Read through the code diff to ensure accuracy
- [x] SiteImprove accessibility check
- [x] Verified each page looks good on each viewport size
- [x] Screen shot or video of before/after

## Screenshots

| Columns | View |
|--------|--------|
| One | ![screen shot 2019-01-15 at 11 58 58 am](https://user-images.githubusercontent.com/37359/51196409-10b9ac00-18bd-11e9-9d7f-6bed9f1c9e64.png) | 
| Two | ![screen shot 2019-01-15 at 11 59 08 am](https://user-images.githubusercontent.com/37359/51196424-17482380-18bd-11e9-9084-84975902099e.png) |
| Three | ![screen shot 2019-01-15 at 11 59 23 am](https://user-images.githubusercontent.com/37359/51196431-1dd69b00-18bd-11e9-9240-ab4f1d04eeae.png) |


