### PR TITLE
A11y fixes for off-canvas

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -53,6 +53,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Top Menu Label for Off-canvas
+    |--------------------------------------------------------------------------
+    |
+    | When there is a top menu and a local page menu, this is the label the
+    | will be give to the top menu when the off-canvas menu is expanded.
+    | It can be changed here based on context, ex. "CLAS menu".
+    |
+    */
+    'top_menu_label' => 'Main menu',
+
+    /*
+    |--------------------------------------------------------------------------
     | Homepage Menu Enabled
     |--------------------------------------------------------------------------
     |

--- a/resources/js/modules/slideout.js
+++ b/resources/js/modules/slideout.js
@@ -75,6 +75,7 @@ import Slideout from 'slideout/dist/slideout.js';
 
         // Set that it was expanded
         document.querySelector('.menu-toggle').setAttribute('aria-expanded', 'true');
+        document.querySelector('.menu-toggle').setAttribute('aria-label', 'Close menu');
     });
 
     slideout.on('close', function () {
@@ -95,6 +96,10 @@ import Slideout from 'slideout/dist/slideout.js';
 
         // Set that it was closed
         document.querySelector('.menu-toggle').setAttribute('aria-expanded', 'false');
+        document.querySelector('.menu-toggle').setAttribute('aria-label', 'Menu');
+
+        // Return focus to the menu icon
+        document.querySelector('.menu-toggle').focus();
     });
 
     // Toggle the appropriate classes for slideout based on the menu icon's visibility state

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -16,7 +16,7 @@
                     <div class="slideout-main-menu mt:hidden">
                         <ul class="main-menu mb-2">
                             <li>
-                                <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">Main Menu</a>
+                                <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">{{ config('base.top_menu_label') }}</a>
 
                                 {!! $top_menu_output !!}
                             </li>


### PR DESCRIPTION
Three accessibility improvements.

1. When the off-canvas menu is open, the "Menu" button is renamed to "Close" since the keyboard is trapped in the menu until the user closes or hits "Esc"
1. The "Esc" key now returns the user back to the menu button that expanded the off-canvas menu instead of being hidden off-screen
1. For sites that have a top menu and a local page menu the "Main menu" in the off-canvas can be confusing, this moves it to a config value so it can be changed based on the context, ex. "CLAS menu"

| Before | After |
|--------|--------|
| <img width="694" alt="Screen Shot 2020-07-30 at 4 02 37 PM" src="https://user-images.githubusercontent.com/37359/88969716-3af47400-d27f-11ea-9aed-544b35cfe49b.png"> | <img width="666" alt="Screen Shot 2020-07-30 at 4 02 14 PM" src="https://user-images.githubusercontent.com/37359/88969749-3fb92800-d27f-11ea-8262-a87d5f3e8c45.png"> |