### PR TITLE
adding tailwind float classes to the float:none

### DIFF
--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -53,7 +53,9 @@
             @apply .block .my-0 .mx-auto;
 
             &[style*="float:right"],
-            &[style*="float:left"] {
+            &[style*="float:left"],
+            &.float-right,
+            &.float-left {
                 float: none !important;
             }
         }


### PR DESCRIPTION
Since we're intentionally setting "float:none" when the user inlines "style=float:none", we should also be overriding the float-right and float-left classes from tailwind.