### PR TITLE
Feature - #123009 Base - Content.scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.22.2",
+  "version": "6.22.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -1,17 +1,5 @@
 // Content returning from CMS
 .content {
-
-    h2 {
-        margin-bottom: 0.5rem;
-    }
-
-    h3,
-    h4,
-    h5,
-    h6 {
-        margin-bottom: 0.3rem;
-    }
-
     ul {
         list-style-type: disc;
 

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -1,5 +1,17 @@
 // Content returning from CMS
 .content {
+
+    h2 {
+        margin-bottom: 0.5rem;
+    }
+
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin-bottom: 0.3rem;
+    }
+
     ul {
         list-style-type: disc;
 
@@ -11,7 +23,7 @@
 
         @apply .ml-8;
     }
-
+    
     hr {
         @apply .border-b .border-solid .border-grey-lighter .my-5;
     }

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -11,7 +11,7 @@
 
         @apply .ml-8;
     }
-    
+
     hr {
         @apply .border-b .border-solid .border-grey-lighter .my-5;
     }

--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -46,22 +46,32 @@ h1 {
 
 h2 {
     @apply .text-3xl;
+
+    margin-bottom: 0.5rem;
 }
 
 h3 {
     @apply .text-2xl;
+
+    margin-bottom: 0.3rem;
 }
 
 h4 {
     @apply .text-xl;
+
+    margin-bottom: 0.3rem;
 }
 
 h5 {
     @apply .text-lg;
+
+    margin-bottom: 0.3rem;
 }
 
 h6 {
     @apply .text-sm;
+
+    margin-bottom: 0.3rem;
 }
 
 // Firefox uses the outline focus color as the text color. Since our overall background is white we need to change it.

--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -1,5 +1,4 @@
 // Restricts the embedded font from combining two characters like "fi"
-test
 html {
     font-feature-settings: "liga" 0;
 }

--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -1,4 +1,5 @@
 // Restricts the embedded font from combining two characters like "fi"
+test
 html {
     font-feature-settings: "liga" 0;
 }


### PR DESCRIPTION
## Reason for change

Visually group flow of text after headers

## Required checklist

- [x] Provide TP3 link: [#123009 Base - Content.scss](https://waynedotedu.tpondemand.com/restui/board.aspx?#page=userstory/123009)
- [x] Screen shot or video of before/after - Screenshots will be added after

## Reminders

- Update package version number
- SiteImprove accessibility check
- Verified each page looks good on each viewport size
- Add an example to the styleguide if applicable
- Add tests to prove the code works
- Provide CMS site link if applicable

## Screenshots / Videos

| Before | After |
|--------|--------|
![old_base-wayne-edu-styleguide-profiles-2021-09-28-11_00_00](https://user-images.githubusercontent.com/89077791/135116427-512bc1c0-1e3f-4352-9c99-96d8b48edd80.jpg)|![new_base-wayne-local-styleguide-profile-aa0000-2021-09-28-11_10_10](https://user-images.githubusercontent.com/89077791/135116689-df681b63-4bd1-46dd-8364-65332701663b.jpg)

