### PR TITLE
Carousel Accessibility

### DIFF
--- a/resources/js/modules/carousel.js
+++ b/resources/js/modules/carousel.js
@@ -25,5 +25,7 @@ var Flickity = require('flickity');
             setGallerySize: true,
             wrapAround: true,
         });
+
+        document.querySelector('.rotate').removeAttribute('tabindex');
     }
 })(Flickity);


### PR DESCRIPTION
Remove the tabindex that flickity adds so it does not tab to it, rather it will tab to natural tabbable elements inside the hero area.