### PR TITLE
Formy dropdown carrot icon now visible in Windows High Contrast mode

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -57,14 +57,23 @@
         @apply .block .border-grey .border .bg-white .w-full .p-2 .pr-8 .rounded-sm;
 
         appearance: none;
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+);
-        background-position: 100% center;
+        background-image: linear-gradient(45deg, transparent 49%, #000 49%), linear-gradient(135deg, #000 49%, transparent 49%), linear-gradient(to right, #FFF, #FFF);
+        background-position: calc(100% - 10px) calc(1em + 5px), calc(100% - 5px) calc(1em + 5px), 100% 0;
+        background-size: 5px 5px, 5px 5px, 22px 100%;
         background-repeat: no-repeat;
         transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
+
+        @media screen and (-ms-high-contrast: active) {
+            appearance: menulist;
+        }
 
         // Remove double arrow for IE
         &::-ms-expand {
             display: none;
+
+            @media screen and (-ms-high-contrast: active) {
+                display: block;
+            }
         }
     }
 


### PR DESCRIPTION
Inspired by the [Select2 dropdown PR to address the missing caret in Windows High Contrast mode](https://github.com/jadu/pulsar/issues/959), this PR addresses the WIndows Edge and IE support.

## Edge 

| Before | After |
|--------|--------|
| ![Screen Shot 2021-04-20 at 10 55 25 AM](https://user-images.githubusercontent.com/37359/115417816-f327cb00-a1c6-11eb-9e04-ab83226783fb.png) | ![Screen Shot 2021-04-20 at 10 34 26 AM](https://user-images.githubusercontent.com/37359/115417840-f9b64280-a1c6-11eb-8c99-feb7970974f8.png) |

## IE

| Before | After |
|--------|--------|
| ![Screen Shot 2021-04-20 at 10 55 25 AM](https://user-images.githubusercontent.com/37359/115417885-0175e700-a1c7-11eb-90ce-b5829a701c8a.png) | ![Screen Shot 2021-04-20 at 10 33 37 AM](https://user-images.githubusercontent.com/37359/115417904-063a9b00-a1c7-11eb-8c44-7d4714f1c69e.png) |

There are extra spacing on the right of the dropdown in IE, but with the diminishing number of people using IE on Windows 10, the goal is to make it functional instead of pixel-perfect in high contrast mode.



