### PR TITLE
Feature/accordion accessibility updates

### DIFF
--- a/factories/Accordion.php
+++ b/factories/Accordion.php
@@ -25,7 +25,7 @@ class Accordion implements FactoryContract
         for ($i = 1; $i <= $limit; $i++) {
             $data[$i] = [
                 'title' => $this->faker->sentence,
-                'description' => '<p>'.$this->faker->paragraph.'</p>',
+                'description' => '<p>'.$this->faker->paragraph.' <a href="/styleguide">Example link.</a></p>',
             ];
 
             $data[$i] = array_replace_recursive($data[$i], $options);

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -31,8 +31,5 @@ import 'accordion/src/accordion.js';
     document.querySelectorAll('ul.accordion > li').forEach(function(item) {
         // Apply the required content fold afterwards to simplify the html
         item.querySelector('div').classList.add('fold');
-
-        // Use this span container for the + and - close text and hide it from screen readers
-        // item.querySelector('a').insertAdjacentHTML('afterbegin', '<span class="hidden"></span>');
     });
 })();

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -23,6 +23,9 @@ import 'accordion/src/accordion.js';
         item.querySelectorAll('.content').forEach(function(item) {
             item.classList.add('hidden');
         });
+
+        // Remove the role="tablist" since it is not needed
+        item.removeAttribute('role');
     });
 
     document.querySelectorAll('ul.accordion > li').forEach(function(item) {

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -5,20 +5,31 @@ import 'accordion/src/accordion.js';
 
     document.querySelectorAll('.accordion').forEach(function(item) {
         new Accordion(item, {
-            // Only allow one accordion item open at time
             onToggle: function(target){
+                // Only allow one accordion item open at time
                 target.accordion.folds.forEach(fold => {
                     if(fold !== target) {
                         fold.open = false;
                     }
                 });
+
+                // Allow the content to be shown if its open or hide it when closed
+                target.content.classList.toggle('hidden')
             },
             enabledClass: 'enabled'
         });
+
+        // Hide all accordion content from the start so content inside it isn't part of the tabindex
+        item.querySelectorAll('.content').forEach(function(item) {
+            item.classList.add('hidden');
+        });
     });
 
-    // Apply the required content fold afterwards to simplify the html
     document.querySelectorAll('ul.accordion > li').forEach(function(item) {
+        // Apply the required content fold afterwards to simplify the html
         item.querySelector('div').classList.add('fold');
+
+        // Use this span container for the + and - close text and hide it from screen readers
+        // item.querySelector('a').insertAdjacentHTML('afterbegin', '<span class="hidden"></span>');
     });
 })();

--- a/resources/scss/components/_accordion.scss
+++ b/resources/scss/components/_accordion.scss
@@ -20,7 +20,7 @@
             }
 
             // Open symbol
-            &::before {
+            & span::before {
                 @apply .absolute .pin-r .pr-4 .pin-t .pt-4;
 
                 content: '+';
@@ -28,7 +28,7 @@
         }
 
         // Close symbol
-        &.open > a::before {
+        &.open > a span::before {
             content: '\2013';
         }
 

--- a/resources/views/components/accordion.blade.php
+++ b/resources/views/components/accordion.blade.php
@@ -4,7 +4,7 @@
 <ul class="accordion">
     @foreach($items as $key=>$item)
         <li>
-            <a href="#definition-{{ $key }}">{{ $item['title'] }}</a>
+            <a href="#definition-{{ $key }}"><span aria-hidden="true"></span>{{ $item['title'] }}</a>
             <div class="content" id="definition-{{ $key }}">{!! $item['description'] !!}</div>
         </li>
     @endforeach

--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -17,20 +17,20 @@
     {!! htmlspecialchars('
 <ul class="accordion">
     <li>
-        <a href="#panel1a">Accordion 1</a>
-        <div id="panel1a">
+        <a href="#panel1a"><span aria-hidden="true"></span>Accordion 1</a>
+        <div class="content" id="panel1a">
             <p>Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>
     <li>
-        <a href="#panel2a">Accordion 2</a>
-        <div id="panel2a">
+        <a href="#panel2a"><span aria-hidden="true"></span>Accordion 2</a>
+        <div class="content" id="panel2a">
             <p>Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>
     <li>
-        <a href="#panel3a">Accordion 3</a>
-        <div id="panel3a">
+        <a href="#panel3a"><span aria-hidden="true"></span>Accordion 3</a>
+        <div class="content" id="panel3a">
             <p>Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>


### PR DESCRIPTION
* Display none on actual content so you can’t tab into it if it is closed (if there is a link within that content).
* Fix for not reading the + and - icon for open and close with a screen reader
* Tabbing to the first tab in the accordion now says: "Collasped, tab list 5 items" instead of "Tab list 1 of 1"
* Updated the example accordion copy/paste code.