### PR TITLE
Feature/accordion

### DIFF
--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -20,7 +20,11 @@ import 'accordion/src/accordion.js';
                 // Allow the content to be shown if its open or hide it when closed
                 target.content.classList.toggle('hidden')
 
+                // Set accessible state of expanded
                 target.el.firstElementChild.setAttribute('aria-expanded', 'true');
+
+                // Update the browsers hash so if the url is copied it will deep link properly
+                window.location.hash = target.heading.hash.substr(1);
             },
             enabledClass: 'enabled',
             noAria: true,
@@ -41,14 +45,21 @@ import 'accordion/src/accordion.js';
         if(window.location.hash != '') {
             accordion.folds.forEach(function (fold) {
                 if(fold.heading.getAttribute('id') == window.location.hash.substr(1)) {
-                    fold.open = true;
+                    window.setTimeout(function () {
+                        fold.open = true;
+                    }, 500);
                 }
             });
         }
     });
 
+    // Apply the required content fold afterwards to simplify the html
     document.querySelectorAll('ul.accordion > li').forEach(function(item) {
-        // Apply the required content fold afterwards to simplify the html
         item.querySelector('div').classList.add('fold');
+    });
+
+    // Remove IDs from content folds so the browser doesn't jump around when opening an accordion item
+    document.querySelectorAll('.accordion li a').forEach(function (item) {
+        item.removeAttribute('id');
     });
 })();

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -4,7 +4,7 @@ import 'accordion/src/accordion.js';
     "use strict";
 
     document.querySelectorAll('.accordion').forEach(function(item) {
-        new Accordion(item, {
+        let accordion = new Accordion(item, {
             onToggle: function(target){
                 // Only allow one accordion item open at time
                 target.accordion.folds.forEach(fold => {
@@ -31,10 +31,20 @@ import 'accordion/src/accordion.js';
             item.classList.add('hidden');
         });
 
+        // Apply accessibility attributes
         item.querySelectorAll('li a:first-child').forEach(function(item) {
             item.setAttribute('role', 'button');
             item.setAttribute('aria-expanded', 'false');
         });
+
+        // See if the hash is within this accordion so we can open it
+        if(window.location.hash != '') {
+            accordion.folds.forEach(function (fold) {
+                if(fold.heading.getAttribute('id') == window.location.hash.substr(1)) {
+                    fold.open = true;
+                }
+            });
+        }
     });
 
     document.querySelectorAll('ul.accordion > li').forEach(function(item) {

--- a/resources/js/modules/anchor.js
+++ b/resources/js/modules/anchor.js
@@ -1,11 +1,19 @@
 (function() {
     "use strict";
 
+    var offset = function offset(el) {
+        var rect = el.getBoundingClientRect(),
+        scrollLeft = window.pageXOffset || document.documentElement.scrollLeft,
+        scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        return { top: rect.top + scrollTop, left: rect.left + scrollLeft }
+    }
+
     var scrollToHash = function () {
         var hash = window.location.hash.substring(1);
 
         if(hash !== '' && document.getElementById(hash)) {
-            let y = document.getElementById(hash).offsetTop - document.querySelector('.menu-top-container').offsetHeight;
+            let y = offset((document.getElementById(hash))).top - document.querySelector('.menu-top-container').offsetHeight;
 
             window.scroll(0, y);
         }

--- a/resources/views/components/accordion.blade.php
+++ b/resources/views/components/accordion.blade.php
@@ -4,8 +4,8 @@
 <ul class="accordion">
     @foreach($items as $key=>$item)
         <li>
-            <a href="#definition-{{ $key }}"><span aria-hidden="true"></span>{{ $item['title'] }}</a>
-            <div class="content" id="definition-{{ $key }}">{!! $item['description'] !!}</div>
+            <a href="#definition-{{ $key }}" id="definition-{{ $key }}"><span aria-hidden="true"></span>{{ $item['title'] }}</a>
+            <div class="content">{!! $item['description'] !!}</div>
         </li>
     @endforeach
 </ul>

--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -15,20 +15,20 @@
     {!! htmlspecialchars('
 <ul class="accordion">
     <li>
-        <a href="#panel1a"><span aria-hidden="true"></span>Accordion 1</a>
-        <div class="content" id="panel1a">
+        <a href="#panel1a" id="panel1a"><span aria-hidden="true"></span>Accordion 1</a>
+        <div class="content">
             <p>Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>
     <li>
-        <a href="#panel2a"><span aria-hidden="true"></span>Accordion 2</a>
-        <div class="content" id="panel2a">
+        <a href="#panel2a" id="panel2a"><span aria-hidden="true"></span>Accordion 2</a>
+        <div class="content">
             <p>Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>
     <li>
-        <a href="#panel3a"><span aria-hidden="true"></span>Accordion 3</a>
-        <div class="content" id="panel3a">
+        <a href="#panel3a" id="panel3a"><span aria-hidden="true"></span>Accordion 3</a>
+        <div class="content">
             <p>Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </li>


### PR DESCRIPTION
This PR allows for deep linking accordions. When linking to a page with a hash, it will search the accordion items for a match and trigger it to be automatically open.

* Move the id attribute to the link itself, this way the browser can anchor to something visible (the content-fold is hidden, which is why it needed to be moved)
* When clicking an accordion item, update the URL hash so the link can be sharable.
* When the page is done loading remove all IDs from accordion links. This prevents the browser from "jumping" around when clicking links, since you want them to just open and not anchor to it every single time. Anchoring will only occur on first page load to deep link.
* Update the `resources/js/modules/anchor.js` code to use `getBoundingClientRect` to figure out how far from the top an element is. It seems more reliable and worked for figuring out the placement of an accordion link item.