### PR TITLE
Fix the package version for sass-loader to be consistent with others

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mediabox": "^1.1.2",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "^1.15.2",
-    "sass-loader": "7.*",
+    "sass-loader": "^7.0",
     "slideout": "^1.0.1",
     "stylelint": "^9.0.0",
     "stylelint-config-standard": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7061,7 +7061,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@7.*:
+sass-loader@^7.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.1.0.tgz#16fd5138cb8b424bf8a759528a1972d72aad069d"
   integrity sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==


### PR DESCRIPTION
Change from `7.*` to `^7.0` no difference in what package it brings in, just makes it consistent with all the other package sem versions