### PR TITLE
Accessibility - Tabbing left menu fix

### DIFF
--- a/resources/scss/components/_menu-main.scss
+++ b/resources/scss/components/_menu-main.scss
@@ -1,6 +1,6 @@
 .main-menu {
     ul {
-        @apply .list-reset .m-0 .p-0;
+        @apply .list-reset .m-0 .mb-2 .p-0;
     }
 
     // Padding above and below menu

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -26,7 +26,6 @@
 
                 @if(!empty($site_menu_output))
                     {!! $site_menu_output !!}
-                    <hr class="mb-2">
                 @endif
 
                 @if(!empty($banner))


### PR DESCRIPTION
Screen readers will read the `<hr>` tag at the end of the menu which isn't ideal. Since this is used for spacing only, I moved it to CSS instead which makes it look identical.

This PR introduced it: https://github.com/waynestate/base-site/commit/f49fd3af240ce8bc38dfc18573ba01f17ee0f5e0#diff-5af06945f27d37e67539117206b015a3R27