### PR TITLE
Remove the link since it was added to the description now

### DIFF
--- a/styleguide/Http/Controllers/HeroContainedTextController.php
+++ b/styleguide/Http/Controllers/HeroContainedTextController.php
@@ -23,7 +23,7 @@ class HeroContainedTextController extends Controller
         // Remove the link from hero images
         $request->data['hero'] = collect($request->data['hero'])
             ->transform(function ($item) {
-                $item['link'] = '';
+                $item['description'] = strip_tags($item['description'], 'a');
 
                 return $item;
             })


### PR DESCRIPTION
Looks like this was missed when we moved the link to the description instead of the "link" field. This makes this page unique again to not show a link at all.

Before:
<img width="891" alt="before" src="https://user-images.githubusercontent.com/634788/57396342-39c9b980-7198-11e9-806d-73e31fb8b4eb.png">

After:
<img width="886" alt="after" src="https://user-images.githubusercontent.com/634788/57396364-41895e00-7198-11e9-9aa4-f0d2f38135a4.png">
