### PR TITLE
Under menu buttons move to content area on small screen

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -17,3 +17,4 @@ import './modules/accordion';
 import './modules/slideout';
 import './modules/slideout-main-menu';
 import './modules/carousel';
+import './modules/under-menu';

--- a/resources/js/modules/under-menu.js
+++ b/resources/js/modules/under-menu.js
@@ -1,0 +1,27 @@
+(function () {
+    "use strict";
+    const menu_button = document.querySelector(".menu-toggle");
+
+    // Only move the under menu buttons if the menu is hidden 
+    if (menu_button.offsetHeight !== 0) {
+        const under_menu_dom = document.querySelector(".under-menu");
+        const body_content = document.querySelector("#content .content");
+
+        // If the elements exist
+        if (under_menu_dom && body_content) {
+
+            // Remove the visible bullets
+            let under_menu_list = under_menu_dom.querySelector("ul");
+            under_menu_list.setAttribute("style", "list-style:none;margin:0;");
+
+            // Inject the elements into the page
+            const first_content_p = body_content.getElementsByTagName("p");
+
+            if (first_content_p.length > 0) {
+                first_content_p[0].after(under_menu_list);
+            } else {
+                body_content.appendChild(under_menu_list);
+            }
+        }
+    }
+})();

--- a/resources/scss/components/_button.scss
+++ b/resources/scss/components/_button.scss
@@ -1,5 +1,5 @@
 .button {
-    @apply .inline-block .align-middle .mb-2 .px-4 .py-2 .rounded .text-center .bg-grey-lighter .text-green .text-sm .cursor-pointer .font-bold;
+    @apply .inline-block .align-middle .mb-2 .px-4 .py-2 .rounded .text-center .bg-grey-lighter .text-green .text-sm .cursor-pointer .font-bold .no-underline;
 
     text-shadow: none;
 

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -156,7 +156,7 @@
     }
 
     // All content links
