### PR TITLE
Automatically pass in the calendar path if it is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -30,7 +30,7 @@
                 @endforeach
                 @if($dates == end($events))
                     <li>
-                        <a href="//events.wayne.edu/{{ $cal_name ?? 'main' }}/month/">{{ $link_text ?? 'More events' }}</a>
+                        <a href="//events.wayne.edu/{{ $cal_name ?? 'main/' }}month/">{{ $link_text ?? 'More events' }}</a>
                     </li>
                 @endif
             </ul>

--- a/resources/views/homepage.blade.php
+++ b/resources/views/homepage.blade.php
@@ -17,7 +17,7 @@
 
             @if(!empty($events))
                 <div class="w-full md:w-1/2 px-4">
-                    @include('components/events-listing', ['events' => $events])
+                    @include('components/events-listing', ['events' => $events, 'cal_name' => !empty($site['events']['path']) ? $site['events']['path'] : null])
                 </div>
             @endif
         </div>


### PR DESCRIPTION
Our CMS now writes this value to the JSON file for each page. Benefits are:

* We no longer would need to hardcode the path to the calendar.
* There would be no need to use custom page fields anymore if you are using the same controller/view across multiple sites. Each site will write the path based on the site you are on.