### PR TITLE
Fix profiles index view from displaying on the profiles show view when no accessid is passed

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -66,6 +66,10 @@ class ProfileController extends Controller
      */
     public function show(Request $request)
     {
+        if (empty($request->accessid)) {
+            abort(404);
+        }
+
         // Determine what site to pull profiles from
         $site_id = !empty($request->data['data']['profile_site_id']) ? $request->data['data']['profile_site_id'] : $request->data['site']['id'];
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@
 */
 
 // Profile view
-Route::get('{any?}profile/{accessid}', 'ProfileController@show')
+Route::get('{any?}profile/{accessid?}', 'ProfileController@show')
     ->where(['any' => '.*', 'accessid' => '[a-zA-Z]{2}\d{4}']);
 
 // News listing by topic

--- a/tests/Unit/Http/Controllers/ProfileControllerTest.php
+++ b/tests/Unit/Http/Controllers/ProfileControllerTest.php
@@ -14,6 +14,22 @@ class ProfileControllerTest extends TestCase
      * @covers App\Http\Controllers\ProfileController::show
      * @test
      */
+    public function no_profile_accessid_should_404()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        // Construct the news controller
+        $this->profileController = app('App\Http\Controllers\ProfileController', []);
+
+        // Call the profile listing
+        $view = $this->profileController->show(new Request());
+    }
+
+    /**
+     * @covers App\Http\Controllers\ProfileController::__construct
+     * @covers App\Http\Controllers\ProfileController::show
+     * @test
+     */
     public function invalid_profile_should_404()
     {
         $this->expectException(NotFoundHttpException::class);
@@ -34,7 +50,10 @@ class ProfileControllerTest extends TestCase
         // Construct the news controller
         $this->profileController = app('App\Http\Controllers\ProfileController', ['profile' => $profileRepository]);
 
+        $request = new Request();
+        $request->accessid = 'aa1234';
+
         // Call the profile listing
-        $view = $this->profileController->show(new Request());
+        $view = $this->profileController->show($request);
     }
 }


### PR DESCRIPTION
The issue is when there is no `accessid` in the URL for `/profile/aa1234` then it will display out the Profile Listing view since it didn't match the route with the access id to use the show method and used the WildCardController with the index method.

Fixes the ability so that `/profile` will 404 properly since it is now going through the Profile show method due to it not having the now optional `accessid` in the URL.