### PR TITLE
Feature/grid

### DIFF
--- a/resources/views/grid.blade.php
+++ b/resources/views/grid.blade.php
@@ -16,7 +16,7 @@
                             @image($item['relative_url'], $item['filename_alt_text'])
                         </div>
                         <div class="w-2/3 md:w-full pl-4 md:pl-0">
-                            <div class="font-bold hover:underline my-1 lg:mt-2">{{ $item['title'] }}</div>
+                            <div class="font-bold hover:underline mt-1 lg:mt-2">{{ $item['title'] }}</div>
                             <p class="text-sm">{{ $item['excerpt'] }}</p>
                         </div>
                     </a>

--- a/resources/views/grid.blade.php
+++ b/resources/views/grid.blade.php
@@ -15,8 +15,8 @@
                         <div class="w-1/3 md:w-full">
                             @image($item['relative_url'], $item['filename_alt_text'])
                         </div>
-                        <div class="w-2/3 pl-4 md:pl-0">
-                            <div class="font-bold hover:underline">{{ $item['title'] }}</div>
+                        <div class="w-2/3 md:w-full pl-4 md:pl-0">
+                            <div class="font-bold hover:underline my-1 lg:mt-2">{{ $item['title'] }}</div>
                             <p class="text-sm">{{ $item['excerpt'] }}</p>
                         </div>
                     </a>


### PR DESCRIPTION
Grid text w-2/3 is for small only, needed to be set to full for large views. Also vertical spacing around the title. We didn't catch it before because the style guide titles and excerpts are short. 

**Before**
<img width="888" alt="Screen Shot 2019-10-08 at 2 44 00 PM" src="https://user-images.githubusercontent.com/2616607/66423697-31d9a400-e9da-11e9-9f78-f0c2b9503218.png">
**After**
<img width="884" alt="Screen Shot 2019-10-08 at 2 44 07 PM" src="https://user-images.githubusercontent.com/2616607/66423703-356d2b00-e9da-11e9-861c-e02b53385729.png">

