### PR TITLE
hotfix/6.2.3

### DIFF
--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -48,15 +48,7 @@ class ArticleRepository implements ArticleRepositoryContract
         }
 
         $articles['articles'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
-            $items = $this->newsApi->request($params['method'], $params);
-
-            if (!empty($items['data'])) {
-                $items['data'] = collect($items['data'])->map(function ($item) {
-                    return $this->setArticleLink($item);
-                })->toArray();
-            }
-
-            return $items;
+            return $this->newsApi->request($params['method'], $params);
         });
 
         return $articles;
@@ -97,18 +89,6 @@ class ArticleRepository implements ArticleRepositoryContract
         }
 
         return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setArticleLink($item)
-    {
-        if (empty($item['link'])) {
-            $item['link'] = '/'.config('base.news_view_route').'/'.$item['permalink'].'-'.$item['id'];
-        }
-
-        return $item;
     }
 
     /**

--- a/contracts/Repositories/ArticleRepositoryContract.php
+++ b/contracts/Repositories/ArticleRepositoryContract.php
@@ -33,14 +33,6 @@ interface ArticleRepositoryContract
     public function getImageUrl($article);
 
     /**
-     * Set the article link based on the route
-     *
-     * @param array $item
-     * @return array
-     */
-    public function setArticleLink($item);
-
-    /**
      * Set the paging.
      *
      * @param array $meta

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ArticleRepositoryTest.php
+++ b/tests/Unit/Repositories/ArticleRepositoryTest.php
@@ -188,32 +188,4 @@ class ArticleRepositoryTest extends TestCase
 
         $this->assertEquals($image, $imageUrl);
     }
-
-    /**
-     * @covers App\Repositories\ArticleRepository::setArticleLink
-     * @test
-     */
-    public function setting_article_link_should_set_link()
-    {
-        $current_config = config('base.news_view_route');
-
-        // Default news route path
-        $article = app('Factories\Article')->create(1, true, [
-            'link' => null,
-        ]);
-        $updated = app('App\Repositories\ArticleRepository')->setArticleLink($article['data']);
-        $this->assertContains('/'.$current_config, $updated['link']);
-
-        // Randomly changing the news view route path
-        $news_view_route = $this->faker->word;
-        config(['base.news_view_route' => $news_view_route]);
-        $article = app('Factories\Article')->create(1, true, [
-            'link' => null,
-        ]);
-        $updated = app('App\Repositories\ArticleRepository')->setArticleLink($article['data']);
-        $this->assertContains('/'.$news_view_route, $updated['link']);
-
-        // Change the config back
-        config(['base.news_view_route' => $current_config]);
-    }
 }


### PR DESCRIPTION
The WSU API now controls setting the link for a news article so we can remove the code setting it. It will prefer it in this order:

* External link
* Full URL to article view route, example: https://base.wayne.edu/news/article-title-permalink-id
* Relative URL if the main path and news route can't be found it will assume: /news/article-title-permalink-id