### PR TITLE
hotfix/6.6.4

### DIFF
--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -49,7 +49,11 @@ class ArticleRepository implements ArticleRepositoryContract
         }
 
         $articles['articles'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
-            return $this->newsApi->request($params['method'], $params);
+            try {
+                return $this->newsApi->request($params['method'], $params);
+            } catch (\Exception $e) {
+                return [];
+            }
         });
 
         return $articles;

--- a/app/Repositories/TopicRepository.php
+++ b/app/Repositories/TopicRepository.php
@@ -37,7 +37,11 @@ class TopicRepository implements TopicRepositoryContract
         ];
 
         $topics['topics'] = $this->cache->remember('newsroom-topics', config('cache.ttl'), function () use ($params) {
-            $topics = $this->newsApi->request($params['method'], $params);
+            try {
+                $topics = $this->newsApi->request($params['method'], $params);
+            } catch (\Exception $e) {
+                $topics = [];
+            }
 
             if (!empty($topics['data'])) {
                 $topics['data'] = collect($topics['data'])->map(function ($topic) {

--- a/composer.lock
+++ b/composer.lock
@@ -3649,16 +3649,16 @@
         },
         {
             "name": "waynestate/news-api-php",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waynestate/news-api-php.git",
-                "reference": "c94335728df26e8d82076e1a13b8db144ab8d620"
+                "reference": "ddcc8eee7ad27a05de1644aba4faf002b3d1f7eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waynestate/news-api-php/zipball/c94335728df26e8d82076e1a13b8db144ab8d620",
-                "reference": "c94335728df26e8d82076e1a13b8db144ab8d620",
+                "url": "https://api.github.com/repos/waynestate/news-api-php/zipball/ddcc8eee7ad27a05de1644aba4faf002b3d1f7eb",
+                "reference": "ddcc8eee7ad27a05de1644aba4faf002b3d1f7eb",
                 "shasum": ""
             },
             "require": {
@@ -3685,7 +3685,7 @@
                 }
             ],
             "description": "Connector for News API",
-            "time": "2019-03-07T16:57:56+00:00"
+            "time": "2019-06-10T13:16:25+00:00"
         },
         {
             "name": "waynestate/parse-menu",


### PR DESCRIPTION
Upgrade the news API connector and catch exceptions when interacting with the API. Returning a blank array will result in showing no data to the view instead of 500ing.