### PR TITLE
Pre Push Hook

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+branch=`git rev-parse --abbrev-ref HEAD`
+
+if [[ $branch =~ release ]] || [[ $branch =~ hotfix ]]; then
+  printf "Running version checker...\n"
+
+  branch_version=$(echo "${branch}" | grep -Eo '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+')
+  version_check=$(awk "/version*(.+)${branch_version}/" package.json)
+
+  if [[ -z "$version_check" ]]; then
+      printf "Version Mismatch Error: The package.json version does not match the current branch version.\n"
+      exit 1
+  fi
+fi
+
+exit 1;


### PR DESCRIPTION
Added pre push hook to catch version mismatch (lack of version bump) before merging into live code.

The following error occurs when the package.json version is different from the branch version:

<img width="606" alt="Screen Shot 2020-02-04 at 2 16 22 PM" src="https://user-images.githubusercontent.com/3526112/73779097-32046900-475a-11ea-9296-0177ffeccda6.png">