### PR TITLE
Accessibility updates to mediabox

### DIFF
--- a/resources/js/modules/media.js
+++ b/resources/js/modules/media.js
@@ -4,4 +4,17 @@ import Mediabox from "mediabox";
     "use strict";
 
     Mediabox('a[href*="youtu.be"], a[href*="youtube.com/watch"]', { rel: 0 });
+
+    document.querySelectorAll('a[href*="youtu.be"], a[href*="youtube.com/watch"]').forEach(function (item) {
+        item.addEventListener('click', function () {
+            // Change focus to media box upon opening it
+            window.focusedElBeforeOpen = document.activeElement;
+            document.querySelector('.mediabox-content').focus();
+
+            // When exiting the media box go back to the previous focus state
+            document.querySelector('.mediabox-close').addEventListener('click', function () {
+                window.focusedElBeforeOpen.focus();
+            });
+        });
+    });
 })(Mediabox);


### PR DESCRIPTION
When you open mediabox it will now focus on the container so tabbing will tab into the content of the modal. When you exit the modal, it will now return focus back to the element you were on.