-    a:not(.button) {
+    a:not(.button, .content-button) {
         @apply .underline;
 
         &:hover {

--- a/resources/views/components/button-bg-image-dark.blade.php
+++ b/resources/views/components/button-bg-image-dark.blade.php
@@ -3,7 +3,7 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-cover bg-green-darkest overflow-hidden" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-cover bg-green-darkest overflow-hidden my-2" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
         <div class="absolute inset-0 p-4 rounded bg-green-darkest opacity-65"></div>
         <div class="absolute inset-0 p-4 flex items-center">
             <div class="min-w-full text-lg xl:text-xl font-bold text-white leading-tight text-center">{{ $button['title'] }}</div>

--- a/resources/views/components/button-bg-image-light.blade.php
+++ b/resources/views/components/button-bg-image-light.blade.php
@@ -3,7 +3,7 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-grey-lighter bg-cover overflow-hidden" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}');">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-grey-lighter bg-cover overflow-hidden my-2" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}');">
         <div class="absolute inset-0 rounded bg-white opacity-65"></div>
         <div class="absolute inset-0 p-4 flex items-center">
             <div class="min-w-full text-lg xl:text-xl font-bold text-black leading-tight text-center">{{ $button['title'] }}</div>

--- a/resources/views/components/button-icon-dark.blade.php
+++ b/resources/views/components/button-icon-dark.blade.php
@@ -3,13 +3,13 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['secondary_relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-gradient-green hover:bg-gradient-green">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-gradient-green hover:bg-gradient-green">
         <div class="min-w-full flex p-3 xl:p-4 @if(!empty($button['excerpt'])) items-top @else items-center @endif">
             <div class="w-1/6">
                 @image($button['secondary_relative_url'], $button['secondary_alt_text'], 'block')
             </div>
             <div class="w-5/6 pl-2 xl:pl-4">
-                <div class="block text-md xl:text-xl font-bold text-white leading-tight">{{ $button['title'] }}</div>
+                <div class="block text-xl font-bold text-white leading-tight">{{ $button['title'] }}</div>
                 @if(!empty($button['excerpt']))
                     <div class="leading-tight text-sm text-white pb-1">{{ $button['excerpt'] }}</div>
                 @endif

--- a/resources/views/components/button-icon-light.blade.php
+++ b/resources/views/components/button-icon-light.blade.php
@@ -3,13 +3,13 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['secondary_relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-grey-lighter hover:bg-grey-lightest overflow-hidden">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-grey-lighter hover:bg-grey-lightest overflow-hidden">
         <div class="min-w-full flex p-3 xl:p-4 @if(!empty($button['excerpt'])) items-top @else items-center @endif">
             <div class="w-1/6">
                 @image($button['secondary_relative_url'], $button['secondary_alt_text'], 'block')
             </div>
             <div class="w-5/6 pl-2 xl:pl-4">
-                <div class="block text-md xl:text-xl font-bold text-black leading-tight">{{ $button['title'] }}</div>
+                <div class="block text-xl font-bold text-black leading-tight">{{ $button['title'] }}</div>
                 @if(!empty($button['excerpt']))
                     <div class="leading-tight text-sm text-black pb-1">{{ $button['excerpt'] }}</div>
                 @endif

--- a/resources/views/components/button-svg-overlay-dark.blade.php
+++ b/resources/views/components/button-svg-overlay-dark.blade.php
@@ -3,7 +3,7 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['relative_url']) && !empty($button['secondary_relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-cover bg-green-darkest" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-cover bg-green-darkest my-2" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
         <div class="absolute inset-0 p-4 rounded bg-green-darkest opacity-65"></div>
         <div class="absolute min-w-full inset-0 rounded">
             @image($button['secondary_relative_url'], $button['secondary_alt_text'])

--- a/resources/views/components/button-svg-overlay-light.blade.php
+++ b/resources/views/components/button-svg-overlay-light.blade.php
@@ -3,7 +3,7 @@
 --}}
 
 @if(!empty($button['link']) && !empty($button['relative_url']) && !empty($button['secondary_relative_url']))
-    <a href="{{ $button['link'] }}" class="block min-w-full relative rounded bg-cover bg-grey-lighter" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
+    <a href="{{ $button['link'] }}" class="content-button block min-w-full relative rounded bg-cover bg-grey-lighter my-2" style="padding-top: 36.39%; background-image: url('{{ $button['relative_url'] }}'); ">
         <div class="absolute inset-0 p-4 rounded bg-white opacity-65"></div>
         <div class="absolute min-w-full inset-0 rounded">
             @image($button['secondary_relative_url'], $button['secondary_alt_text'])

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -40,7 +40,7 @@
                 @yield('below_menu')
 
                 @if(!empty($under_menu))
-                    @include('components.under-menu', ['buttons' => $under_menu])
+                    @include('components.under-menu', ['buttons' => $under_menu, 'class' => 'under-menu'])
                 @endif
             </nav>
         </div>


### PR DESCRIPTION
## Reason for change

Based on the [success of an A/B test](https://web-team-blog.wayne.edu/2020/11/16/always-be-evaluating/), this puts the change in place for all future sites going forward.

Eventually, it would be nice to have a CKEditor extension to add a hidden HTML element within the page where the buttons could go based on the content.

This implementation injects the buttons after the first paragraph in the content area, if there are no paragraphs in the content area, it puts the buttons at the bottom of the page. This hits the 80% mark for sites across campus.

## Reminders

- Update package version number
- Frontend accessibility check
- Frontend view on multiple screen sizes
- Styleguide example in place
- New functionality covered by tests

## Demo

| Desktop | Small screen |
|--------|--------|
| <img width="447" alt="Screen Shot 2020-11-19 at 3 08 53 PM" src="https://user-images.githubusercontent.com/37359/99807359-6d1b3180-2b0d-11eb-8688-00cf127c5839.png"> | <img width="455" alt="Screen Shot 2020-11-19 at 3 08 33 PM" src="https://user-images.githubusercontent.com/37359/99807380-75736c80-2b0d-11eb-9e75-a2ef4294f0d5.png"> |
