### PR TITLE
Display the list of assets as a file list under the article

### DIFF
--- a/resources/views/article.blade.php
+++ b/resources/views/article.blade.php
@@ -10,6 +10,18 @@
 
         <div class="content mt:text-xl">
             {!! $article['data']['body'] !!}
+
+            @if(!empty($article['data']['assets']))
+                <h2 class="border-b mt-4">Assets</h2>
+
+                <ul>
+                    @foreach($article['data']['assets'] as $asset)
+                        <li>
+                            <a href="{{ $asset['url'] }}">{{ !empty($asset['caption']) ? $asset['caption'] . ' ('.pathinfo($asset['filename'])['extension'].')' : basename($asset['filename']) }}</a>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
         </div>
 
         <p class="pt-4">


### PR DESCRIPTION
The view already had this data but we weren't doing anything with it. This PR keeps in line with the functionality of the news manager and https://today.wayne.edu.

<img width="1016" alt="Screen Shot 2019-09-03 at 11 12 46 AM" src="https://user-images.githubusercontent.com/634788/64194302-c76a9c80-ce4c-11e9-93a2-8b57f4b26905.png">
