### PR TITLE
hotfix/6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/articles.blade.php
+++ b/resources/views/articles.blade.php
@@ -15,7 +15,7 @@
             @endforeach
         </ul>
     @else
-        <p>Currently there are no articles {{ !empty($topic['data']['name']) ? ' for the category ' . strtolower($topic['data']['name']) : '' }} {{ config('base.news_topic_route') }}.</p>
+        <p>Currently there are no articles{{ !empty($topic['data']['name']) ? ' for the category ' . strtolower($topic['data']['name']) : '' }}.</p>
     @endif
 
     @if(!empty($articles['meta']['prev_page_url']) || !empty($articles['meta']['next_page_url']))


### PR DESCRIPTION
When no articles are found don't inject the route name since the wording doesn't make sense. This will now show the proper text of "Currently there are no articles."