### PR TITLE
hotfix/6.0.1

### DIFF
--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -31,6 +31,10 @@ class ArticleRepository implements ArticleRepositoryContract
      */
     public function listing($application_ids, $limit=5, $page=1, $topics=[])
     {
+        if (empty($application_ids)) {
+            return ['articles' => []];
+        }
+
         $params = [
             'perPage' =>  $limit,
             'page' => $page,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ArticleRepositoryTest.php
+++ b/tests/Unit/Repositories/ArticleRepositoryTest.php
@@ -41,7 +41,7 @@ class ArticleRepositoryTest extends TestCase
         $newsApi->shouldReceive('request')->andReturn($return);
 
         // Get the articles
-        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing($this->faker->randomDigit, $this->faker->randomDigit, $this->faker->randomDigit, [$this->faker->word]);
+        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing(1, 5, $this->faker->randomDigit, [$this->faker->word]);
 
         $this->assertEquals($return['data'], $articles['articles']['data']);
     }
@@ -62,7 +62,7 @@ class ArticleRepositoryTest extends TestCase
 
         $page = 1;
 
-        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing($this->faker->randomDigit, $this->faker->randomDigit, $page);
+        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing(1, 5, $page);
 
         $articles['articles']['meta'] = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->setPaging($articles['articles']['meta'], $page);
 
@@ -91,7 +91,7 @@ class ArticleRepositoryTest extends TestCase
 
         $page = 3;
 
-        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing($this->faker->randomDigit, $this->faker->randomDigit, $page);
+        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing(1, 5, $page);
 
         $articles['articles']['meta'] = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->setPaging($articles['articles']['meta'], $page);
 
@@ -119,7 +119,7 @@ class ArticleRepositoryTest extends TestCase
 
         $page = null;
 
-        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing($this->faker->randomDigit, $this->faker->randomDigit, $page);
+        $articles = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->listing(1, 5, $page);
 
         $articles['articles']['meta'] = app('App\Repositories\ArticleRepository', ['newsApi' => $newsApi])->setPaging($articles['articles']['meta'], $page);
 
@@ -129,6 +129,17 @@ class ArticleRepositoryTest extends TestCase
         $prev = parse_url($articles['articles']['meta']['prev_page_url']);
         parse_str($prev['query'], $prev);
         $this->assertEquals(2, $prev['page']);
+    }
+
+    /**
+     * @covers App\Repositories\ArticleRepository::listing
+     * @test
+     */
+    public function getting_articles_with_no_applications()
+    {
+        $articles = app('App\Repositories\ArticleRepository')->listing([]);
+
+        $this->assertCount(0, $articles['articles']);
     }
 
     /**


### PR DESCRIPTION
Allow no applications to be passed for article listings and return a blank array instead. The case for this is if a site doesn't use news then it won't try to hit the API at all.