### PR TITLE
Add aria-labelledby for svgs that have links around them.

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -6,7 +6,7 @@
         @foreach($breadcrumbs as $key=>$crumb)
             @if($key == 0)
                 <li class="inline">
-                    <a href="/"><span class="text-black align-middle">@svg('home', 'w-4 h-4 inline align-baseline')</span></a>
+                    <a href="/" aria-labelledby="Home"><span class="text-black align-middle">@svg('home', 'w-4 h-4 inline align-baseline')</span></a>
                     <span class="icon-right-open px-2"></span>
             @elseif($key == (count($breadcrumbs) - 1))
                 <li class="font-bold text-green inline">

--- a/resources/views/components/footer-social.blade.php
+++ b/resources/views/components/footer-social.blade.php
@@ -4,7 +4,7 @@
 <div class="bg-green-darker py-6">
     <div class="row flex justify-center items-center">
             @foreach($social as $item)
-                <a href="{{ $item['link'] }}" target="_blank" rel="noopener" class="flex justify-center items-center h-10 w-10 lg:h-14 lg:w-14 mx-1 sm:mx-2 md:mx-3 lg:mx-4 text-green-lightest fill-current bg-green rounded-full transition transition-property-bg transition-delay-none hover:bg-green-lighter hover:text-white">
+                <a href="{{ $item['link'] }}" target="_blank" aria-labelledby="{{ strtolower(trim($item['title'])) }}" rel="noopener" class="flex justify-center items-center h-10 w-10 lg:h-14 lg:w-14 mx-1 sm:mx-2 md:mx-3 lg:mx-4 text-green-lightest fill-current bg-green rounded-full transition transition-property-bg transition-delay-none hover:bg-green-lighter hover:text-white">
                     @svg($item['title'], 'w-6 h-6 lg:w-8 lg:h-8')
                 </a>
             @endforeach


### PR DESCRIPTION
NVDA on windows does not read the labelledby on the svg, it requires it on the link element itself. Leaving it on both makes it work properly for NVDA and voice over on mac.