### PR TITLE
Hotfix/6.20.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.20.4",
+  "version": "6.20.5",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_bg-gradient.scss
+++ b/resources/scss/components/_bg-gradient.scss
@@ -4,5 +4,9 @@
 
         content: '';
         background-image: radial-gradient(200% 100% at 50% 100%, rgba(#05211e, 0.9) 10%, transparent 100%);
+
+        @media print {
+            @apply .bg-none;
+        }
     }
 }

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -44,12 +44,6 @@
         content: " (" attr(title) ") ";
     }
 
-    @responsive {
-        .bg-gradient-darkest::before {
-            @apply .bg-none;
-        }
-    }
-
     .content {
         pre {
             @apply .border .bg-transparent .overflow-auto .whitespace-pre-wrap;


### PR DESCRIPTION
The `@responsive` style inside the `@screen print` media query was escaping that print scope for some reason. Since `@responsive` isn't a normal CSS thing, it was causing specificity issues.