### PR TITLE
Remove hiding the legend with SCSS since we want the heading displayed.

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -68,10 +68,6 @@
     // Fieldsets
     fieldset {
         @apply .m-0 .p-0 .border-0;
-
-        legend {
-            @apply .hidden;
-        }
     }
 
     // Textareas

--- a/styleguide/Views/styleguide-forms.blade.php
+++ b/styleguide/Views/styleguide-forms.blade.php
@@ -3,7 +3,14 @@
 @section('content')
     @include('components.page-title', ['title' => $page['title']])
 
-    <style>.formy fieldset legend { display:block; }</style>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            document.querySelectorAll('.formy fieldset legend').forEach(function (legend) {
+                legend.style.display = 'block';
+            });
+        });
+    </script>
+
     <div class="formy">
         <div class="form-description">
             <div class="form-description">


### PR DESCRIPTION
* Remove hiding the legend with SCSS since we want the heading displayed.
* Change the style element to be a script since style isn't allowed in a div (this is copied from forms.wayne.edu output)