### PR TITLE
Hotfix/7.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/stubs/repository-styleguide.stub
+++ b/stubs/repository-styleguide.stub
@@ -13,7 +13,7 @@ class DummyRepository extends Repository
     public function getDummy()
     {
         return [
-            'dummy' => app(DummyFactory::class)->create(5)
+            'dummy' => app(DummyFactory::class)->create(5),
         ];
     }
 }

--- a/stubs/repository.stub
+++ b/stubs/repository.stub
@@ -78,7 +78,7 @@ class DummyRepository implements DummyRepositoryContract
          */
 
         return [
-            'dummy' => []
+            'dummy' => [],
         ];
     }
 }


### PR DESCRIPTION
When using the `base:feature`, two files require phplinting after creation, this corrects it so that it doesn't need to