### PR TITLE
Release/6.12.4

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -66,6 +66,10 @@ class ProfileController extends Controller
      */
     public function show(Request $request)
     {
+        if (empty($request->accessid)) {
+            abort(404);
+        }
+
         // Determine what site to pull profiles from
         $site_id = !empty($request->data['data']['profile_site_id']) ? $request->data['data']['profile_site_id'] : $request->data['site']['id'];
 

--- a/factories/Profile.php
+++ b/factories/Profile.php
@@ -33,7 +33,7 @@ class Profile implements FactoryContract
                     'Last Name' => $this->faker->lastName,
                     'Title' => $this->faker->sentence(3),
                     'Picture' => [
-                        'url' => '/styleguide/image/550x400?text='.$i,
+                        'url' => '/styleguide/image/400x533?text=400x533%20('.$i.')',
                     ],
                     'Phone' => $this->faker->phoneNumber,
                     'Email' => $this->faker->email,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.12.3",
+  "version": "6.12.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -1,15 +1,15 @@
 @extends('components.content-area')
 
 @section('content')
-    <div class="row flex flex-wrap">
+    <div class="row flex flex-wrap -mx-4">
         <div class="w-full lg:w-1/3 px-4 mt-6">
             @if(!empty($profile['data']['Picture']['url']))
-                <img src="{{ $profile['data']['Picture']['url'] }}" alt="{{ $page['title'] }}" class="sm:h-64 md:h-auto block mx-auto">
+                <img src="{{ $profile['data']['Picture']['url'] }}" alt="{{ $page['title'] }}" class="sm:h-64 lg:h-auto mx-auto lg:mx-0 block mb-4">
             @else
-                <img src="/_resources/images/no-photo.svg" alt="{{ $page['title'] }}" class="sm:h-64 md:h-auto block mx-auto">
+                <img src="/_resources/images/no-photo.svg" alt="{{ $page['title'] }}" class="sm:h-64lgg:h-auto block mx-auto lg:mx-0 mb-4">
             @endif
 
-            @include('components.page-title', ['title' => $page['title'], 'class' => 'block md:hidden'])
+            @include('components.page-title', ['title' => $page['title'], 'class' => 'block lg:hidden'])
 
             <div class="content">
                 @if(!empty($profile['data']['Title']))
@@ -47,7 +47,7 @@
         </div>
 
         <div class="w-full lg:w-2/3 px-4">
-            @include('components.page-title', ['title' => $page['title'], 'class' => 'hidden md:block'])
+            @include('components.page-title', ['title' => $page['title'], 'class' => 'hidden lg:block'])
 
             <div class="content">
                 @foreach($profile['data'] as $field=>$data)

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@
 */
 
 // Profile view
-Route::get('{any?}profile/{accessid}', 'ProfileController@show')
+Route::get('{any?}profile/{accessid?}', 'ProfileController@show')
     ->where(['any' => '.*', 'accessid' => '[a-zA-Z]{2}\d{4}']);
 
 // News listing by topic

--- a/tests/Unit/Http/Controllers/ProfileControllerTest.php
+++ b/tests/Unit/Http/Controllers/ProfileControllerTest.php
@@ -14,6 +14,22 @@ class ProfileControllerTest extends TestCase
      * @covers App\Http\Controllers\ProfileController::show
      * @test
      */
+    public function no_profile_accessid_should_404()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        // Construct the news controller
+        $this->profileController = app('App\Http\Controllers\ProfileController', []);
+
+        // Call the profile listing
+        $view = $this->profileController->show(new Request());
+    }
+
+    /**
+     * @covers App\Http\Controllers\ProfileController::__construct
+     * @covers App\Http\Controllers\ProfileController::show
+     * @test
+     */
     public function invalid_profile_should_404()
     {
         $this->expectException(NotFoundHttpException::class);
@@ -34,7 +50,10 @@ class ProfileControllerTest extends TestCase
         // Construct the news controller
         $this->profileController = app('App\Http\Controllers\ProfileController', ['profile' => $profileRepository]);
 
+        $request = new Request();
+        $request->accessid = 'aa1234';
+
         // Call the profile listing
-        $view = $this->profileController->show(new Request());
+        $view = $this->profileController->show($request);
     }
 }


### PR DESCRIPTION
- Grid template promo item text extends to the full width of the column
- Accessibility update for empty profile listing
- Print styles
- Remove footer h1 link
- New hero options
- Whitelist grid layout sizes from 1/1-5/5 for use in CMS
- Group-hover for the "Featured-Promo" and "Video" components 
- Profile listing page grid images use portrait ratio