### PR TITLE
Feature/events listing

### DIFF
--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -8,15 +8,18 @@
 
 <ul>
     @foreach($events as $key => $dates)
-        <li class="flex -mx-2">
-            <div class="mx-2">
-                <div class="relative border-2 border-green rounded-sm text-center mb-4">
-                    <div class="w-12 bg-green text-white leading-none border-b-2 border-green text-sm">{{ apdatetime(date('M' , strtotime($key))) }}</div>
-                    <div class="text-green text-2xl leading-tight">{{ apdatetime(date('j' , strtotime($key))) }}</div>
-                </div>
-            </div>
-            <div class="mx-2 flex-grow">
-                @foreach($dates as $event)
+        @foreach($dates as $event)
+            <li class="flex -mx-2">
+                @if($loop->first)
+                    <div class="mx-2">
+                        <div class="relative border-2 border-green rounded-sm text-center mb-4">
+                            <div class="w-12 bg-green text-white leading-none border-b-2 border-green text-sm">{{ apdatetime(date('M' , strtotime($key))) }}</div>
+                            <div class="text-green text-2xl leading-tight">{{ apdatetime(date('j' , strtotime($key))) }}</div>
+                        </div>
+                    </div>
+                @endif
+
+                <div class="mx-2 flex-grow{{ ! $loop->first ? ' ml-19' :'' }}">
                     <div class="mb-2 pb-2 border-b border-solid border-grey-light">
                         <a class="block hover:underline" href="{{ $event['url'] }}">{{ $event['title'] }}
                             <span class="visually-hidden"> on {{ apdatetime(date('M d, Y' , strtotime($key))) }}
@@ -27,13 +30,13 @@
                             @if(!(bool)$event['is_all_day']){{ apdatetime(date('g:i a' , strtotime($event['start_time']))) }}@else All day @endif
                         </time>
                     </div>
-                @endforeach
-                @if($dates == end($events))
-                    <div>
-                        <a href="//events.wayne.edu/{{ $cal_name ?? 'main/' }}month/" class="hover:underline">{{ $link_text ?? 'More events' }}</a>
-                    </div>
-                @endif
-            </div>
-        </li>
+                </div>
+            </li>
+        @endforeach
+        @if($dates == end($events))
+            <li class="flex -mx-2 ml-17">
+                <a href="//events.wayne.edu/{{ $cal_name ?? 'main/' }}month/" class="hover:underline">{{ $link_text ?? 'More events' }}</a>
+            </li>
+        @endif
     @endforeach
 </ul>

--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -15,9 +15,9 @@
                     <div class="text-green text-2xl leading-tight">{{ apdatetime(date('j' , strtotime($key))) }}</div>
                 </div>
             </div>
-            <ul class="mx-2 flex-grow">
+            <div class="mx-2 flex-grow">
                 @foreach($dates as $event)
-                    <li class="mb-2 pb-2 border-b border-solid border-grey-light">
+                    <div class="mb-2 pb-2 border-b border-solid border-grey-light">
                         <a class="block hover:underline" href="{{ $event['url'] }}">{{ $event['title'] }}
                             <span class="visually-hidden"> on {{ apdatetime(date('M d, Y' , strtotime($key))) }}
                                 @if(!(bool)$event['is_all_day']) at {{ apdatetime(date('g:i a' , strtotime($event['start_time']))) }}@endif
@@ -26,14 +26,14 @@
                         <time class="text-sm text-grey-darker" datetime="{{ $event['date'] }}T{{ $event['start_time'] }}{{ date('P') }}">
                             @if(!(bool)$event['is_all_day']){{ apdatetime(date('g:i a' , strtotime($event['start_time']))) }}@else All day @endif
                         </time>
-                    </li>
+                    </div>
                 @endforeach
                 @if($dates == end($events))
-                    <li>
+                    <div>
                         <a href="//events.wayne.edu/{{ $cal_name ?? 'main/' }}month/" class="hover:underline">{{ $link_text ?? 'More events' }}</a>
-                    </li>
+                    </div>
                 @endif
-            </ul>
+            </div>
         </li>
     @endforeach
 </ul>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -92,6 +92,10 @@ module.exports = {
             spacing: {
                 '14' : '3.5rem',
             },
+            margin: {
+                '17' : '4.25rem',
+                '19' : '4.75rem',
+            },
             boxShadow: {
                 'white': '0 7px 0 '+ colors.white +', 0 14px 0 '+ colors.white,
                 'grey': '0 7px 0 '+ colors.grey +', 0 14px 0 '+ colors.grey,


### PR DESCRIPTION
* Remove the nested list of event information since it doesn't work well with a screen reader.
* Move the visual date inside the loop and only show it on the first item of the loop.
* If the visual date isn't shown, then margin the event information over to visually line it up properly.

No visual change to any viewport, but this is the output:

<img width="529" alt="Screen Shot 2019-07-09 at 11 39 35 AM" src="https://user-images.githubusercontent.com/634788/60903159-d400b900-a23e-11e9-84b8-0e08a565f6db.png">
