### PR TITLE
Hotfix/7.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.16",
+  "version": "7.1.17",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -67,11 +67,8 @@ mix.copy([
     ], 'public/_resources/fonts')
 
     // Images
-    .copy([
-        'resources/images/**/*.jpg',
-        'resources/images/**/*.gif',
-        'resources/images/**/*.png',
-        'resources/images/**/*.svg'
+    .copyDirectory([
+        'resources/images'
     ], 'public/_resources/images');
 
 // Compile assets and setup browersync


### PR DESCRIPTION
copyDirectory(src, dest) to retain the directory subfolder structure rather than copying individual image types otherwise we lose the directory structure if there are any subfolders within the `resources/images` using `copy(dest, src)`
https://laravel-mix.com/docs/6.0/copying-files#copy-a-directory

such as `resources/images/assessment/**/*.jpg` will end up being at `public/_resources/images` using just `copy`