### PR TITLE
Add hover and focus variants

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,7 +101,9 @@ module.exports = {
             },
         }
     },
-    variants: {},
+    variants: {
+        opacity: ['responsive', 'hover', 'focus'],
+    },
     plugins: [
         require('glhd-tailwindcss-transitions')(), // https://github.com/glhd/tailwindcss-plugins/
     ],


### PR DESCRIPTION
Hover and focus for opacity is used on a lot of projects when new features are added. We'll add those by default since purgeCSS will strip anything we don't use anyway.