### PR TITLE
feature/wild-care-route

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -93,6 +93,7 @@ extractreleasepack_on_remote
 syncshareddata_remotesrc
 baseenvlink_remoterelease
 prepare_remoterelease
+cache_remote_release
 link_newrelease_on_remote
 cleanup_oldreleases_on_remote
 clean_localsrc
@@ -174,7 +175,7 @@ make composerinstalldev
 fi
 echo "Composer installed.";
 
-echo "Generate the artisian key...";
+echo "Generate the artisan key...";
 make generatekey
 
 echo "Yarn install...";
@@ -260,6 +261,14 @@ echo "RemoteRelease Prepare...";
 rsync --progress -e ssh -avzh --delay-updates --delete {{ $source_dir }}/ {{ $release_dir }}/{{ $release }}/;
 chmod -R g+s {{ $release_dir }}/{{ $release }}
 echo "RemoteRelease Prepare Done.";
+@endtask
+
+@task('cache_remote_release', ['on' => $remote_server])
+echo "Caching configs...";
+php73 artisan config:cache
+echo "Caching routes...";
+php73 artisan route:cache
+echo "Done caching";
 @endtask
 
 @task('link_newrelease_on_remote', ['on' => $remote_server])

--- a/app/Http/Controllers/WildCardController.php
+++ b/app/Http/Controllers/WildCardController.php
@@ -1,0 +1,24 @@
+<?php
+/*
+* Status: Private
+* Description: Wild Card Template
+* Default: false
+*/
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class WildCardController extends Controller
+{
+    /**
+     * Display the view.
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        return app($request->controller)->index($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,5 @@ Route::get('{any?}'.config('base.news_view_route').'/{slug}-{id}', config('base.
     ->where(['any' => '.*', 'slug' => '.+', 'id' => '\d+']);
 
 // The wild card route is a catch all route that tries to resolve the requests path to a json file
-Route::match(['get', 'post'], '{path}', function (Illuminate\Http\Request $request) {
-    return app($request->controller)->index($request);
-})
+Route::match(['get', 'post'], '{path}', 'WildCardController@index')
     ->where('path', '.*');


### PR DESCRIPTION
I noticed when running `php artisan route:cache` it would error since we are using a closure on the wild card route. This PR moves it to a proper Controller method so it is cacheable.

Error:
local.ERROR: Unable to prepare route [{path}] for serialization. Uses Closure. {"exception":"[object] (LogicException(code: 0): Unable to prepare route [{path}] for serialization. Uses Closure. at /vagrant/base/vendor/laravel/framework/src/Illuminate/Routing/Route.php:917)
