### PR TITLE
Profile and directory adjustments

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -54,7 +54,7 @@
     }
 
     select {
-        @apply .block .border-grey .border-solid .border .bg-white .h-10 .w-full .m-0 .mb-4 .p-2 .pr-6 .text-base .leading-normal .rounded-none;
+        @apply .block .border-grey .border .bg-white .w-full .p-2 .pr-8 .rounded-sm;
 
         appearance: none;
         transition: box-shadow 0.5s, border-color 0.25s ease-in-out;

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -12,9 +12,9 @@
 
         <div class="row flex flex-wrap -mx-4">
             @foreach($profiles as $profile)
-                <div class="w-full sm:w-1/2 md:w-1/3 px-4 pb-6">
-                    <a href="{{ $profile['link'] }}">
-                        <div class="block bg-cover bg-center w-full pt-full lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
+                <div class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 px-4 pb-6">
+                    <a href="{{ $profile['link'] }}" class="underline hover:no-underline">
+                        <div class="block bg-cover bg-center w-full pt-portrait lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
                         <span class="font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
                     </a>
 

--- a/resources/views/grid.blade.php
+++ b/resources/views/grid.blade.php
@@ -11,15 +11,17 @@
         <ul class="flex flex-wrap -mx-4">
             @foreach($grid_promos as $item)
                 <li class="w-full md:w-1/2 xl:w-1/3 px-4 pb-6">
-                    <a href="{{ $item['link'] }}" class="flex md:block">
-                        <div class="w-1/3 md:w-full">
-                            @image($item['relative_url'], $item['filename_alt_text'])
+                    @if(!empty($item['link']))<a href="{{ $item['link'] }}" class="group">@endif
+                        <div class="flex md:block">
+                            <div class="w-1/3 md:w-full">
+                                @image($item['relative_url'], $item['filename_alt_text'], 'block')
+                            </div>
+                            <div class="w-2/3 pl-4 md:p-0 md:w-full">
+                                <div class="font-bold mt-1 lg:mt-2 {{ (!empty($item['link']) ? 'underline group-hover:no-underline' : '') }}">{{ $item['title'] }}</div>
+                                <p class="text-sm text-black">{{ $item['excerpt'] }}</p>
+                            </div>
                         </div>
-                        <div class="w-2/3 md:w-full pl-4 md:pl-0">
-                            <div class="font-bold hover:underline mt-1 lg:mt-2">{{ $item['title'] }}</div>
-                            <p class="text-sm">{{ $item['excerpt'] }}</p>
-                        </div>
-                    </a>
+                    @if(!empty($item['link']))</a>@endif
                 </li>
             @endforeach
         </ul>

--- a/resources/views/profile-listing.blade.php
+++ b/resources/views/profile-listing.blade.php
@@ -5,19 +5,16 @@
 
     @if($hide_filtering == false)
         <form name="departments" method="get" class="filter formy">
-            <label for="filter-group" class="text-black">View by department:</label>
+            <label for="filter-group" class="text-black block mb-2">View by department:</label>
             <div class="row -mx-4">
-                <div class="w-5/6 px-4 inline-block relative w-64">
+                <div class="w-5/6 px-4 inline-block relative w-64 mb-6 flex items-center text-black">
+                    <svg class="fill-current h-4 w-4 absolute mr-4 right-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                     <select name="group" id="filter-group">
                         @foreach($dropdown_groups as $key=>$value)
                             <option value="{{ $key }}"@if($key == $selected_group) selected="selected"@endif>{{ $value }}</option>
                         @endforeach
                     </select>
-                    <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center p-6 text-gray-700">
-                        <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
-                      </div>
                 </div>
-
                 <div class="w-1/6 px-4">
                     <input type="submit" value="Filter" class="postfix button expanded" />
                 </div>
@@ -27,12 +24,11 @@
 
     <ul class="row flex flex-wrap -mx-4">
         @forelse($profiles as $profile)
-            <li class="w-full sm:w-1/2 md:w-1/3 px-4 pb-6">
-                <a href="{{ $profile['link'] }}" class="underline">
+            <li class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 px-4 pb-6">
+                <a href="{{ $profile['link'] }}" class="underline hover:no-underline">
                     <div class="block bg-cover bg-center w-full pt-portrait lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
                     <span class="font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
                 </a>
-
                 @if(!empty($profile['data']['Title']))
                     <span class="block text-sm">{{ $profile['data']['Title'] }}</span>
                 @endif

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,18 +84,18 @@ module.exports = {
                 'screen-xxxl': screens.xxxl,
             },
             padding: {
-                '3/4' : '75%',
+                '3/4': '75%',
                 '16/9': '56.35%',
-                'hero' : '36.3%',
-                'full' : '100%',
+                'hero': '36.3%',
+                'full': '100%',
                 'portrait' : '133%',
             },
             spacing: {
-                '14' : '3.5rem',
+                '14': '3.5rem',
             },
             margin: {
-                '17' : '4.25rem',
-                '19' : '4.75rem',
+                '17': '4.25rem',
+                '19': '4.75rem',
             },
             minHeight: {
                 'hero': '36.3vw',
@@ -105,8 +105,11 @@ module.exports = {
                 'grey': '0 7px 0 '+ colors.grey +', 0 14px 0 '+ colors.grey,
             },
             opacity: {
-                '20' : '.20',
-                '65' : '.65',
+                '20': '.20',
+                '65': '.65',
+            },
+            inset: {
+                '4': '1rem',
             },
         },
     },


### PR DESCRIPTION
* Corrected the SVG drop down arrow on the profile listing page
* Changed the profile listing and directory templates to display 4 profiles per row instead of three
    * Individuals have a hard time providing quality images for that space
    * More users per line, appears more like a yearbook
* Directory template uses portrait size instead of square
* Reconfigured the grid template
    * Each element is wrapped in an a tag if a link is present 
    * Only the title is green and underlined if it is a link, instead of all the text being green
* Extended inset in tailwind.js, ex: right-4 = 1rem from the right

|Before|After|
|-----|-----|
|![directory-og](https://user-images.githubusercontent.com/2616607/74982926-098b9880-5403-11ea-9223-f24f8d192a3c.jpg)|![directory](https://user-images.githubusercontent.com/2616607/74983052-4eafca80-5403-11ea-9007-547c49243739.jpg)|
|![profile-og](https://user-images.githubusercontent.com/2616607/74983073-5a02f600-5403-11ea-920a-1ff78823792f.jpg)|![profile-listing](https://user-images.githubusercontent.com/2616607/74983090-60916d80-5403-11ea-83b5-bf591a697ffa.jpg)|
|![grid-og](https://user-images.githubusercontent.com/2616607/74983115-6edf8980-5403-11ea-9276-5bc2ad5cefcf.jpg)|![grid](https://user-images.githubusercontent.com/2616607/74983120-730ba700-5403-11ea-80bd-d69a097725e5.jpg)|



