### PR TITLE
Changing <p> to <li>

### DIFF
--- a/resources/views/profile-listing.blade.php
+++ b/resources/views/profile-listing.blade.php
@@ -35,7 +35,7 @@
                 @endif
             </li>
         @empty
-            <p>No profiles found.</p>
+            <li>No profiles found.</li>
         @endforelse
     </ul>
 @endsection


### PR DESCRIPTION
Currently "No profiles found" in list, but not a list item. Axe sees this as an error with the list structure. Changing to `<li>` ensure this is read as being in the list.