### PR TITLE
Remove example buttons and expose the code so it is more accessible.

### DIFF
--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -11,9 +11,7 @@
         @include('components.accordion', ['items' => $accordion_page])
     @endif
 
-    <a href="#accordions" class="button" onclick="document.querySelector('pre.accordions').classList.toggle('hidden');">See accordion code</a>
-
-    <pre id="accordions" class="accordions hidden bg-grey-lightest overflow-scroll">
+    <pre class="bg-grey-lightest overflow-scroll p-4">
     {!! htmlspecialchars('
 <ul class="accordion">
     <li>
@@ -34,7 +32,6 @@
             <p>Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>
-</ul>
-    ') !!}
+</ul>') !!}
     </pre>
 @endsection

--- a/styleguide/Views/styleguide-figure.blade.php
+++ b/styleguide/Views/styleguide-figure.blade.php
@@ -13,15 +13,12 @@
             <figcaption>{{ $faker->sentence }}</figcaption>
         </figure>
 
-        <a href="#fig-none" class="button" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See figure code</a>
-
-        <pre id="fig-none" class="fig-none hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <figure>
     <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-</figure>
-        ') !!}
+</figure>') !!}
         </pre>
 
         <hr>
@@ -36,15 +33,12 @@
                 </figure>
                 <p>{{ $faker->paragraph(38) }}</p>
 
-                <a href="#fig-left" class="button" onclick="document.querySelector('pre.fig-left').classList.toggle('hidden');">See float left code</a>
-
-                <pre id="fig-left" class="fig-left hidden bg-grey-lightest overflow-scroll">
+                <pre class="bg-grey-lightest overflow-scroll p-4">
                 {!! htmlspecialchars('
 <figure class="float-left">
     <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-</figure>
-                ') !!}
+</figure>')!!}
                 </pre>
             </div>
         </div>
@@ -61,15 +55,12 @@
                 </figure>
                 <p>{{ $faker->paragraph(28) }}</p>
 
-                <a href="#fig-right" class="button" onclick="document.querySelector('pre.fig-right').classList.toggle('hidden');">See float right code</a>
-
-                <pre id="fig-right" class="fig-right hidden bg-grey-lightest overflow-scroll">
+                <pre class="bg-grey-lightest overflow-scroll p-4">
                 {!! htmlspecialchars('
 <figure class="float-right">
     <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-</figure>
-                ') !!}
+</figure>') !!}
                 </pre>
             </div>
         </div>
@@ -87,15 +78,12 @@
                 </figure>
                 <p>{{ $faker->paragraph(12) }}</p>
 
-                <a href="#fig-center" class="button" onclick="document.querySelector('pre.fig-center').classList.toggle('hidden');">See center image code</a>
-
-                <pre id="fig-center" class="fig-center hidden bg-grey-lightest overflow-scroll">
+                <pre class="bg-grey-lightest overflow-scroll p-4">
                 {!! htmlspecialchars('
 <figure class="text-center">
     <img src="/styleguide/image/800x450" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-</figure>
-                ') !!}
+</figure>') !!}
                 </pre>
             </div>
         </div>

--- a/styleguide/Views/styleguide-tablestack.blade.php
+++ b/styleguide/Views/styleguide-tablestack.blade.php
@@ -27,9 +27,7 @@
             </tbody>
         </table>
 
-        <a href="#table-stack" class="button" onclick="document.querySelector('pre.table-stack').classList.toggle('hidden');">See table code</a>
-
-        <pre id="table-stack" class="table-stack hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <table class="table-stack">
     <caption>Example table with caption</caption>
@@ -48,8 +46,7 @@
             <td></td>
         </tr>
     </tbody>
-</table>
-        ') !!}
+</table>') !!}
         </pre>
     </div>
 @endsection

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -18,8 +18,7 @@
             </div>
         </div>
 
-        <a href="#two-columns-code" class="button" onclick="document.querySelector('pre.two-columns-code').classList.toggle('hidden');">See two column code</a>
-        <pre id="two-columns-code" class="two-columns-code hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
             {!! htmlspecialchars('
 <div class="row -mx-4 md:flex">
     <div class="md:w-1/2 px-4">
@@ -28,8 +27,7 @@
     <div class="md:w-1/2 px-4">
         <p>'.$faker->paragraph.'</p>
     </div>
-</div>
-            ') !!}
+</div>') !!}
         </pre>
 
         <hr>
@@ -50,8 +48,7 @@
             </div>
         </div>
 
-        <a href="#three-columns-code" class="button" onclick="document.querySelector('pre.three-columns-code').classList.toggle('hidden');">See three column code</a>
-        <pre id="three-columns-code" class="three-columns-code hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
             {!! htmlspecialchars('
 <div class="row -mx-4 lg:flex">
     <div class="lg:w-1/3 px-4">
@@ -63,8 +60,7 @@
     <div class="lg:w-1/3 px-4">
         <p>'.$faker->paragraph.'</p>
     </div>
-</div>
-            ') !!}
+</div>') !!}
         </pre>
 
         <hr>
@@ -94,9 +90,7 @@
             </tbody>
         </table>
 
-        <a href="#table-stack" class="button" onclick="document.querySelector('pre.table-stack').classList.toggle('hidden');">See table code</a>
-
-        <pre id="table-stack" class="table-stack hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <table class="table-stack">
         <caption>Example table with caption</caption>
@@ -115,8 +109,7 @@
             <td></td>
         </tr>
     </tbody>
-</table>
-        ') !!}
+</table>') !!}
         </pre>
 
         <hr>
@@ -170,14 +163,12 @@
             <p>{{ $faker->paragraph(10) }}</p>
         </blockquote>
 
-        <a href="#blockquote" class="button" onclick="document.querySelector('pre.blockquote').classList.toggle('hidden');">See blockquote code</a>
 
-        <pre id="blockquote" class="blockquote hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <blockquote>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-</blockquote>
-        ') !!}
+</blockquote>') !!}
         </pre>
 
         <hr>
@@ -195,14 +186,12 @@
         <a href="#button-examples" class="button bg-gradient-green text-white">Dark button</a>
         <a href="#button-examples" class="button expanded">Expanded button</a>
         <br />
-        <a href="#button-examples" class="button" onclick="document.querySelector('pre.button-examples').classList.toggle('hidden');">See button code</a>
 
-        <pre id="button-examples" class="button-examples hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <a href="#" class="button">Standard button</a>
 <a href="#" class="button bg-gradient-green text-white">Dark button</a>
-<a href="#" class="button expanded">Expanded button</a>
-        ') !!}
+<a href="#" class="button expanded">Expanded button</a>') !!}
         </pre>
 
         <hr>
@@ -222,16 +211,13 @@
         <p>Any valid YouTube URL starting with <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">youtu.be</code> or <code class="bg-grey-lightest py-px pb-1 px-1 text-sm">youtube.com/watch</code> will open a lightbox with the video.</p>
         <p><a href="//www.youtube.com/watch?v=guRgefesPXE"><img src="//i.wayne.edu/youtube/guRgefesPXE" alt="School of Medicine Commencement YouTube video"></a></p>
 
-        <a href="#media-example" class="button" onclick="document.querySelector('pre.media-example').classList.toggle('hidden');">See media code</a>
-
-        <pre id="media-example" class="media-example hidden">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <p>
     <a href="//www.youtube.com/watch?v=guRgefesPXE">
         <img src="//i.wayne.edu/youtube/guRgefesPXE" alt="Description of YouTube video">
     </a>
-</p>
-        ') !!}
+</p>') !!}
         </pre>
 
         <hr>
@@ -243,14 +229,11 @@
             <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" title="Responsive embed example" allowfullscreen></iframe>
         </div>
 
-        <a href="#responsive-embed-example" class="button" onclick="document.querySelector('pre.responsive-embed-example').classList.toggle('hidden');">See responsive embed code</a>
-
-        <pre id="responsive-embed-example" class="responsive-embed-example hidden bg-grey-lightest overflow-scroll">
+        <pre class="bg-grey-lightest overflow-scroll p-4">
         {!! htmlspecialchars('
 <div class="responsive-embed">
     <iframe width="420" height="315" src="//www.youtube.com/embed/guRgefesPXE" title="Responsive embed example" allowfullscreen></iframe>
-</div>
-        ') !!}
+</div>') !!}
         </pre>
 
         <hr>
@@ -266,17 +249,15 @@
                     </figure>
                 </div>
 
-                <a href="#fig-none" class="button mr-4" onclick="document.querySelector('pre.fig-none').classList.toggle('hidden');">See code</a>
-                <a href="/styleguide/figure" class="button">More options</a>
-
-                <pre id="fig-none" class="fig-none hidden bg-grey-lightest overflow-scroll">
+                <pre class="bg-grey-lightest overflow-scroll p-4">
                 {!! htmlspecialchars('
 <figure>
     <img src="/styleguide/image/400x300" alt="">
     <figcaption>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</figcaption>
-</figure>
-                ') !!}
+</figure>') !!}
                 </pre>
+
+                <a href="/styleguide/figure" class="button mt-4">More options</a>
             </div>
         </div>
 
@@ -286,7 +267,7 @@
 
         <div class="flex flex-wrap -mx-4">
             <div class="w-full md:w-1/2 lg:w-1/3 px-4 mb-8">
-                <div class="rounded overflow-hidden border">
+                <div class="rounded overflow-hidden border border-grey">
                     <div class="text-black bg-green-lightest px-6 py-3 text-sm font-semibold flex justify-between">
                         <span>Lightest green</span>
                     </div>
@@ -312,7 +293,7 @@
             </div>
 
             <div class="w-full md:w-1/2 lg:w-1/3 px-4 mb-8">
-                <div class="rounded overflow-hidden border">
+                <div class="rounded overflow-hidden border border-grey">
                     <div class="text-black bg-yellow-lightest px-6 py-3 text-sm font-semibold flex justify-between">
                         <span>Lightest yellow</span>
                     </div>
@@ -338,7 +319,7 @@
             </div>
 
             <div class="w-full md:w-1/2 lg:w-1/3 px-4 mb-8">
-                <div class="rounded overflow-hidden border">
+                <div class="rounded overflow-hidden border border-grey">
                     <div class="text-black bg-white px-6 py-3 text-sm font-semibold flex justify-between">
                         <span>White</span>
                     </div>


### PR DESCRIPTION
The buttons to toggle open/close the code are not accessible since they did not say "expanded/collapsed" with a screen reader. In order to make that work properly, more javascript code would need to be added to do the toggle and it doesn't make sense to do that all inline.

In an effort to not bloat the javascript file with styleguide specific code, I decided to remove the buttons entirely and expose the code all the time. It does make the page a lot longer, but I think it looks pretty good and I enjoy seeing the code exposed all the time for reference.

I'll leave this open for discussion since it is a larger change.

# Example:

<img width="945" alt="Screen Shot 2019-07-02 at 11 10 41 AM" src="https://user-images.githubusercontent.com/634788/60524439-8cb47e80-9cba-11e9-938b-9a17ba5cd292.png">
