### PR TITLE
Slate form added to styleguide and style added to account for the embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "6.23.1",
+  "version": "6.23.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_menu-top.scss
+++ b/resources/scss/components/_menu-top.scss
@@ -23,3 +23,9 @@ ul.menu-top {
         }
     }
 }
+
+.top_menu_hidden {
+    @media (max-width: theme('screens.mt')) {
+        @apply .hidden;
+    }
+}

--- a/resources/scss/components/_slate.scss
+++ b/resources/scss/components/_slate.scss
@@ -1,0 +1,17 @@
+.form_responses {
+    & * {
+        @apply .border .border-grey .py-1 .px-2 .rounded-sm;
+    }
+}
+
+.form_response {
+    @apply .border-0;
+}
+
+.form_responses div[id*="maxlength"] {
+    @apply .border-0;
+}
+
+button.default {
+    @extend .button;
+}

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -24,6 +24,7 @@
 @import "components/share";
 @import "components/row";
 @import "components/skip";
+@import "components/slate";
 @import "components/table-stack";
 @import "components/text-shadow";
 @import "components/visually-hidden";

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -42,7 +42,7 @@
         </div>
 
         @if(config('base.top_menu_enabled') === true)
-            <div class="hidden mx-4 mt:flex mt:shrink-0 mt:justify-end mt:items-center">
+            <div class="top_menu_hidden mx-4 mt:flex mt:shrink-0 mt:justify-end mt:items-center">
                 <nav id="top-menu" aria-label="Site menu" tabindex="-1">
                     {!! $top_menu_output !!}
                 </nav>

--- a/styleguide/Pages/FormsSlate.php
+++ b/styleguide/Pages/FormsSlate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Styleguide\Pages;
+
+class FormsSlate extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app('Factories\Page')->create(1, true, [
+            'page' => [
+                'controller' => 'MenuTopController',
+                'title' => 'Slate Form',
+                'id' => 111100101,
+                'content' => [
+                    'main' => '<div id="form_35cc1a63-ef80-9d66-6cec-23cc284d0d15">Loading...</div>
+                    <script async="async" src="https://gradslate.wayne.edu/register/?id=35cc1a63-ef80-9d66-6cec-23cc284d0d15&amp;output=embed&amp;div=form_35cc1a63-ef80-9d66-6cec-23cc284d0d15"></script>',
+                ],
+            ],
+        ]);
+    }
+}

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -566,6 +566,16 @@
                         "class_name": "",
                         "relative_url": "/styleguide/forms/error",
                         "submenu": []
+                    },
+                    "111100101": {
+                        "menu_item_id": 111100101,
+                        "is_active": 1,
+                        "page_id": 111100101,
+                        "target": "",
+                        "display_name": "Form Slate",
+                        "class_name": "",
+                        "relative_url": "/styleguide/forms/slate",
+                        "submenu": []
                     }
                 }
             },

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -66,7 +66,7 @@ mix.js('resources/js/main.js', 'public/_resources/js')
             path.join(__dirname, "node_modules/mediabox/dist/mediabox.js")
         ],
         extensions: ['html', 'js', 'php', 'vue'],
-        whitelistPatterns: [/at-/, /w-[1-5]\/[1-5]/, /(sm|md|lg|xl|xxl|xxxl|mt)\:w-[1-5]\/[1-5]/]
+        whitelistPatterns: [/at-/, /w-[1-5]\/[1-5]/, /(sm|md|lg|xl|xxl|xxxl|mt)\:w-[1-5]\/[1-5]/,/form_responses/]
     })
    .sourceMaps()
    .options({


### PR DESCRIPTION
## Reason for change

Building Slate form style directly into Base because all graduate programs will eventually be using Slate forms.

This will allow us to test the form in all scenarios in the future.

## Relevant links

- TP3: https://waynedotedu.tpondemand.com/entity/124831-base-add-slate-form-and-adapted
- CMS: https://gradschool.wayne.edu/admissions/request-information

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![screencapture-base-wayne-local-styleguide-forms-slate-2021-10-29-06_46_12](https://user-images.githubusercontent.com/37359/139425088-233d7ca6-f6b9-417d-8c87-398ea6ac44ea.png) | ![screencapture-base-wayne-local-styleguide-forms-slate-2021-10-29-06_49_26](https://user-images.githubusercontent.com/37359/139425157-d64772a9-7ffc-40a3-90d1-181423714708.png) | 