### PR TITLE
hotfix/6.2.6

### DIFF
--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -101,6 +101,11 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             $menus['show_site_menu'] = false;
         }
 
+        // Hide the site menu if its equal to the top menu so the menu doesn't show twice
+        if (config('base.top_menu_enabled') === true && $site_menu['menu'] == $top_menu['menu']) {
+            $menus['show_site_menu'] = false;
+        }
+
         // If no site menu is selected then hide the site menu
         if (empty($menus['site_menu_output'])) {
             $menus['show_site_menu'] = false;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.2.5",
+  "version": "6.2.6",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
If the top menu is enabled check if the top menu is equal to the site menu. If so then hide the site menu so it doesn't show it twice.

This should properly fix the issue that I was trying to fix with this PR: https://github.com/waynestate/base-site/pull/290