### PR TITLE
Add back the default cache store for file

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -33,6 +33,11 @@ return [
             'driver' => 'array',
         ],
 
+        'file' => [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/data'),
+        ],
+
         'redis' => [
             'driver' => 'redis',
             'connection' => 'default',


### PR DESCRIPTION
add back in the default file cache store otherwise something errors on base that is trying to access the file store as a fallback but it doesn't exist when on production.

[2020-09-10 20:48:00] production.ERROR: Cache store [file] is not defined. {"exception":"[object] (InvalidArgumentException(code: 0): Cache store [file] is not defined.