### PR TITLE
Feature/directory order by group

### DIFF
--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -32,7 +32,11 @@ class DirectoryController extends Controller
     {
         $site_id = !empty($request->data['data']['profile_site_id']) ? $request->data['data']['profile_site_id'] : $request->data['site']['id'];
 
-        $profiles = $this->profile->getProfilesByGroup($site_id);
+        if (!empty($request->data['data']['profile_group_id'])) {
+            $profiles = $this->profile->getProfilesByGroupOrderPiped($site_id, $request->data['data']['profile_group_id']);
+        } else {
+            $profiles = $this->profile->getProfilesByGroup($site_id);
+        }
 
         return view('directory', merge($request->data, $profiles));
     }

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -124,6 +124,8 @@ class ProfileRepository implements ProfileRepositoryContract
 
         $group_order = explode('|', $groups);
 
+        $profiles = [];
+
         // Retain the order of the groups as they were piped in
         foreach ($group_order as $group) {
             foreach ($profile_listing['profiles'] as $profile) {

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -118,6 +118,27 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
+    public function getProfilesByGroupOrderPiped($site_id, $groups)
+    {
+        $profile_listing = $this->getProfiles($site_id);
+
+        $group_order = explode('|', $groups);
+
+        // Retain the order of the groups as they were piped in
+        foreach ($group_order as $group) {
+            foreach ($profile_listing['profiles'] as $profile) {
+                if (array_key_exists($group, $profile['groups'])) {
+                    $profiles['profiles'][$profile['groups'][$group]][] = $profile;
+                }
+            }
+        }
+
+        return $profiles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDropdownOptions($selected_group = null, $forced_profile_group_id = null)
     {
         // Default Options

--- a/resources/views/directory.blade.php
+++ b/resources/views/directory.blade.php
@@ -7,24 +7,28 @@
         {!! $page['content']['main'] !!}
     </div>
 
-    @forelse($profiles as $key => $profiles)
-        <h2>{{ $key }}</h2>
+    @if(!empty($profiles))
+        @forelse($profiles as $key => $profiles)
+            <h2>{{ $key }}</h2>
 
-        <div class="row flex flex-wrap -mx-4">
-            @foreach($profiles as $profile)
-                <div class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 px-4 pb-6">
-                    <a href="{{ $profile['link'] }}" class="underline hover:no-underline">
-                        <div class="block bg-cover bg-center w-full pt-portrait lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
-                        <span class="font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
-                    </a>
+            <div class="row flex flex-wrap -mx-4">
+                @foreach($profiles as $profile)
+                    <div class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 px-4 pb-6">
+                        <a href="{{ $profile['link'] }}" class="underline hover:no-underline">
+                            <div class="block bg-cover bg-center w-full pt-portrait lazy mb-1" data-src="{{ $profile['data']['Picture']['url'] ?? '/_resources/images/no-photo.svg' }}"></div>
+                            <span class="font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</span>
+                        </a>
 
-                    @if(!empty($profile['data']['Title']))
-                        <span class="block text-sm">{{ $profile['data']['Title'] }}</span>
-                    @endif
-                </div>
-            @endforeach
-        </div>
-    @empty
+                        @if(!empty($profile['data']['Title']))
+                            <span class="block text-sm">{{ $profile['data']['Title'] }}</span>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        @empty
+            <p>No profiles found.</p>
+        @endforelse
+    @else
         <p>No profiles found.</p>
-    @endforelse
+    @endif
 @endsection

--- a/styleguide/Pages/DirectoryOrdered.php
+++ b/styleguide/Pages/DirectoryOrdered.php
@@ -13,7 +13,7 @@ class DirectoryOrdered extends Page
             'page' => [
                 'controller' => 'DirectoryController',
                 'title' => 'Directory ordered',
-                'id' => 101110,
+                'id' => 101112,
             ],
             'data' => [
                 'profile_group_id' => '0|1',

--- a/styleguide/Pages/DirectoryOrdered.php
+++ b/styleguide/Pages/DirectoryOrdered.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class DirectoryOrdered extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'DirectoryController',
+                'title' => 'Directory ordered',
+                'id' => 101110,
+            ],
+            'data' => [
+                'profile_group_id' => '0|1',
+            ],
+        ]);
+    }
+}

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -118,10 +118,10 @@
                 "relative_url": "/styleguide/grid",
                 "submenu": []
             },
-            "101110": {
-                "menu_item_id": "101110",
+            "101112": {
+                "menu_item_id": "101112",
                 "is_active": "1",
-                "page_id": "101110",
+                "page_id": "101112",
                 "target": "",
                 "display_name": "Directory ordered",
                 "class_name": "",

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -117,6 +117,16 @@
                 "class_name": "",
                 "relative_url": "/styleguide/grid",
                 "submenu": []
+            },
+            "101110": {
+                "menu_item_id": "101110",
+                "is_active": "1",
+                "page_id": "101110",
+                "target": "",
+                "display_name": "Directory ordered",
+                "class_name": "",
+                "relative_url": "/styleguide/directoryordered",
+                "submenu": []
             }
         }
     },

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -266,9 +266,7 @@ class ProfileRepositoryTest extends TestCase
 
         $groups = collect($return_user_listing)->map(function ($item) {
             return array_shift($item['groups']);
-        })->unique()->toArray();
-
-        krsort($groups);
+        })->unique()->reverse()->toArray();
 
         $piped_groups = implode('|', array_keys($groups));
 

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -254,4 +254,38 @@ class ProfileRepositoryTest extends TestCase
             $this->assertTrue(array_key_exists($item['display_name'], $profiles['profiles']));
         });
     }
+
+    /**
+     * @covers App\Repositories\ProfileRepository::getProfilesByGroupOrderPiped
+     * @test
+     */
+    public function profile_group_ids_should_return_ordered_array()
+    {
+        // Mock the user listing
+        $return_user_listing = app('Factories\Profile')->create(10);
+
+        $groups = collect($return_user_listing)->map(function ($item) {
+            return array_shift($item['groups']);
+        })->unique()->toArray();
+
+        krsort($groups);
+
+        $piped_groups = implode('|', array_keys($groups));
+
+        $return_user_listing = collect($return_user_listing)->mapWithKeys(function ($item, $key) use ($groups) {
+            $group_id = array_search($item['groups'][0], $groups);
+            $item['groups'] = [$group_id => $item['groups'][0]];
+
+            return [$key => $item];
+        });
+
+        $wsuApi = Mockery::mock('Waynestate\Api\Connector');
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.listing', Mockery::type('array'))->once()->andReturn($return_user_listing);
+
+        $wsuApi->shouldReceive('nextRequestProduction')->once();
+
+        $profiles = app('App\Repositories\ProfileRepository', ['wsuApi' => $wsuApi])->getProfilesByGroupOrderPiped($this->faker->numberBetween(1, 10), $piped_groups);
+
+        $this->assertEquals(array_values($groups), array_values(array_keys($profiles['profiles'])));
+    }
 }


### PR DESCRIPTION
Giving the users the ability to display only certain groups on a directory page, as well as choose the order those groups are displayed in. Works non-invasively in the standard directory template (as in, if you don't supply the appropriate custom fields, it defaults to the normal/existing template).

![directory-order-pipe](https://user-images.githubusercontent.com/46427222/97462489-29217c00-1915-11eb-93c0-9c0342827293.png)
