### PR TITLE
Feature/group hover updates

### DIFF
--- a/resources/views/components/featured-promo.blade.php
+++ b/resources/views/components/featured-promo.blade.php
@@ -2,7 +2,7 @@
     $featured_promo => array // ['link', 'title', 'relative_url', 'excerpt']
 --}}
 
-@if(!empty($featured_promo['link']))<a href="{{ $featured_promo['link'] }}">@endif
+@if(!empty($featured_promo['link']))<a class="group" href="{{ $featured_promo['link'] }}">@endif
     @image($featured_promo['relative_url'], $featured_promo['filename_alt_text'], 'min-w-full mt-2')
-    <p class="font-bold hover:underline pt-2">{{ $featured_promo['title'] }}</p>
+    <p class="font-bold no-underline group-hover:underline pt-2">{{ $featured_promo['title'] }}</p>
 @if(!empty($featured_promo['link']))</a>@endif

--- a/resources/views/components/video.blade.php
+++ b/resources/views/components/video.blade.php
@@ -2,7 +2,7 @@
     $video => array // [['title', 'link', 'relative_url', 'youtube_id', 'excerpt']]
 --}}
 
-@if(!empty($video['link']))<a class="no-underline hover:underline font-bold" href="{{ $video['link'] }}">@endif
+@if(!empty($video['link']))<a class="group" href="{{ $video['link'] }}">@endif
 
     <div class="relative">
         @if(!empty($video['relative_url']))
@@ -12,14 +12,16 @@
         @endif
 
         <div class="absolute inset-0 flex items-center justify-center">
-            <div class="w-1/4 opacity-50 transition transition-delay-none transition-timing-ease-in-out hover:opacity-75">
+            <div class="w-1/4 opacity-50 group-hover:opacity-75 transition-slow">
                 @svg('video-play')
             </div>
         </div>
     </div>
 
     @if(!empty($video['title']))
-        {!! $video['title'] !!}
+        <div class="no-underline group-hover:underline font-bold">
+            {!! $video['title'] !!}
+        </div>
     @endif
 
 @if(!empty($video['link']))</a>@endif


### PR DESCRIPTION
We added the 'group-hover' variants in the variants section of the tailwind.config.js file already.
This update makes use of the group-hover for the "Featured-Promo" and "Video" components when hovering on the multiple elements.

### Video:
**Before (when hovering on the title):**
<img width="478" alt="Screen Shot 2019-11-21 at 2 10 48 PM" src="https://user-images.githubusercontent.com/5089876/69370300-b53e1480-0c6b-11ea-9a81-4c0d3c283693.png">

**After (when hovering on the title):**
<img width="486" alt="Screen Shot 2019-11-21 at 2 10 17 PM" src="https://user-images.githubusercontent.com/5089876/69370356-d0a91f80-0c6b-11ea-856e-7cca1f4019c0.png">

### Featured Promo
**Before (when hovering on the image):**
<img width="471" alt="Screen Shot 2019-11-21 at 2 16 50 PM" src="https://user-images.githubusercontent.com/5089876/69370449-f3d3cf00-0c6b-11ea-8fc3-04171ca7e6aa.png">

**After (when hovering on the image):**
<img width="472" alt="Screen Shot 2019-11-21 at 2 17 02 PM" src="https://user-images.githubusercontent.com/5089876/69370477-03531800-0c6c-11ea-88b3-ca85eddc6f34.png">

