### PR TITLE
Event listing calendar date no longer has leading zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -12,7 +12,7 @@
             <div class="mx-2">
                 <div class="relative border-2 border-green rounded-sm text-center mb-4">
                     <div class="w-12 bg-green text-white leading-none border-b-2 border-green text-sm">{{ apdatetime(date('M' , strtotime($key))) }}</div>
-                    <div class="text-green text-2xl leading-tight">{{ apdatetime(date('d' , strtotime($key))) }}</div>
+                    <div class="text-green text-2xl leading-tight">{{ apdatetime(date('j' , strtotime($key))) }}</div>
                 </div>
             </div>
             <ul class="mx-2 flex-grow">


### PR DESCRIPTION
## Reason for change

Removing the leading zero per university style and readability.

## Checklist

- [x] Read through the code diff to ensure accuracy
- [x] Verified each page looks good on each viewport size
- [x] Added an example to the styleguide if applicable
- [x] Screen shot or video of before/after

## Screenshots / Videos

| Before | After |
|--------|--------|
| <img width="451" alt="Screen Shot 2019-06-14 at 2 20 17 PM" src="https://user-images.githubusercontent.com/37359/59530319-4638e480-8eb1-11e9-93e2-34d90a71c29c.png"> | <img width="459" alt="Screen Shot 2019-06-14 at 2 19 59 PM" src="https://user-images.githubusercontent.com/37359/59530328-4c2ec580-8eb1-11e9-81e0-35ca4f27ae70.png"> |