### PR TITLE
Update accordion contrast between selected and not selected states to…

### DIFF
--- a/resources/scss/components/_accordion.scss
+++ b/resources/scss/components/_accordion.scss
@@ -16,7 +16,7 @@
 
             &:first-child:hover,
             &:first-child:focus, {
-                @apply .bg-grey-light;
+                @apply .bg-grey-darker .text-white;
             }
 
             // Open symbol


### PR DESCRIPTION
Sticking with our grey scale we need to use `.bg-grey-darker` which is `#575959` : `#e6e6e6` which is a 5.64:1 ratio. Using `.bg-grey-dark` isn't good enough, it's only like 2.6.

<img width="912" alt="Screen Shot 2019-06-26 at 1 53 10 PM" src="https://user-images.githubusercontent.com/634788/60203323-6ace7e00-981a-11e9-82e6-f820a5f4818b.png">


