### PR TITLE
Feature/revert blockquote

### DIFF
--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -29,37 +29,15 @@
     }
 
     blockquote {
-        @apply .pt-12 .px-6 .pb-8 .my-10 .relative .text-center .text-xl .font-bold;
+        @apply .ml-8 .my-8 .border-l-4 .border-grey .pl-4 .pt-2 .pb-1;
 
-        @screen mt {
-            @apply .px-20;
+        > *:last-child {
+            @apply .mb-2;
         }
-    }
 
-    blockquote::before,
-    blockquote::after {
-        @apply .block .px-6 .absolute .text-4xl;
-
-        content: '';
-        font-family: Arial Black, sans-serif;
-    }
-
-    blockquote::before {
-        @apply .top-0 .border-b;
-
-        content: "\201C";
-        line-height: 0.5em;
-        left: 50%;
-        transform: translateX(-50%);
-    }
-
-    blockquote::after {
-        @apply .bottom-0 .border-t .leading-none;
-
-        content: "\201D";
-        bottom: -1rem;
-        left: 50%;
-        transform: translateX(-50%);
+        cite {
+            @apply .block .mb-4;
+        }
     }
 
     // Tailwind preflight sets images to block

--- a/styleguide/Views/styleguide.blade.php
+++ b/styleguide/Views/styleguide.blade.php
@@ -160,14 +160,16 @@
         <h2>Blockquote</h2>
 
         <blockquote>
-            <p>{{ $faker->paragraph(10) }}</p>
+            <p>&ldquo;{{ $faker->paragraph(10) }}&rdquo;</p>
+            <p>&ldquo;{{ $faker->paragraph(4) }}&rdquo;</p>
+            <cite>&mdash; {{ $faker->Name }}</cite>
         </blockquote>
-
 
         <pre class="bg-grey-lightest overflow-scroll p-4" tabindex="0">
         {!! htmlspecialchars('
 <blockquote>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."</p>
+    <cite>Name or citation</cite>
 </blockquote>') !!}
         </pre>
 


### PR DESCRIPTION
## Reason for change
* Concluded we would need additional elements or images beyond before/after pseudo elements to make a complete fancy quote style
* Fancy quote styles wil be additional beyond what's default in content, either designed and available through the components area of the styleguide in the future or designed per site 
* Reverting back to a web-default blockquote approach, but included cite tags as mentioned in a previous PR 

Before | After
-- | --
![blockquote-before](https://user-images.githubusercontent.com/2616607/89055741-f1606380-d328-11ea-82aa-c78c963e2b50.jpg)|![blockquote-after](https://user-images.githubusercontent.com/2616607/89055752-f58c8100-d328-11ea-99c5-5b724cac8b08.jpg)


