### PR TITLE
Upgrade spotlight template to use custom field

### DIFF
--- a/app/Http/Controllers/SpotlightController.php
+++ b/app/Http/Controllers/SpotlightController.php
@@ -30,7 +30,7 @@ class SpotlightController extends Controller
      */
     public function index(Request $request)
     {
-        $spotlights = $this->spotlight->getSpotlights();
+        $spotlights = $this->spotlight->getSpotlights($request->data);
 
         return view('spotlight-listing', merge($request->data, $spotlights));
     }
@@ -49,7 +49,9 @@ class SpotlightController extends Controller
             return abort('404');
         }
 
-        $request->data['page']['title'] = $spotlight['spotlight']['title'];
+        if (!empty($spotlight['spotlight']['title'])) {
+            $request->data['page']['title'] = $spotlight['spotlight']['title'];
+        }
 
         // Set the back URL
         $request->data['back_url'] = $this->spotlight->getBackToSpotlightsListing($request->server->get('HTTP_REFERER'), $request->server->get('REQUEST_SCHEME'), $request->server->get('HTTP_HOST'), $request->server->get('REQUEST_URI'));

--- a/app/Repositories/SpotlightRepository.php
+++ b/app/Repositories/SpotlightRepository.php
@@ -35,11 +35,14 @@ class SpotlightRepository implements SpotlightRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getSpotlights()
+    public function getSpotlights(array $data)
     {
-        $group_reference = [
-            //            0000 => 'spotlights',
-        ];
+        $group_reference = [];
+
+        // If there is an spotlight custom page field then inject it into the group reference
+        if (!empty($data['data']['spotlight_promo_group_id']) && ! array_key_exists($data['data']['spotlight_promo_group_id'], $group_reference)) {
+            $group_reference[$data['data']['spotlight_promo_group_id']] = 'spotlights';
+        }
 
         $group_config = [];
 

--- a/contracts/Repositories/SpotlightRepositoryContract.php
+++ b/contracts/Repositories/SpotlightRepositoryContract.php
@@ -9,7 +9,7 @@ interface SpotlightRepositoryContract
      *
      * @return array
      */
-    public function getSpotlights();
+    public function getSpotlights(array $data);
 
     /**
      * Get promotions for individual spotlights.

--- a/styleguide/Repositories/SpotlightRepository.php
+++ b/styleguide/Repositories/SpotlightRepository.php
@@ -9,7 +9,7 @@ class SpotlightRepository extends Repository
     /**
      * {@inheritdoc}
      */
-    public function getSpotlights()
+    public function getSpotlights(array $data)
     {
         return [
             'spotlights' => app('Factories\Spotlight')->create(12),

--- a/tests/Unit/Repositories/SpotlightRepositoryTest.php
+++ b/tests/Unit/Repositories/SpotlightRepositoryTest.php
@@ -18,13 +18,22 @@ class SpotlightRepositoryTest extends TestCase
             'spotlights' => [],
         ];
 
+        // Create a fake data request
+        $data = app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'SpotlightController',
+            ],
+            'data' => [
+                'spotlight_promo_group_id' => $this->faker->numberbetween(1, 3),
+            ],
+        ]);
+
         // Mock the connector and set the return
         $wsuApi = Mockery::mock('Waynestate\Api\Connector');
         $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn($return);
 
         // Get the spotlights
-        $spotlights = app('App\Repositories\SpotlightRepository', ['wsuApi' => $wsuApi])->getSpotlights();
-
+        $spotlights = app('App\Repositories\SpotlightRepository', ['wsuApi' => $wsuApi])->getSpotlights($data);
         $this->assertTrue(is_array($spotlights));
     }
 
@@ -79,3 +88,4 @@ class SpotlightRepositoryTest extends TestCase
         $this->assertEquals($referer, $url);
     }
 }
+

--- a/tests/Unit/Repositories/SpotlightRepositoryTest.php
+++ b/tests/Unit/Repositories/SpotlightRepositoryTest.php
@@ -88,4 +88,3 @@ class SpotlightRepositoryTest extends TestCase
         $this->assertEquals($referer, $url);
     }
 }
-


### PR DESCRIPTION
After selecting the Spotlight Template, add the `spotlight_promo_group_id` custom page field with your promo group id. No visual change. 