### PR TITLE
Feature/enhancing print styles

### DIFF
--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -68,12 +68,3 @@ h6 {
 a.text-white:-moz-focusring {
     outline-color: #000;
 }
-
-// Global print styles
-@screen print {
-    .content a[href]::after {
-        @apply .text-sm .font-normal;
-
-        content: " (" attr(href) ") ";
-    }
-}

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -29,7 +29,7 @@
     }
 
     .wsufooter {
-        background: transparent;
+        @apply .bg-transparent;
     }
 
     .pt-hero {
@@ -42,7 +42,7 @@
 
     @responsive {
         .bg-gradient-darkest::before {
-            background-image: none;
+            @apply .bg-none;
         }
     }
 
@@ -58,22 +58,11 @@
         }
 
         a.button {
-            padding: 0;
-            background-color: transparent;
-            color: #000;
-            border-radius: 0;
-            text-align: left;
-            text-decoration: underline;
-            font-size: 1rem;
+            @apply .p-0 .bg-transparent .text-black .rounded-none .text-left .text-base .underline .font-normal;
         }
 
         figure figcaption {
-            font-size: 1rem;
-            color: #000;
+            @apply .text-base .text-black;
         }
-    }
-
-    .news-item .addthis_sharing_toolbox {
-        display: none;
     }
 }

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -22,12 +22,11 @@
         content: " (" attr(href) ") ";
     }
 
+    abbr[title]::after {
+        content: " (" attr(title) ") ";
+    }
+
     .content {
-
-        abbr[title]::after {
-            content: " (" attr(title) ") ";
-        }
-
         pre {
             @apply .border .bg-transparent .overflow-auto .whitespace-pre-wrap;
 

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -1,0 +1,60 @@
+// Global print styles
+@screen print {
+    *,
+    *::before,
+    *::after {
+        color: #000 !important;
+        background-color: transparent !important;
+        border-color: #000 !important;
+    }
+
+    .wsufooter {
+        background: transparent;
+    }
+
+    .pt-hero {
+        padding-top: 0 !important;
+    }
+
+    a[href]::after {
+        @apply .text-sm .font-normal;
+
+        content: " (" attr(href) ") ";
+    }
+
+    .content {
+
+        abbr[title]::after {
+            content: " (" attr(title) ") ";
+        }
+
+        pre {
+            @apply .border .bg-transparent .overflow-auto .whitespace-pre-wrap;
+
+            word-wrap: break-word;
+        }
+
+        hr {
+            @apply .border-black;
+        }
+
+        a.button {
+            padding: 0;
+            background-color: transparent;
+            color: #000;
+            border-radius: 0;
+            text-align: left;
+            text-decoration: underline;
+            font-size: 1rem;
+        }
+
+        figure figcaption {
+            font-size: 1rem;
+            color: #000;
+        }
+    }
+
+    .news-item .addthis_sharing_toolbox {
+        display: none;
+    }
+}

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -8,6 +8,26 @@
         border-color: #000 !important;
     }
 
+    a[href]::after {
+        @apply .font-normal;
+
+        content: " (" attr(href) ") ";
+    }
+
+    .wsuwordmark a[href]::after {
+        content: '';
+    }
+
+    .menu-top-container {
+        &.fixed {
+            @apply .relative;
+        }
+
+        h1 > a[href]::after {
+            content: '';
+        }
+    }
+
     .wsufooter {
         background: transparent;
     }
@@ -16,14 +36,14 @@
         padding-top: 0 !important;
     }
 
