### PR TITLE
Hotfix/6.8.3

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -266,9 +266,15 @@ class ProfileRepository implements ProfileRepositoryContract
     {
         $name_fields = $this->getFields()['name_fields'];
 
-        return collect($profile['profile']['data'])->filter(function ($value, $key) use ($name_fields) {
+        $name = collect($profile['profile']['data'])->filter(function ($value, $key) use ($name_fields) {
             return in_array($key, $name_fields) && $value != '';
-        })->implode(' ');
+        })
+            ->map(function ($value, $key) {
+                return $key == 'Suffix' ? ', '.$value : $value;
+            })
+            ->implode(' ');
+
+        return str_replace(' ,', ',', $name);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.8.1",
+  "version": "6.8.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -47,18 +47,31 @@ class ProfileRepositoryTest extends TestCase
      */
     public function getting_page_title_should_come_from_name()
     {
-        $name_fields = app('App\Repositories\ProfileRepository')->getFields()['name_fields'];
+        $returnNameFields = [
+            'name_fields' => [
+                'Honorific',
+                'First Name',
+                'Last Name',
+                'Suffix',
+            ],
+        ];
 
-        // Build the return set
-        foreach ((array) $name_fields as $name) {
-            $return['profile']['data'][$name] = $this->faker->word;
-        }
+        $return['profile']['data'] = [
+            'Honorific' => 'Dr.',
+            'First Name' => 'Anthony',
+            'Last Name' => 'Wayne',
+            'Suffix' => 'Jr.',
+        ];
+
+        // Mock the Connector and set the return
+        $profile = Mockery::mock('App\Repositories\ProfileRepository')->makePartial();
+        $profile->shouldReceive('getFields')->once()->andReturn($returnNameFields);
 
         // Get the page title
-        $pageTitle = app('App\Repositories\ProfileRepository')->getPageTitleFromName($return);
+        $pageTitle = $profile->getPageTitleFromName($return);
 
         // Make sure the page title equals all the name fields
-        $this->assertEquals(implode($return['profile']['data'], ' '), $pageTitle);
+        $this->assertEquals('Dr. Anthony Wayne, Jr.', $pageTitle);
     }
 
     /**


### PR DESCRIPTION
Fix issue with the default name fields including Suffix without a comma. This required reworking the test since it was expecting only spaces between each of the fields. Suffix is the only one which requires ", Suffix"

`Dr. Anthony Wayne Jr.` => `Dr. Anthony Wayne, Jr.`