### PR TITLE
hotfix/6.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -14,6 +14,9 @@ import 'accordion/src/accordion.js';
                     }
                 });
 
+                // Force the focus on the element they opened
+                target.el.firstElementChild.focus();
+
                 // Allow the content to be shown if its open or hide it when closed
                 target.content.classList.toggle('hidden')
 


### PR DESCRIPTION
Force the focus for accordion since certain browser versions would go back to the first element rather than the one they selected.