-    a[href]::after {
-        @apply .text-sm .font-normal;
-
-        content: " (" attr(href) ") ";
-    }
-
     abbr[title]::after {
         content: " (" attr(title) ") ";
+    }
+
+    @responsive {
+        .bg-gradient-darkest::before {
+            background-image: none;
+        }
     }
 
     .content {

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -28,8 +28,8 @@
 @import "components/text-shadow";
 @import "components/visually-hidden";
 @import "components/table-of-contents";
+@import "components/print";
 
 // Tailwind
 @tailwind components;
 @tailwind utilities;
-

--- a/resources/views/article.blade.php
+++ b/resources/views/article.blade.php
@@ -6,7 +6,7 @@
     <div class="news-item">
         <time class="block text-sm text-grey-darker mb-6" datetime="{{ $article['data']['article_date'] }}">{{ apdatetime(date('F j, Y', strtotime($article['data']['article_date']))) }}</time>
 
-        <div class="addthis_sharing_toolbox mb-4"></div>
+        <div class="addthis_sharing_toolbox mb-4 print:hidden"></div>
 
         <div class="content mt:text-xl">
             {!! $article['data']['body'] !!}

--- a/resources/views/article.blade.php
+++ b/resources/views/article.blade.php
@@ -24,7 +24,7 @@
             @endif
         </div>
 
-        <p class="pt-4">
+        <p class="pt-4 print:hidden">
             <a href="/{{ ($site['subsite-folder'] !== null) ? $site['subsite-folder'] : '' }}{{ config('base.news_listing_route') }}" class="button">&larr; Back to listing</a>
         </p>
     </div>

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 {{--
     $breadcrumbs => array // ['display_name', 'relative_url']
 --}}
-<nav class="mt-6 print:mt-0 mb-2" aria-label="Breadcrumbs">
+<nav class="mt-6 print:hidden mb-2" aria-label="Breadcrumbs">
     <ul class="text-sm">
         @foreach($breadcrumbs as $key=>$crumb)
             @if($key == 0)

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -10,7 +10,7 @@
     @endif
 
     @if(!in_array($page['controller'], config('base.full_width_controllers')))<div class="row mt:flex">@endif
-        <div class="mt:w-1/4 mt:px-4 mt:block {{ $show_site_menu === false ? ' mt:hidden' : '' }}">
+        <div class="mt:w-1/4 mt:px-4 mt:block print:hidden {{ $show_site_menu === false ? ' mt:hidden' : '' }}">
             <nav id="menu" aria-label="Page menu" tabindex="-1">
                 @if(!empty($top_menu_output) && $site_menu !== $top_menu && config('base.top_menu_enabled'))
                     @if(!empty($site_menu_output))

--- a/resources/views/components/content-area.blade.php
+++ b/resources/views/components/content-area.blade.php
@@ -45,7 +45,7 @@
             </nav>
         </div>
 
-        <main class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8" tabindex="-1">
+        <main class="w-full{{ !in_array($page['controller'], config('base.full_width_controllers')) ? ' px-4' : '' }} {{$show_site_menu === true ? 'mt:w-3/4' : '' }} content-area mb-8 print:w-full" tabindex="-1">
             @if(!empty($hero) && !in_array($page['controller'], config('base.hero_full_controllers')))
                 @include('components.hero', ['images' => $hero])
 

--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -8,14 +8,14 @@
             <div class="w-full relative overflow-hidden">
                 @if(!empty($image['link']))<a href="{{  $image['link'] }}">@endif
                     <div class="pt-hero w-full bg-cover bg-top {{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $image['relative_url'] }}')" @else data-src="{{ $image['relative_url'] }}"@endif></div>
-                    <div class="absolute inset-0 flex items-center justify-center">
+                    <div class="absolute print:relative inset-0 flex items-center justify-center">
                         <img src="{{ $image['secondary_relative_url'] }}" alt="{{ $image['secondary_alt_text'] }}" class="w-full max-w-full max-h-full">
                     </div>
                 @if(!empty($image['link']))</a>@endif
             </div>
         @elseif(!empty($image['option']) && $image['option'] === "Logo Overlay" && in_array($page['controller'], config('base.hero_full_controllers')))
             <div class="mb-4 full min-h-hero relative overflow-hidden flex bg-green-darkest">
-                <div class="inset-0 absolute bg-cover bg-top opacity-20 {{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $image['relative_url'] }}')" @else data-src="{{ $image['relative_url'] }}"@endif></div>
+                <div class="inset-0 absolute print:relative bg-cover bg-top opacity-20 {{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $image['relative_url'] }}')" @else data-src="{{ $image['relative_url'] }}"@endif></div>
                 <div class="w-full relative text-white flex flex-col justify-center">
                     <div class="row w-full px-4 pt-10 pb-6 text-center md:white-links content">
                         @if(!empty($image['secondary_relative_url']))<img class="mx-auto mb-4" src="{{ $image['secondary_relative_url'] }}" alt="{{ $image['secondary_alt_text'] }}">@endif
@@ -27,7 +27,7 @@
         @elseif(!empty($image['option']) && $image['option'] === "Text Overlay")
             <div class="w-full relative">
                 <div class="pt-hero w-full bg-cover bg-top relative{{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $image['relative_url'] }}')" @else data-src="{{ $image['relative_url'] }}"@endif></div>
-                <div class="relative md:absolute md:bottom-0 md:inset-x-0 md:text-white md:white-links content md:bg-gradient-darkest">
+                <div class="relative md:absolute print:relative md:bottom-0 md:inset-x-0 md:text-white md:white-links content md:bg-gradient-darkest">
                     <div class="row">
                         <div class="mx-4 relative pb-0 pt-4 @if(in_array($page['controller'], config('base.hero_full_controllers'))) md:pb-2 md:pt-8 md:pt-20 @else md:pt-12 @endif">
                             <h1 class="md:text-shadow-darkest leading-tight text-2xl mb-1 @if(in_array($page['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</h1>

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -65,7 +65,7 @@
                 @endforeach
 
                 @if($back_url != '')
-                    <p class="pt-4">
+                    <p class="pt-4 print:hidden">
                         <a href="{{ $back_url }}" class="button">&larr; Return to listing</a>
                     </p>
                 @endif


### PR DESCRIPTION
ticket 109981:

- moved print styles out of global.scss and into it's own partial
- print partial now at bottom of imports in main.scss
- moved the rule for appending link href outside of content scope and into global scope
- appended abbr title after abbr
- hiding the "back to X" links for news/profile view
- changed all text/borders to black and making background colors transparent
- removed appended href from the wordmark and site title
- changed site title bar to position relative
- removed padding-top from heroes since background images don't show up
- changed text inside heroes to position relative so it's still visible in page flow
- formatted pre and hr
- change button links to look like normal links
- hid sharing toolbox on news item view