### PR TITLE
Feature/slideout accessibility

### DIFF
--- a/resources/js/modules/slideout-main-menu.js
+++ b/resources/js/modules/slideout-main-menu.js
@@ -19,21 +19,28 @@
         parentNode.prepend(childNode);
     }
 
+    let toggleMainMenu = function () {
+        document.querySelector('.offcanvas-main-menu ul ul').classList.toggle('hidden');
+
+        if(document.querySelector('.offcanvas-main-menu ul ul').offsetParent === null) {
+            document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-right-open');
+            document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-down-open');
+        } else {
+            document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-down-open');
+            document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-right-open');
+        }
+
+        // Return false so it does not complete the click through
+        return false;
+    }
+
     // Toggle the menu and show the appropriate icons
     if(document.querySelector('a.main-menu-toggle') != null) {
-        document.querySelector('a.main-menu-toggle').addEventListener('click', function (){
-            document.querySelector('.offcanvas-main-menu ul ul').classList.toggle('hidden');
-
-            if(document.querySelector('.offcanvas-main-menu ul ul').offsetParent === null) {
-                document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-right-open');
-                document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-down-open');
-            } else {
-                document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-down-open');
-                document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-right-open');
+        document.querySelector('a.main-menu-toggle').addEventListener('click', toggleMainMenu);
+        document.querySelector('a.main-menu-toggle').addEventListener('keypress', function (e) {
+            if(e.keyCode == 13) {
+               toggleMainMenu(); 
             }
-
-            // Return false so it does not complete the click through
-            return false;
         });
     }
 })();

--- a/resources/js/modules/slideout-main-menu.js
+++ b/resources/js/modules/slideout-main-menu.js
@@ -16,6 +16,7 @@
         childNode.classList.add('float-right');
         childNode.classList.add('text-lg');
         childNode.classList.add('-mt-0.5');
+        childNode.setAttribute('aria-hidden', 'true');
         parentNode.prepend(childNode);
     }
 

--- a/resources/js/modules/slideout-main-menu.js
+++ b/resources/js/modules/slideout-main-menu.js
@@ -22,6 +22,12 @@
     let toggleMainMenu = function () {
         document.querySelector('.offcanvas-main-menu ul ul').classList.toggle('hidden');
 
+        if(document.querySelector('a.main-menu-toggle').getAttribute('aria-expanded') == 'false') {
+            document.querySelector('a.main-menu-toggle').setAttribute('aria-expanded', 'true');
+        } else {
+            document.querySelector('a.main-menu-toggle').setAttribute('aria-expanded', 'false');
+        }
+
         if(document.querySelector('.offcanvas-main-menu ul ul').offsetParent === null) {
             document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-right-open');
             document.querySelector('a.main-menu-toggle .expand-icons').classList.toggle('icon-down-open');

--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -33,24 +33,62 @@ import Slideout from 'slideout/dist/slideout.js';
         window.scrollTo(0,0);
     });
 
-    // Allow clicking the content area to close offcanvas
+    // Get a list of all menu links
+    var all_links = document.querySelectorAll('#menu a');
+
+    // Trap focus within the slideout by tabbing back to the close button
+    let tabToCloseButton = function (e) {
+        if (!e.shiftKey && e.keyCode == 9) {
+            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug) 
+            setTimeout(function () {
+                document.querySelector('button.menu-toggle').focus();
+            }, 0);
+        }
+    }
+
+    // Trap focus within the slideout by tabbing to the last element
+    let tabToLastElement = function (e) {
+        if (e.shiftKey && e.keyCode == 9) {
+            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug) 
+            setTimeout(function () {
+                all_links[all_links.length-1].focus();
+            }, 0);
+        }
+    }
+
     slideout.on('open', function () {
+        // Allow clicking the content area to close offcanvas
         document.querySelector('.content-area').addEventListener('click', function (e) {
             if (slideout.isOpen()) {
                 e.preventDefault();
                 slideout.close();
             }
         });
+
+        if(all_links.length > 0) {
+            // When tabbing off the last link in the menu make it go back to the close button
+            all_links[all_links.length-1].addEventListener('keydown', tabToCloseButton);
+            
+            // When tabbing backwards off the menu toggle goto the last focusable element in the slideout
+            document.querySelector('.menu-toggle').addEventListener('keydown', tabToLastElement);
+        }
     });
 
-    // Remove the event listener for closing slideout whenever the slideout closes
     slideout.on('close', function () {
+        // Remove the event listener for closing slideout whenever the slideout closes
         document.querySelector('.content-area').removeEventListener('click', function (e) {
             if (slideout.isOpen()) {
                 e.preventDefault();
                 slideout.close();
             }
         });
+
+        // Remove listeners for trapping focus within the slideout
+        if(all_links.length > 0) {
+            all_links[all_links.length-1].removeEventListener('keydown', tabToCloseButton);
+        }
+
+        document.querySelector('.menu-toggle').removeEventListener('keydown', tabToLastElement);
     });
 
     // Toggle the appropriate classes for slideout based on the menu icon's visibility state

--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -72,6 +72,9 @@ import Slideout from 'slideout/dist/slideout.js';
             // When tabbing backwards off the menu toggle goto the last focusable element in the slideout
             document.querySelector('.menu-toggle').addEventListener('keydown', tabToLastElement);
         }
+
+        // Set that it was expanded
+        document.querySelector('.menu-toggle').setAttribute('aria-expanded', 'true');
     });
 
     slideout.on('close', function () {
@@ -89,6 +92,9 @@ import Slideout from 'slideout/dist/slideout.js';
         }
 
         document.querySelector('.menu-toggle').removeEventListener('keydown', tabToLastElement);
+
+        // Set that it was closed
+        document.querySelector('.menu-toggle').setAttribute('aria-expanded', 'false');
     });
 
     // Toggle the appropriate classes for slideout based on the menu icon's visibility state

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -16,7 +16,7 @@
                     <div class="offcanvas-main-menu mt:hidden">
                         <ul>
                             <li>
-                                <a class="main-menu-toggle">Main Menu</a>
+                                <a class="main-menu-toggle" tabindex="0">Main Menu</a>
 
                                 {!! $top_menu_output !!}
                             </li>

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -16,7 +16,7 @@
                     <div class="offcanvas-main-menu mt:hidden">
                         <ul>
                             <li>
-                                <a class="main-menu-toggle" tabindex="0">Main Menu</a>
+                                <a class="main-menu-toggle" tabindex="0" aria-expanded="false">Main Menu</a>
 
                                 {!! $top_menu_output !!}
                             </li>


### PR DESCRIPTION
*Trap the focus in the slideout when they open it. Once they tab through everything it should cycle back to the close (X) button again (not go into the content-area). The user needs to close the offcanvas themselve in order to get back to the content-area.
* Make sure it says "expanded" and "closed" when using the button AND when you toggle the "Main Menu"
* Make sure it does not read "Greater than" for the icon toggle on "Main Menu" for screen readers.
* Make sure you can tab onto and open "Main Menu" in the slideout