### PR TITLE
Firefox Focusring Accessibility

### DIFF
--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -60,6 +60,11 @@ h6 {
     @apply .text-sm;
 }
 
+// Firefox uses the outline focus color as the text color. Since our overall background is white we need to change it.
+a.text-white:-moz-focusring {
+    outline-color: #000;
+}
+
 // Global print styles
 @screen print {
     a::after {


### PR DESCRIPTION
Firefox uses the text color as the focus ring. This causes issues of the text color is white and the overall container background is white. This forces the ring to be black in this case (to match the default of most cases of being the best contrast against white).