### PR TITLE
feature/fix-menu

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -84,11 +84,6 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             config('base.top_menu_id')
         );
 
-        // Override the menu so it doesn't show the same menu twice
-        if (config('base.top_menu_enabled') === true && $site_menu['meta']['has_selected'] === false) {
-            $site_menu['menu'] = [];
-        }
-
         // Build the return
         $menus = [
             'site_menu' => $site_menu,


### PR DESCRIPTION
Fix the case where the top level menu is activated but no selected menu item is found. This makes sure the "Main Menu" toggle doesn't show and it just reveals the actual menu on offcanvas instead. Saves the user a click. I couldn't find why this code was necessary to begin with. All the tests still pass and I manually checked the styleguide pages and they all seem to work as I would expect.

If an issue comes up and this commit is found please let me know so I can understand the case in which this code is necessary so I can come up with a solution for both.