### PR TITLE
Move content skip

### DIFF
--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -42,7 +42,7 @@
             </nav>
         </div>
 
-        <main class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" id="content" tabindex="-1">
+        <main class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" tabindex="-1">
             @if(!empty($hero) && !in_array($page['controller'], config('base.hero_full_controllers')))
                 @include('components.hero', ['images' => $hero])
 
@@ -53,7 +53,9 @@
                 @include('components.breadcrumbs', ['breadcrumbs' => $breadcrumbs])
             @endif
 
-            @yield('content')
+            <div id="content" tabindex="-1">
+                @yield('content')
+            </div>
         </main>
     @if(!in_array($page['controller'], config('base.full_width_controllers')))</div>@endif
 


### PR DESCRIPTION
Move the skip to content to be directly around the content, so it skips hero and breadcrumbs. This solves the issue of a screen reader starting to read the breadcrumbs instead of the actual content first.