### PR TITLE
Banner fix

### DIFF
--- a/resources/js/modules/sticky.js
+++ b/resources/js/modules/sticky.js
@@ -13,13 +13,13 @@
             document.querySelector('.menu-top-container').classList.add('w-full');
             document.querySelector('.menu-top-container').classList.add('fixed');
             document.querySelector('.menu-top-container').classList.add('top-0');
-            document.querySelector('.menu-top-container').classList.add('z-10');
+            document.querySelector('.menu-top-container').classList.add('z-50');
         } else if(window.pageYOffset < offsetHeight) {
             document.getElementById('panel').style.marginTop = '0px';
             document.querySelector('.menu-top-container').classList.remove('w-full');
             document.querySelector('.menu-top-container').classList.remove('fixed');
             document.querySelector('.menu-top-container').classList.remove('top-0');
-            document.querySelector('.menu-top-container').classList.remove('z-10');
+            document.querySelector('.menu-top-container').classList.remove('z-50');
         }
     });
 })();

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -2,7 +2,7 @@
     $banner => array // [['title', 'link', 'excerpt']]
 --}}
 <div class="row relative">
-    <a class="banner bg-yellow items-center justify-center absolute right-0 mr-4 transition transition-timing-ease-out hover:text-black hidden mt:flex z-5" href="{{ $banner['link'] }}">
+    <a class="banner bg-yellow items-center justify-center absolute right-0 mr-4 transition transition-timing-ease-out hover:text-black hidden mt:flex z-40" href="{{ $banner['link'] }}">
         <span class="title uppercase text-sm tracking-wide">{{ $banner['title'] }}</span>
         @if($banner['excerpt'] != '')
             <span class="excerpt normal-case text-xl italic font-serif">{{ $banner['excerpt'] }}</span>


### PR DESCRIPTION
Since base does not have `z-5` value at all this change uses the z-10 value instead. Since that is equal value to the sticky header, that needed to be changed to 50. Otherwise if they both match, the issue arises that the banner goes ontop of the menu.