### PR TITLE
Mimic the Formy select style dropdowns

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -57,7 +57,15 @@
         @apply .block .border-grey .border .bg-white .w-full .p-2 .pr-8 .rounded-sm;
 
         appearance: none;
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+);
+        background-position: 100% center;
+        background-repeat: no-repeat;
         transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
+
+        // Remove double arrow for IE
+        &::-ms-expand {
+            display: none;
+        }
     }
 
     // Fieldsets


### PR DESCRIPTION
In an effort to bring the drop-down arrow back to sites, this change builds in the Formy style into Base natively. This is a starting point and the accessibility was tested on a Mac, need to get it published to test further.

I had initially thought the appearance of Formy forms in Base was controlled by another package and pulled in, but it looks like that is not the case. That approach has its advantages and disadvantages and willing to explore that if we want to evolve that style independent of Base style.

But for now, this gets the desired effect to users sooner than later and it can go to prod/new sites as soon as we are able to test on Windows with NVDA and Jaws.

| Before | After |
|--------|--------|
| ![Screen Shot 2021-04-19 at 6 42 25 AM](https://user-images.githubusercontent.com/37359/115375773-1a1cd780-a19c-11eb-9585-179f2e6ec645.png) | ![Screen Shot 2021-04-19 at 6 42 32 AM](https://user-images.githubusercontent.com/37359/115375786-1ee18b80-a19c-11eb-9363-3e031f6475e0.png) |

| Formy | Base |
|--------|--------|
| ![Screen Shot 2021-04-19 at 8 55 57 AM](https://user-images.githubusercontent.com/37359/115375908-3a4c9680-a19c-11eb-8e67-8f44f20fd36a.png) | ![Screen Shot 2021-04-19 at 8 55 04 AM](https://user-images.githubusercontent.com/37359/115375943-420c3b00-a19c-11eb-8ed7-927a3f006ddb.png) |

Tested on:
- Mac Chrome
- Mac Safari
- Mac Firefox
- Mac Safari + VoiceOver
- Windows 10 Edge
- Windows 10 IE 11
- Windows 10 Firefox