### PR TITLE
hotfix/6.1.1

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -33,7 +33,7 @@ class ArticleController extends Controller
      */
     public function index(Request $request)
     {
-        $topics = $this->topic->listing($request->data['site']['news']['application_id']);
+        $topics = $this->topic->listing($request->data['site']['news']['application_id'], 25);
 
         if (!empty($topics['topics']['data'])) {
             $topics['topics']['data'] = $this->topic->setSelected($topics['topics']['data'], $request->slug);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/styleguide/Repositories/ArticleRepository.php
+++ b/styleguide/Repositories/ArticleRepository.php
@@ -9,7 +9,7 @@ class ArticleRepository extends Repository
     /**
      * {@inheritdoc}
      */
-    public function listing($application_ids, $limit=25, $page=1, $topics=[])
+    public function listing($application_ids, $limit=5, $page=1, $topics=[])
     {
         // Stop the paging after page 3 so it doesn't go on forever
         $limit = $page >= 3 ? 5 : $limit;


### PR DESCRIPTION
Change the default to 5 articles and make the article listing page specifically set it to 25 instead. This solves the issue of the styleguide homepage showing 25 items.