### PR TITLE
hotfix/7.0.1 - Scrollbars were automatically showing on content area for some users

### DIFF
--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -1,8 +1,5 @@
 // Content returning from CMS
 .content {
-    // This allows tables to scroll
-    @apply overflow-scroll;
-
     dl,
     ol,
     ul {


### PR DESCRIPTION
Fixing scrollbars automatically showing on content area for some users

|before|after|
|------|-----|
|![basebefore](https://user-images.githubusercontent.com/2616607/148091356-04bdd721-edfb-47d8-af76-22110356ab15.jpg)|![baseafter](https://user-images.githubusercontent.com/2616607/148091391-46e92f33-a41f-412a-9f2a-72adf2aa0a53.png)|