### PR TITLE
Hotfix/7.1.11

### DIFF
--- a/app/Console/Commands/BaseFeature.php
+++ b/app/Console/Commands/BaseFeature.php
@@ -102,7 +102,7 @@ class BaseFeature extends Command
         $this->replaceController();
         $this->stub = str_replace('DummyPage', $this->feature, $this->stub);
         $this->stub = str_replace('DummyTitle', $this->feature, $this->stub);
-        $this->stub = str_replace('DummyId', end($menu[101]['submenu'])['menu_item_id'], $this->stub);
+        $this->stub = str_replace('DummyId', end($menu[101]['submenu'][999]['submenu'])['menu_item_id'], $this->stub);
 
         Storage::disk('base')->put('styleguide\Pages\/'.$this->feature.'.php', $this->stub);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.10",
+  "version": "7.1.11",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Issue when adding a new `base:feature` it wouldn't add the proper menu page id to the styleguide Page, which then resulted in the `all_styleguide_tests` to not cover any newly created features due to it always testing the site_specific page at 999