### PR TITLE
hotfix/6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,13 +83,14 @@ module.exports = {
                 'half': '50%',
                 'screen-xxxl': screens.xxxl,
             },
-            spacing: {
-                '14' : '3.5rem',
+            padding: {
                 '3/4' : '75%',
                 '16/9': '56.35%',
                 'hero' : '36.3%',
                 'full' : '100%',
-                'portrait' : '133%',
+            },
+            spacing: {
+                '14' : '3.5rem',
             },
             boxShadow: {
                 'white': '0 7px 0 '+ colors.white +', 0 14px 0 '+ colors.white,


### PR DESCRIPTION
Move config options to padding since that is where those values are actually used. There isn't much harm keeping them in the spacing object, it's just that the spacing object is used as a default for lots of different css properties. This reduces the availability to only the properties we care about using them on (padding).