### PR TITLE
Update logging channels and permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ APP_TIMEZONE=America/Detroit
 APP_LOG_LEVEL=debug
 APP_URL=http://base.wayne.local
 
-LOG_CHANNEL=daily
+LOG_CHANNEL=stack
 
 CACHE_DRIVER=redis
 SESSION_DRIVER=array

--- a/config/logging.php
+++ b/config/logging.php
@@ -39,6 +39,7 @@ return [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
+            'permission' => 02770,
         ],
 
         'daily' => [
@@ -46,6 +47,7 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
             'days' => 7,
+            'permission' => 02770,
         ],
 
         'syslog' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -32,7 +32,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily', 'errorlog'],
         ],
 
         'single' => [


### PR DESCRIPTION
Update the permissions to be 02770 for the servers

Switch over the LOG_CHANNEL to be stack to now use both the daily log and passing the log onto the errorlog as well for use in AppOptics