### PR TITLE
add config:clear to the runtests to make sure we always have the latest config for the testing

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,6 +51,7 @@ yarncheck: $(YARNFILE)
 
 runtests: $(COMPOSERFILE)
 	php artisan view:clear
+	php artisan config:clear
 	php vendor/bin/phpunit
 
 phplint: $(COMPOSERFILE)


### PR DESCRIPTION
Taking over #437 

TravisCI kept trying to use REDIS when it should be using array