### PR TITLE
blockquote style

### DIFF
--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -29,42 +29,35 @@
     }
 
     blockquote {
-        padding: 3.5rem 1.5rem 3rem;
-        margin: 2.5rem 0;
-        font-weight: bold;
-        font-size: 1.25rem;
-        position: relative;
-        text-align: center;
+        @apply .pt-16 .px-6 .pb-12 .my-10 .relative .text-center .text-xl .font-bold;
 
         @screen mt {
-            padding: 3.5rem 6rem 3rem;
+            @apply .px-20;
         }
     }
 
     blockquote::before,
     blockquote::after {
+        @apply .block .px-6 .absolute .text-4xl;
+
         content: '';
-        display: block;
         font-family: Arial Black, sans-serif;
-        font-size: 2.5rem;
-        padding: 0 1.5rem;
-        position: absolute;
     }
 
     blockquote::before {
+        @apply .top-0 .border-b .border-black;
+
         content: "\201C";
-        border-bottom: 1px solid black;
         line-height: 0.5em;
-        top: 0;
         left: 50%;
         transform: translateX(-50%);
     }
 
     blockquote::after {
+        @apply .bottom-0 .border-t .border-black .leading-none;
+
         content: "\201D";
-        border-top: 1px solid black;
-        line-height: 1em;
-        bottom: -0.75rem;
+        bottom: -1rem;
         left: 50%;
         transform: translateX(-50%);
     }

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -29,18 +29,44 @@
     }
 
     blockquote {
-        @apply .pt-6 .pb-2 .pl-16 .pr-6 .my-8 .text-xl .text-black .relative .bg-transparent .flex;
+        padding: 3.5rem 1.5rem 3rem;
+        margin: 2.5rem 0;
+        font-weight: bold;
+        font-size: 1.25rem;
+        position: relative;
+        text-align: center;
 
         @screen mt {
-            @apply .text-2xl;
+            padding: 3.5rem 6rem 3rem;
         }
+    }
 
-        &::before {
-            @apply .absolute .inset-0 .mt-4 .leading-none .text-grey-lighter .pr-1 .font-serif;
+    blockquote::before,
+    blockquote::after {
+        content: '';
+        display: block;
+        font-family: Arial Black, sans-serif;
+        font-size: 2.5rem;
+        padding: 0 1.5rem;
+        position: absolute;
+    }
 
-            content: '\201C'; // Double quote
-            font-size: 85pt;
-        }
+    blockquote::before {
+        content: "\201C";
+        border-bottom: 1px solid black;
+        line-height: 0.5em;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    blockquote::after {
+        content: "\201D";
+        border-top: 1px solid black;
+        line-height: 1em;
+        bottom: -0.75rem;
+        left: 50%;
+        transform: translateX(-50%);
     }
 
     // Tailwind preflight sets images to block

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -45,7 +45,7 @@
     }
 
     blockquote::before {
-        @apply .top-0 .border-b .border-black;
+        @apply .top-0 .border-b;
 
         content: "\201C";
         line-height: 0.5em;
@@ -54,7 +54,7 @@
     }
 
     blockquote::after {
-        @apply .bottom-0 .border-t .border-black .leading-none;
+        @apply .bottom-0 .border-t .leading-none;
 
         content: "\201D";
         bottom: -1rem;

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -29,7 +29,7 @@
     }
 
     blockquote {
-        @apply .pt-16 .px-6 .pb-12 .my-10 .relative .text-center .text-xl .font-bold;
+        @apply .pt-12 .px-6 .pb-8 .my-10 .relative .text-center .text-xl .font-bold;
 
         @screen mt {
             @apply .px-20;


### PR DESCRIPTION
Solving the issue of having only an open quote with no closing quote.
**Before**
<img width="511" alt="image" src="https://user-images.githubusercontent.com/2616607/78838559-6e577e00-79c4-11ea-9143-bd9d8eeed696.png">
**After**
<img width="488" alt="image" src="https://user-images.githubusercontent.com/2616607/78838618-92b35a80-79c4-11ea-9818-cf4e2191ab92.png">
**In context**
![image](https://user-images.githubusercontent.com/2616607/78838470-3ea87600-79c4-11ea-92d7-bb9fca1dc7eb.png)
