### PR TITLE
Hotfix/7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,7 +60,6 @@ const screens = {
 }
 
 module.exports = {
-    mode: 'jit',
     content: [
         path.join(__dirname, "resources/views/**/*.blade.php"),
         path.join(__dirname, "styleguide/Views/**/*.blade.php"),


### PR DESCRIPTION
Removes `mode: 'jit'` not needed in the `tailwind.config.js` due to it being enabled by default, was left over from Tailwind V2