### PR TITLE
Hotfix/7.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -25,7 +25,7 @@ fs.copyFileSync('vendor/waynestate/error-403/dist/403.php', 'resources/views/err
 fs.copyFileSync('vendor/waynestate/error-429/dist/429.php', 'resources/views/errors/429.blade.php', fs.constants.COPYFILE_FICLONE);
 fs.copyFileSync('vendor/waynestate/error-500/dist/500.php', 'resources/views/errors/500.blade.php', fs.constants.COPYFILE_FICLONE);
 fs.copyFileSync('vendor/waynestate/error-500/dist/500.php', 'resources/views/errors/500.blade.php', fs.constants.COPYFILE_FICLONE);
-fs.copyFileSync('hooks/pre-commit', '.git/hooks/pre-commit', fs.constants.COPYFILE_FICLONE);
+mix.copy('hooks/pre-commit', '.git/hooks/');
 replace.sync({
     files: 'resources/views/components/footer.blade.php',
     from: /2\d{3}/g,


### PR DESCRIPTION
Fix issue when trying to copy to the `.git` folder will error using `fs.copyFileSync`, since we are not renaming the file and just copying, we can rely on the `mix.copy` which works.

```
$ mix
[webpack-cli] Error: ENOENT: no such file or directory, copyfile 'hooks/pre-commit' -> '.git/hooks/pre-commit'
at Object.copyFileSync (node:fs:2800:3)
at Object.<anonymous> (/vagrant/wayne2/webpack.mix.js:28:4)
at Module._compile (node:internal/modules/cjs/loader:1101:14)
at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
at Module.load (node:internal/modules/cjs/loader:981:32)
at Function.Module._load (node:internal/modules/cjs/loader:822:12)
at Module.require (node:internal/modules/cjs/loader:1005:19)
at require (node:internal/modules/cjs/helpers:102:18)
at module.exports (/vagrant/wayne2/node_modules/laravel-mix/setup/webpack.config.js:11:5)
at loadConfigByPath (/vagrant/wayne2/node_modules/webpack-cli/lib/webpack-cli.js:1747:27) {
errno: -2,
syscall: 'copyfile',
code: 'ENOENT',
path: 'hooks/pre-commit',
dest: '.git/hooks/pre-commit'
}
```