### PR TITLE
hotfix/6.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.11.3",
+  "version": "6.11.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/js/modules/accordion.js
+++ b/resources/js/modules/accordion.js
@@ -33,6 +33,7 @@ import 'accordion/src/accordion.js';
             },
             enabledClass: 'enabled',
             noAria: true,
+            noTransforms: true
         });
 
         // Hide all accordion content from the start so content inside it isn't part of the tabindex


### PR DESCRIPTION
Removed the usage of translate3D since on mobile phones (tested with iOS chrome/safari) the accordion would be stacked on top of each other. There is no visual change disabling this feature and using css positions instead. For reference, this issue has exisited since Base v5.0.0.