### PR TITLE
Feature/profile listing image ratio portrait by default

### DIFF
--- a/resources/views/profile-listing.blade.php
+++ b/resources/views/profile-listing.blade.php
@@ -26,7 +26,7 @@
         @forelse($profiles as $profile)
             <li class="w-full sm:w-1/2 md:w-1/3 px-4 pb-6">
                 <a href="{{ $profile['link'] }}" class="underline">
-                    <div class="block bg-cover bg-center w-full pt-full lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
+                    <div class="block bg-cover bg-center w-full pt-portrait lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
                     <span class="font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
                 </a>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,6 +88,7 @@ module.exports = {
                 '16/9': '56.35%',
                 'hero' : '36.3%',
                 'full' : '100%',
+                'portrait' : '133%',
             },
             spacing: {
                 '14' : '3.5rem',


### PR DESCRIPTION
Updated profile listing page grid images to be portrait ratio by default

### Before:
<img width="897" alt="Screen Shot 2019-11-21 at 3 04 08 PM" src="https://user-images.githubusercontent.com/5089876/69372712-3c8d8700-0c70-11ea-965b-1c98cb3681a3.png">


### After:
![image](https://user-images.githubusercontent.com/5089876/69372638-15cf5080-0c70-11ea-9224-614b234ad5da.png)
