### PR TITLE
Error handler was erroring...

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace App\Exceptions;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Support\Facades\View;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -51,7 +52,7 @@ class Handler extends ExceptionHandler
     {
         // Add custom errors when debug is not enabled
         if (config('app.debug') == false) {
-            if (View::exists('errors.'.$exception->getStatusCode())) {
+            if ($exception instanceof HttpException && View::exists('errors.'.$exception->getStatusCode())) {
                 return response(view('errors.'.$exception->getStatusCode(), compact('request')), $exception->getStatusCode());
             } else {
                 return response(view('errors.500', compact('request')), 500);


### PR DESCRIPTION
`getStatusCode()` does not exist in php core Exception but within the Symfony HttpException, since we only have custom views for HTTP error codes we can rely on making sure the exception is an instance of HttpException otherwise give it a standard 500 error view