### PR TITLE
skipping surtitle in menu-top when surtitle_disabled is true

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -268,6 +268,7 @@ return [
             //         ],
             //     ],
             //     'callbacks' => [],
+            //     'surtitle_disabled' => null,
             // ],
         ],
     ],

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -5,7 +5,7 @@
 <div class="menu-top-container bg-green-dark print:bg-transparent">
     <div class="row flex">
         <div class="flex-grow mx-4 py-2" data-short-title="{{ $site['short-title'] }}">
-            @if(config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null))
+            @if((config('base.surtitle') !== null && ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) || ($site['parent']['id'] !== null && config('base.surtitle') !== null)) && (!config('base.global.sites.' . $site['id'] . '.surtitle_disabled')))
                 <h1 class="text-base mb-0 font-normal leading-tight">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black">{{ config('base.surtitle') }}</a>
                 </h1>


### PR DESCRIPTION
If a subsite has the property surtitle_disabled set to true, the surtitle will not show in menu-top.blade.php.