### PR TITLE
Back button style

### DIFF
--- a/resources/views/article.blade.php
+++ b/resources/views/article.blade.php
@@ -13,7 +13,7 @@
         </div>
 
         <p class="pt-4">
-            <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}">Back to listing</a>
+            <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}" class="button">&larr; Back to listing</a>
         </p>
     </div>
 @endsection

--- a/resources/views/articles.blade.php
+++ b/resources/views/articles.blade.php
@@ -23,7 +23,7 @@
             <div class="w-1/2 px-4">
                 @if(!empty($articles['meta']['prev_page_url']))
                     <p>
-                        <a href="{{ $articles['meta']['prev_page_url'] }}">&larr; Previous</a>
+                        <a href="{{ $articles['meta']['prev_page_url'] }}" class="button">&larr; Previous</a>
                     </p>
                 @endif
             </div>
@@ -31,7 +31,7 @@
             <div class="w-1/2 px-4 text-right">
                 @if(!empty($articles['meta']['next_page_url']) && $articles['meta']['current_page'] !== 1)
                     <p>
-                        <a href="{{ $articles['meta']['next_page_url'] }}">Next &rarr;</a>
+                        <a href="{{ $articles['meta']['next_page_url'] }}" class="button">Next &rarr;</a>
                     </p>
                 @endif
             </div>

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -1,12 +1,6 @@
 @extends('components.content-area')
 
 @section('content')
-    @if($back_url != '')
-        <div class="relative">
-            <a href="{{ $back_url }}" class="text-right absolute pin-r md:py-1 pr-4">&lt; Return to listing</a>
-        </div>
-    @endif
-
     <div class="row flex flex-wrap">
         <div class="w-full lg:w-1/3 px-4 mt-6">
             @if(!empty($profile['data']['Picture']['url']))
@@ -69,6 +63,12 @@
                         @endif
                     @endif
                 @endforeach
+
+                @if($back_url != '')
+                    <p class="pt-4">
+                        <a href="{{ $back_url }}" class="button">&larr; Return to listing</a>
+                    </p>
+                @endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
* Make the back buttons all the same style with the same arrows.
* Move the profile back button down below the profile, so it doesn't overlap ontop of the profile image. This puts it in the same place as the individual news view as well.

Example:

<img width="210" alt="Screen Shot 2019-04-24 at 11 19 17 AM" src="https://user-images.githubusercontent.com/634788/56671582-eaa56400-6682-11e9-83e7-58f292239d78.png">
