### PR TITLE
Hotfix/7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Faker\Factory;
+use Illuminate\Routing\Middleware\ThrottleRequests;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -29,6 +30,10 @@ abstract class TestCase extends BaseTestCase
 
         // Don't run through the exception handler so we have cleaner errors in CLI
         $this->withoutExceptionHandling();
+
+        $this->withoutMiddleware(
+            ThrottleRequests::class,
+        );
 
         // Create a new faker that every test can use
         $this->faker = (new Factory)->create();


### PR DESCRIPTION
Too many feature tests are now causing sites to fail tests due to Throttling the requests.

This removes the Middleware for ThrottleRequests when testing