### PR TITLE
Individual profile route Access ID parameter updated regular expression to be more strict

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@
 
 // Profile view
 Route::get('{any?}profile/{accessid}', 'ProfileController@show')
-    ->where(['any' => '.*', 'accessid' => '.+']);
+    ->where(['any' => '.*', 'accessid' => '[a-zA-Z]{2}\d{4}']);
 
 // News listing by topic
 Route::get('{any?}'.config('base.news_listing_route').'/'.config('base.news_topic_route').'/{slug}', config('base.news_controller').'@index')


### PR DESCRIPTION
Since we now use Access ID as the unique identifier it should be reflected in the route for the individual profile to match against the correct Access ID regular expression

- 2 letters, case insensitive
- 4 digits