### PR TITLE
Whitelisting grid layout variables

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -63,7 +63,7 @@ mix.js('resources/js/main.js', 'public/_resources/js')
             path.join(__dirname, "node_modules/mediabox/dist/mediabox.js")
         ],
         extensions: ['html', 'js', 'php', 'vue'],
-        whitelistPatterns: [/at-/, /w-[1-5]\/[1-5]/, /(lg|md|sm)\:w-[1-5]\/[1-5]/]
+        whitelistPatterns: [/at-/, /w-[1-5]\/[1-5]/, /(sm|md|lg|xl|xxl|xxxl|mt)\:w-[1-5]\/[1-5]/]
     })
    .sourceMaps()
    .options({

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -63,7 +63,7 @@ mix.js('resources/js/main.js', 'public/_resources/js')
             path.join(__dirname, "node_modules/mediabox/dist/mediabox.js")
         ],
         extensions: ['html', 'js', 'php', 'vue'],
-        whitelistPatterns: [/at-/]
+        whitelistPatterns: [/at-/, /w-[1-5]\/[1-5]/, /(lg|md|sm)\:w-[1-5]\/[1-5]/]
     })
    .sourceMaps()
    .options({


### PR DESCRIPTION
Whitelisting grid layout sizes from 1/1-5/5 with or without breakpoints specified. 
This enables CMS users an array of column size options for their content. 