### PR TITLE
hotfix/7.1.14 - Noticed tables were exceeding content bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.12",
+  "version": "7.1.13",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_global-tables.scss
+++ b/resources/scss/components/_global-tables.scss
@@ -3,7 +3,7 @@ table {
 
     &:not([class]),
     &.table-sort {
-        @apply block overflow-x-auto border-collapse;
+        @apply block overflow-x-scroll border-collapse;
     }
 
     @screen mt {
@@ -55,11 +55,6 @@ table {
         &:hover {
             @apply bg-gold-50;
         }
-    }
-
-    &:not([class]) td,
-    &.table-sort td {
-        @apply whitespace-nowrap;
     }
 }
 


### PR DESCRIPTION
Noticed tables were exceeding content bounds
|before|after|
|---|---|
|<img width="877" alt="Screen Shot 2022-06-14 at 8 36 54 AM" src="https://user-images.githubusercontent.com/2616607/173580838-930305f3-a965-4f55-b363-3c963b3e6543.png">|<img width="639" alt="Screen Shot 2022-06-14 at 8 35 24 AM" src="https://user-images.githubusercontent.com/2616607/173580884-a55fb575-e954-4a5d-b3e7-90add64d7706.png">|
|<img width="318" alt="Screen Shot 2022-06-14 at 8 43 29 AM" src="https://user-images.githubusercontent.com/2616607/173581061-c0aa2a13-d550-4da0-a5c4-20d98ef077a1.png">|<img width="158" alt="Screen Shot 2022-06-14 at 8 43 06 AM" src="https://user-images.githubusercontent.com/2616607/173581101-d624aefe-b19b-410a-8803-82ee20d75d0b.png">|


