### PR TITLE
Feature/skip links

### DIFF
--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -39,7 +39,7 @@ import Slideout from 'slideout/dist/slideout.js';
     // Trap focus within the slideout by tabbing back to the close button
     let tabToCloseButton = function (e) {
         if (!e.shiftKey && e.keyCode == 9) {
-            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug) 
+            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug)
             setTimeout(function () {
                 document.querySelector('button.menu-toggle').focus();
             }, 0);
@@ -49,7 +49,7 @@ import Slideout from 'slideout/dist/slideout.js';
     // Trap focus within the slideout by tabbing to the last element
     let tabToLastElement = function (e) {
         if (e.shiftKey && e.keyCode == 9) {
-            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug) 
+            // Wrapping this in a setTimeout prevents it from focusing on the element after this one (unknown bug)
             setTimeout(function () {
                 all_links[all_links.length-1].focus();
             }, 0);
@@ -68,7 +68,7 @@ import Slideout from 'slideout/dist/slideout.js';
         if(all_links.length > 0) {
             // When tabbing off the last link in the menu make it go back to the close button
             all_links[all_links.length-1].addEventListener('keydown', tabToCloseButton);
-            
+
             // When tabbing backwards off the menu toggle goto the last focusable element in the slideout
             document.querySelector('.menu-toggle').addEventListener('keydown', tabToLastElement);
         }
@@ -143,38 +143,41 @@ import Slideout from 'slideout/dist/slideout.js';
 
     // On small screens when the menu toggle is visible allow the skip to site menu to open slideout and main menu toggle
     let toggleSkipEvents = function () {
-        let skipPageMenu = function (e) {
+        let skipMenu = function (e) {
             slideout.open();
             window.scrollTo(0,0);
             e.preventDefault();
             document.querySelector('.menu-toggle').focus();
         }
 
-        let skipSiteMenu = function (e) {
-            slideout.open();
-            window.scrollTo(0,0);
-            e.preventDefault();
-            document.querySelector('.main-menu-toggle').focus();
-        }
-
         if(getComputedStyle(document.querySelector('.menu-toggle')).display != 'none') {
-            if(document.querySelector('.skip-page-menu')) {
-                document.querySelector('.skip-page-menu').addEventListener('click', skipPageMenu);
+            // Hide the site menu
+            if(document.querySelector('.skip-site-menu')) {
+                document.querySelector('.skip-site-menu').classList.add('hidden');
             }
 
-            if(document.querySelector('.skip-site-menu')) {
-                document.querySelector('.skip-site-menu').addEventListener('click', skipSiteMenu);
+            // Hide the page menu
+            if(document.querySelector('.skip-page-menu')) {
+                document.querySelector('.skip-page-menu').classList.add('hidden');
             }
+
+            // Make the skip menu visible
+            document.querySelector('.skip-menu').classList.remove('hidden');
+
+            // Add a listener to skip to the menu and open it
+            document.querySelector('.skip-menu a').addEventListener('click', skipMenu);
         } else {
-            // Remove skip listeners if the regular menu is showing
-            if(document.querySelector('.skip-page-menu')) {
-                document.querySelector('.skip-page-menu').removeEventListener('click', skipPageMenu);
-                console.log('remove page');
+            // Hide the skip menu
+            document.querySelector('.skip-menu').classList.add('hidden');
+
+            // Bring back the site menu
+            if(document.querySelector('.skip-site-menu')) {
+                document.querySelector('.skip-site-menu').classList.remove('hidden');
             }
 
-            if(document.querySelector('.skip-site-menu')) {
-                document.querySelector('.skip-site-menu').removeEventListener('click', skipSiteMenu);
-                console.log('remove site');
+            // Bring back the page menu
+            if(document.querySelector('.skip-page-menu')) {
+                document.querySelector('.skip-page-menu').classList.remove('hidden');
             }
         }
     }
@@ -182,9 +185,9 @@ import Slideout from 'slideout/dist/slideout.js';
     // When resizing check if we need to toggle skip events
     window.addEventListener('resize', toggleSkipEvents);
 
-    // Check if we need to toggle the slideout on intial load
-    toggleSlideout();
-
     // Check if we need to toggle the skip links
     toggleSkipEvents();
+
+    // Check if we need to toggle the slideout on intial load
+    toggleSlideout();
 })(Slideout);

--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -141,6 +141,50 @@ import Slideout from 'slideout/dist/slideout.js';
         document.querySelector('#panel .mt\\:flex').classList.remove('mt:flex');
     }
 
+    // On small screens when the menu toggle is visible allow the skip to site menu to open slideout and main menu toggle
+    let toggleSkipEvents = function () {
+        let skipPageMenu = function (e) {
+            slideout.open();
+            window.scrollTo(0,0);
+            e.preventDefault();
+            document.querySelector('.menu-toggle').focus();
+        }
+
+        let skipSiteMenu = function (e) {
+            slideout.open();
+            window.scrollTo(0,0);
+            e.preventDefault();
+            document.querySelector('.main-menu-toggle').focus();
+        }
+
+        if(getComputedStyle(document.querySelector('.menu-toggle')).display != 'none') {
+            if(document.querySelector('.skip-page-menu')) {
+                document.querySelector('.skip-page-menu').addEventListener('click', skipPageMenu);
+            }
+
+            if(document.querySelector('.skip-site-menu')) {
+                document.querySelector('.skip-site-menu').addEventListener('click', skipSiteMenu);
+            }
+        } else {
+            // Remove skip listeners if the regular menu is showing
+            if(document.querySelector('.skip-page-menu')) {
+                document.querySelector('.skip-page-menu').removeEventListener('click', skipPageMenu);
+                console.log('remove page');
+            }
+
+            if(document.querySelector('.skip-site-menu')) {
+                document.querySelector('.skip-site-menu').removeEventListener('click', skipSiteMenu);
+                console.log('remove site');
+            }
+        }
+    }
+
+    // When resizing check if we need to toggle skip events
+    window.addEventListener('resize', toggleSkipEvents);
+
     // Check if we need to toggle the slideout on intial load
     toggleSlideout();
+
+    // Check if we need to toggle the skip links
+    toggleSkipEvents();
 })(Slideout);

--- a/resources/views/components/skip.blade.php
+++ b/resources/views/components/skip.blade.php
@@ -1,10 +1,10 @@
 <nav aria-label="Skip navigation" class="skip">
     <ul class="list-reset">
         @if(config('base.top_menu_enabled') === true)
-            <li><a href="#top-menu">Skip to site menu</a></li>
+            <li><a href="#top-menu" class="skip-site-menu">Skip to site menu</a></li>
         @endif
         @if(!empty($site_menu_output))
-            <li><a href="#menu">Skip to page menu</a></li>
+            <li><a href="#menu" class="skip-page-menu">Skip to page menu</a></li>
         @endif
         <li><a href="#content">Skip to main content</a></li>
     </ul>

--- a/resources/views/components/skip.blade.php
+++ b/resources/views/components/skip.blade.php
@@ -1,11 +1,12 @@
 <nav aria-label="Skip navigation" class="skip">
     <ul class="list-reset">
         @if(config('base.top_menu_enabled') === true)
-            <li><a href="#top-menu" class="skip-site-menu">Skip to site menu</a></li>
+            <li class="skip-site-menu"><a href="#top-menu">Skip to site menu</a></li>
         @endif
         @if(!empty($site_menu_output))
-            <li><a href="#menu" class="skip-page-menu">Skip to page menu</a></li>
+            <li class="skip-page-menu"><a href="#menu">Skip to page menu</a></li>
         @endif
+        <li class="skip-menu hidden"><a href="#menu" class="skip-page-menu">Skip to menu</a></li>
         <li><a href="#content">Skip to main content</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
This PR fixes accessibility issues using a keyboard for the skip links once the small screen hamburger menu appears.

Trying to use the existing links caused issues on removing the event listeners, once they were removed the default behavior of the link was not working properly so I opted to introduce a new skip link for small screens only.

### Features:
* On small screens only one menu link is shown called "Skip to menu". Using this will focus you on the hamburger icon and automatically open the menu. Screen readers will say: "Menu, Expanded, Button" 
* Resizing the window will add/remove the appropriate skip links depending on the visibility of the hamburger icon.