### PR TITLE
hotfix/6.6.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3877,16 +3877,16 @@
         },
         {
             "name": "waynestate/waynestate-api",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waynestate/waynestate-api-php.git",
-                "reference": "7f81f2286a352cbd6089751fa5ad7817cc95463f"
+                "reference": "b11c2339678f4ace2204fed5ffdc5de7ae6cd1e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waynestate/waynestate-api-php/zipball/7f81f2286a352cbd6089751fa5ad7817cc95463f",
-                "reference": "7f81f2286a352cbd6089751fa5ad7817cc95463f",
+                "url": "https://api.github.com/repos/waynestate/waynestate-api-php/zipball/b11c2339678f4ace2204fed5ffdc5de7ae6cd1e3",
+                "reference": "b11c2339678f4ace2204fed5ffdc5de7ae6cd1e3",
                 "shasum": ""
             },
             "require": {
@@ -3910,7 +3910,7 @@
             ],
             "description": "An API wrapper for the Wayne State University v1 API",
             "homepage": "https://github.com/waynestate/waynestate-api-php",
-            "time": "2019-03-07T17:24:17+00:00"
+            "time": "2019-06-07T18:35:12+00:00"
         }
     ],
     "packages-dev": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Update the WSU API connector so the default timeout is increased. This helps with slow requests so the menu doesn't come back as `null` resulting in no way to navigate the site. It rare that a request takes longer than 3 seconds since we cache everything in REDIS, but it's apparent on our dev server where we don't cache things and sometimes the server is just a little slower than normal.