### PR TITLE
hotfix/6.23.1 - Promo view was scoped to the wrong variable from an older iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.23.0",
+  "version": "6.23.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/promo-view.blade.php
+++ b/resources/views/promo-view.blade.php
@@ -3,8 +3,8 @@
 @section('content')
     <div class="row flex flex-wrap -mx-4">
         <div class="w-full md:w-1/3 px-4 mt-6">
-            @if(!empty($promotion['relative_url']))
-                @image($promotion['relative_url'], $promotion['filename_alt_text'], 'sm:h-64 md:h-auto mx-auto md:mx-0')
+            @if(!empty($promo['relative_url']))
+                @image($promo['relative_url'], $promo['filename_alt_text'], 'sm:h-64 md:h-auto mx-auto md:mx-0')
             @else
                 <img src="/_resources/images/no-photo.svg" alt="{{ $page['title'] }}" class="sm:h-64 md:h-auto block mx-auto md:mx-0">
             @endif
@@ -14,12 +14,12 @@
             @include('components.page-title', ['title' => $page['title']])
 
             <div class="content">
-                @if(!empty($promotion['excerpt']))
-                    <p>{{ $promotion['excerpt'] }}</p>
+                @if(!empty($promo['excerpt']))
+                    <p>{{ $promo['excerpt'] }}</p>
                 @endif
 
-                @if(!empty($promotion['description']))
-                    {!! $promotion['description'] !!}
+                @if(!empty($promo['description']))
+                    {!! $promo['description'] !!}
                 @endif
 
                 @if($back_url != '')

--- a/styleguide/Pages/Sitespecific.php
+++ b/styleguide/Pages/Sitespecific.php
@@ -17,8 +17,8 @@ class Sitespecific extends Page
                 'content' => [
                     'main' => '<p>Feature names should be singular and CamelCased.</p>
                     <h2>Example new features</h2>
-                    <ul><li>"Spotlight" <pre>php artisan base:feature Spotlight</pre></li>
-                    <li>"Faculty Books" <pre>php artisan base:feature FacultyBook</pre></li></ul>
+                    <ul><li>"Spotlight" <code class="bg-grey-lighter py-1 px-2 rounded text-sm">php artisan base:feature Spotlight</code></li>
+                    <li>"Faculty Books" <code class="bg-grey-lighter py-1 px-2 rounded text-sm">php artisan base:feature FacultyBook</code></li></ul>
                     <p>'.$this->faker->paragraph(8).'</p>
                     <p>'.$this->faker->paragraph(8).'</p>',
                 ],


### PR DESCRIPTION
Promo view was scoped to the wrong variable from an older iteration
Also we don't have styling for pre tag at this time so changed pre tag to code tag on the site specific instructions