### PR TITLE
Carousel Accessibility

### DIFF
--- a/resources/js/modules/carousel.js
+++ b/resources/js/modules/carousel.js
@@ -27,5 +27,23 @@ var Flickity = require('flickity');
         });
 
         document.querySelector('.rotate').removeAttribute('tabindex');
+
+        let EnableTabbableItems = function () {
+            // Don't allow tabbing to items that aren't selected
+            document.querySelectorAll('.rotate .content a').forEach(function (item) {
+                item.classList.add('hidden');
+            });
+
+            // Allow tabbing to the selected item
+            document.querySelectorAll('.rotate .is-selected .content a').forEach(function (item) {
+                item.classList.remove('hidden');
+            });
+        }
+
+        EnableTabbableItems();
+
+        document.querySelectorAll('.flickity-button').forEach(function (item) {
+           item.addEventListener('click', EnableTabbableItems);
+        });
     }
 })(Flickity);


### PR DESCRIPTION
Hide the links that aren't selectable yet so you can't tab to them. When the item is active it will make any links tabbable again.