### PR TITLE
use artisan test to display out the failed test quickly

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ yarncheck: $(YARNFILE)
 runtests: $(COMPOSERFILE)
 	php artisan view:clear
 	php artisan config:clear
-	php vendor/bin/phpunit
+	php artisan test
 
 php-cs-fixer:
 	chmod +x php-cs-fixer-script.sh && ./php-cs-fixer-script.sh


### PR DESCRIPTION
Why not?

Before:
<img width="826" alt="Screen Shot 2022-02-11 at 5 06 33 PM" src="https://user-images.githubusercontent.com/636531/153676929-5523c15e-0419-4e2d-a694-bd14f1b4b3f5.png">

After:
<img width="532" alt="Screen Shot 2022-02-11 at 5 03 04 PM" src="https://user-images.githubusercontent.com/636531/153676946-b6df7209-5634-4783-bf96-f43bb2e96fe0.png">

