### PR TITLE
Feature/tailwind config spacing

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,7 +84,7 @@ module.exports = {
                 'screen-xxxl': screens.xxxl,
             },
             padding: {
-                '3/4' : '75%',
+                '4/3' : '75%',
                 '16/9': '56.35%',
                 'hero' : '36.3%',
                 'full' : '100%',


### PR DESCRIPTION
Tailwind config had 3/4 instead of 4/3 for spacing with a value of 75%. 3/4 would be 133.33% (portrait). 