### PR TITLE
displaying contents of main menu when there is no $site_menu_output

### DIFF
--- a/resources/js/modules/slideout-main-menu.js
+++ b/resources/js/modules/slideout-main-menu.js
@@ -3,7 +3,13 @@
 
     // Hide the main menu to start
     if(document.querySelector('#menu .menu-top') != null) {
-        document.querySelector('#menu .menu-top').classList.add('hidden');
+        // Add .hide to .menu-top when it's in .slideout-main-menu
+        if(document.querySelector('#menu .slideout-main-menu') != null) {
+            document.querySelector('#menu .menu-top').classList.add('hidden');
+        } else {
+            // Add .main-menu styling class
+            document.querySelector('#menu .menu-top').classList.add('main-menu');
+        }
     }
 
     // Add the arrow icons to toggle the main menu

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -13,15 +13,18 @@
         <div class="mt:w-1/4 mt:px-4 mt:block {{ $show_site_menu === false ? ' mt:hidden' : '' }}">
             <nav id="menu" aria-label="Page menu" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu)
-                    <div class="slideout-main-menu mt:hidden">
-                        <ul class="main-menu mb-2">
-                            <li>
-                                <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">{{ config('base.top_menu_label') }}</a>
-
-                                {!! $top_menu_output !!}
-                            </li>
-                        </ul>
-                    </div>
+                    @if(!empty($site_menu_output))
+                        <div class="slideout-main-menu mt:hidden">
+                            <ul class="main-menu mb-2">
+                                <li>
+                                    <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">{{ config('base.top_menu_label') }}</a>
+                                    {!! $top_menu_output !!}
+                                </li>
+                            </ul>
+                        </div>
+                    @else
+                        {!! $top_menu_output !!}
+                    @endif
                 @endif
 
                 @if(!empty($site_menu_output))


### PR DESCRIPTION
Fixing weird edge case where the main menu is collapsed on mobile when: 1) the top menu is enabled and 2) there is no site menu.