### PR TITLE
WCAG 2.4.4 events with the same title now have unique text

### DIFF
--- a/factories/Event.php
+++ b/factories/Event.php
@@ -24,10 +24,11 @@ class Event implements FactoryContract
     {
         for ($i = 1; $i <= $limit; $i++) {
             $date = $this->faker->dateTimeThisMonth('now')->format('Y-m-d');
+            $title = ($i !== 2)?$this->faker->sentence(rand(6, 10)):$title;
 
             $event = [
                 'url' => $this->faker->url,
-                'title' => $this->faker->sentence(rand(6, 10)),
+                'title' => $title,
                 'date' => $date,
                 'start_time' => $this->faker->dateTimeThisMonth('now')->format('H:i:s'),
                 'is_all_day' => $this->faker->boolean,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "5.13.2",
+  "version": "5.13.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -18,7 +18,11 @@
             <ul class="list-reset mx-2 flex-grow">
                 @foreach($dates as $event)
                     <li class="mb-2 pb-2 border-b border-solid">
-                        <a class="block" href="{{ $event['url'] }}">{{ $event['title'] }}</a>
+                        <a class="block" href="{{ $event['url'] }}">{{ $event['title'] }}
+                            <span class="visually-hidden"> on {{ apdatetime(date('M d, Y' , strtotime($key))) }}
+                                @if(!(bool)$event['is_all_day']) at {{ apdatetime(date('g:i a' , strtotime($event['start_time']))) }}@endif
+                            </span>
+                        </a>
                         <time class="text-sm text-grey-darker" datetime="{{ $event['date'] }}T{{ $event['start_time'] }}{{ date('P') }}">
                             @if(!(bool)$event['is_all_day']){{ apdatetime(date('g:i a' , strtotime($event['start_time']))) }}@else All day @endif
                         </time>


### PR DESCRIPTION
## Reason for change

Events that occur on multiple days resulted in links with the same text but going to different destinations.

## Issue

The information about the event date/time is located outside of the link text.

## Changes

1. Include the date and time in the link text but hide it visually since the information is already visible on the page.
2. Ensure the styleguide has this case in place.

## Screenshots

| Before | After |
|--------|--------|
| ![screen shot 2019-01-19 at 3 35 51 pm](https://user-images.githubusercontent.com/37359/51472592-ef870e80-1d47-11e9-877a-eb10d4d0af10.png) | ![screen shot 2019-01-19 at 3 36 19 pm](https://user-images.githubusercontent.com/37359/51472598-f4e45900-1d47-11e9-8ab5-67abf9e86547.png) |

