### PR TITLE
Hotfix/6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/styleguide/Pages/Grid.php
+++ b/styleguide/Pages/Grid.php
@@ -13,7 +13,7 @@ class Grid extends Page
             'page' => [
                 'controller' => 'GridController',
                 'title' => 'Grid',
-                'id' => 101106,
+                'id' => 101107,
                 'content' => [
                     'main' => '<p>'.$this->faker->paragraph(8).'</p>',
                 ],

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -88,10 +88,10 @@
                 "relative_url": "/styleguide/fullwidth",
                 "submenu": []
             },
-            "101106": {
-                "menu_item_id": "101106",
+            "101107": {
+                "menu_item_id": "101107",
                 "is_active": "1",
-                "page_id": 101106,
+                "page_id": "101107",
                 "target": "",
                 "display_name": "Grid",
                 "class_name": "",


### PR DESCRIPTION
The menu id/page id for the Grid menu/page in the style guide is a duplicate of the fullwidth, bumping up to 101107 to keep consistent