### PR TITLE
Feature/news paginator - #109872 Base - Pagination, Next/Previous links to page numbers

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -62,8 +62,8 @@ class ArticleController extends Controller
             $request->data['base']['show_site_menu'] = true;
         }
 
-        $paginate = $this->paginate->paginate($articles['articles']['data'], 5, $request->page);
-        
+        $paginate = $this->paginate->paginate($articles['articles']['data'] ?? [], 5, $request->page); // LengthAwarePaginator
+
         // Paginate added so we can use methods in the blade.
         return view('articles', merge($request->data, $articles, $topics) + ['paginate' => $paginate]);
     }

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -9,6 +9,7 @@ namespace App\Http\Controllers;
 
 use Contracts\Repositories\ArticleRepositoryContract;
 use Contracts\Repositories\TopicRepositoryContract;
+use Contracts\Repositories\PaginatorRepositoryContract;
 use Illuminate\Http\Request;
 
 class ArticleController extends Controller
@@ -18,11 +19,13 @@ class ArticleController extends Controller
      *
      * @param ArticleRepositoryContract $article
      * @param TopicRepositoryContract $topic
+     * @param PaginatorRepositoryContract $paginate
      */
-    public function __construct(ArticleRepositoryContract $article, TopicRepositoryContract $topic)
+    public function __construct(ArticleRepositoryContract $article, TopicRepositoryContract $topic, PaginatorRepositoryContract $paginate)
     {
         $this->article = $article;
         $this->topic = $topic;
+        $this->paginate = $paginate;
     }
 
     /**
@@ -48,7 +51,7 @@ class ArticleController extends Controller
             abort('404');
         }
 
-        $articles = $this->article->listing($request->data['base']['site']['news']['application_id'], 25, $request->query('page'), !empty($selected_topic['topic_id']) ? $selected_topic['topic_id'] : null);
+        $articles = $this->article->listing($request->data['base']['site']['news']['application_id'], 50, $request->query('page'), !empty($selected_topic['topic_id']) ? $selected_topic['topic_id'] : null);
 
         if (!empty($articles['articles']['meta'])) {
             $articles['articles']['meta'] = $this->article->setPaging($articles['articles']['meta'], $request->query('page'));
@@ -59,7 +62,10 @@ class ArticleController extends Controller
             $request->data['base']['show_site_menu'] = true;
         }
 
-        return view('articles', merge($request->data, $articles, $topics));
+        $paginate = $this->paginate->paginate($articles['articles']['data'], 5, $request->page);
+        
+        // Paginate added so we can use methods in the blade.
+        return view('articles', merge($request->data, $articles, $topics) + ['paginate' => $paginate]);
     }
 
     /**

--- a/app/Repositories/PaginatorRepository.php
+++ b/app/Repositories/PaginatorRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Repositories;
+
+use Contracts\Repositories\PaginatorRepositoryContract;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class PaginatorRepository implements PaginatorRepositoryContract
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function paginate($items, $limit, $page)
+    {
+        $total = count($items);
+        $items = collect($items)->forPage($page, $limit);
+
+        return new LengthAwarePaginator($items, $total, $limit, $page, ['path' => '']);
+    }
+}

--- a/contracts/Repositories/PaginatorRepositoryContract.php
+++ b/contracts/Repositories/PaginatorRepositoryContract.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Contracts\Repositories;
+
+interface PaginatorRepositoryContract
+{
+    /**
+     * Paginator object
+     *
+     * @param array $items
+     * @param int $limit
+     * @param int $page
+     */
+    public function paginate($items, $limit, $page);
+}

--- a/factories/Paginator.php
+++ b/factories/Paginator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Factories;
+
+use Contracts\Factories\FactoryContract;
+use Faker\Factory;
+
+class Paginator implements FactoryContract
+{
+    /**
+     * Construct the factory.
+     *
+     * @param Factory $faker
+     */
+    public function __construct(Factory $faker)
+    {
+        $this->faker = $faker->create();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($limit = 1, $flatten = false, $options = [])
+    {
+        for ($i = 1; $i <= $limit; $i++) {
+            $data[$i] = [
+                'title' => $this->faker->sentence,
+                'description' => '<p>'.$this->faker->paragraph.'</p>',
+            ];
+
+            $data[$i] = array_replace_recursive($data[$i], $options);
+        }
+
+        if ($limit === 1 && $flatten === true) {
+            return current($data);
+        }
+
+        return $data;
+    }
+}

--- a/resources/views/articles.blade.php
+++ b/resources/views/articles.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     @include('components.page-title', ['title' => $base['page']['title']])
 
-    @if(!empty($paginate->items()))
+    @if(!empty($paginate) && !empty($paginate->items()))
         <ul>
             @foreach($paginate->items() as $article)
                 <li class="mb-3 pb-4 border-b border-gray-200">

--- a/resources/views/articles.blade.php
+++ b/resources/views/articles.blade.php
@@ -3,9 +3,9 @@
 @section('content')
     @include('components.page-title', ['title' => $base['page']['title']])
 
-    @if(!empty($articles['data']))
+    @if(!empty($paginate->items()))
         <ul>
-            @foreach($articles['data'] as $article)
+            @foreach($paginate->items() as $article)
                 <li class="mb-3 pb-4 border-b border-gray-200">
                     <a href="{{ $article['link'] }}" class="font-bold text-lg block">
                         {{ $article['title'] }}
@@ -14,28 +14,10 @@
                 </li>
             @endforeach
         </ul>
+
+        @include('components.paginator')
     @else
         <p>Currently there are no articles{{ !empty($topic['data']['name']) ? ' for the category ' . strtolower($topic['data']['name']) : '' }}.</p>
-    @endif
-
-    @if(!empty($articles['meta']['prev_page_url']) || !empty($articles['meta']['next_page_url']))
-        <div class="row flex -mx-4">
-            <div class="w-1/2 px-4">
-                @if(!empty($articles['meta']['prev_page_url']))
-                    <p>
-                        <a href="{{ $articles['meta']['prev_page_url'] }}" class="button">&larr; Previous</a>
-                    </p>
-                @endif
-            </div>
-
-            <div class="w-1/2 px-4 text-right">
-                @if(!empty($articles['meta']['next_page_url']) && $articles['meta']['current_page'] !== 1)
-                    <p>
-                        <a href="{{ $articles['meta']['next_page_url'] }}" class="button">Next &rarr;</a>
-                    </p>
-                @endif
-            </div>
-        </div>
     @endif
 @endsection
 

--- a/resources/views/components/paginator-tailwind.blade.php
+++ b/resources/views/components/paginator-tailwind.blade.php
@@ -1,0 +1,65 @@
+@if ($paginator->hasPages())
+    <div class="">
+        <div>
+            <p class="">
+                {!! __('Showing') !!}
+                @if ($paginator->firstItem())
+                    <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                @else
+                    {{ $paginator->count() }}
+                @endif
+
+                {!! __('of') !!}
+                <span class="font-medium">{{ $paginator->total() }}</span>
+                {!! __('results') !!}
+            </p>
+        </div>
+
+        <div class="row">
+            <span class="list-none">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <span class="button">
+                        {!! __('pagination.previous') !!}
+                    </span>
+                @else
+                    <a href="{{ $paginator->previousPageUrl() }}" class="button">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                @endif
+                @foreach ($elements as $element)
+                    @if (is_string($element))
+                        <span>
+                            <span class="button">{{ $element }}</span>
+                        </span>
+                    @endif
+                    @if (is_array($element))
+                        @foreach ($element as $page => $url)
+                            @if ($page == $paginator->currentPage())
+                                <span aria-current="page">
+                                    <span class="button">{{ $page }}</span>
+                                </span>
+                            @else
+                                <a href="{{ $url }}" class="button" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                    {{ $page }}
+                                </a>
+                            @endif
+                        @endforeach
+                    @endif
+                @endforeach
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <a href="{{ $paginator->nextPageUrl() }}" class="button">
+                        {!! __('pagination.next') !!}
+                    </a>
+                @else
+                    <span class="">
+                        {!! __('pagination.next') !!}
+                    </span>
+                @endif
+            </span>
+        </div>
+    </div>
+@endif

--- a/resources/views/components/paginator.blade.php
+++ b/resources/views/components/paginator.blade.php
@@ -1,0 +1,3 @@
+@if(!empty($paginate))
+    {{ $paginate->links('components/paginator-tailwind') }}
+@endif

--- a/styleguide/Http/Controllers/PaginatorController.php
+++ b/styleguide/Http/Controllers/PaginatorController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class PaginatorController extends Controller
+{
+    /**
+     * Display an example accordion.
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request)
+    {
+        return view('styleguide-paginator', merge($request->data));
+    }
+}

--- a/styleguide/Pages/Paginator.php
+++ b/styleguide/Pages/Paginator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Styleguide\Pages;
+
+use Factories\Page as PageFactory;
+
+class Paginator extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app(PageFactory::class)->create(1, true, [
+            'page' => [
+                'controller' => 'PaginatorController',
+                'title' => 'Paginator',
+                'id' => 116101,
+            ],
+        ]);
+    }
+}

--- a/styleguide/Repositories/PaginatorRepository.php
+++ b/styleguide/Repositories/PaginatorRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Styleguide\Repositories;
+
+use App\Repositories\PaginatorRepository as Repository;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class PaginatorRepository extends Repository
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function paginate($items, $limit, $page)
+    {
+        $total = count($items);
+        $items = collect($items)->forPage($page, $limit);
+
+        return new LengthAwarePaginator($items, $total, $limit, $page, ['path' => '']);
+    }
+}

--- a/styleguide/Views/styleguide-paginator.blade.php
+++ b/styleguide/Views/styleguide-paginator.blade.php
@@ -1,0 +1,5 @@
+@extends('components.content-area')
+
+@section('content')
+    @include('components.page-title', ['title' => $base['page']['title']])
+@endsection

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -300,6 +300,16 @@
                 "class_name": "",
                 "relative_url": "/styleguide/featuredpromo",
                 "submenu": []
+            },
+            "116101": {
+                "menu_item_id": 116101,
+                "is_active": 1,
+                "page_id": 116101,
+                "target": "",
+                "display_name": "Paginator",
+                "class_name": "",
+                "relative_url": "/styleguide/paginator",
+                "submenu": []
             }
         }
     },

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -688,9 +688,20 @@
                         "class_name": "",
                         "relative_url": "/styleguide/sitespecific",
                         "submenu": []
+                    },
+                    "99902": {
+                        "menu_item_id": 99902,
+                        "is_active": 1,
+                        "page_id": 99902,
+                        "target": "",
+                        "display_name": "Paginator",
+                        "class_name": "",
+                        "relative_url": "/styleguide/paginator",
+                        "submenu": []
                     }
                 }
             }
         }
     }
 }
+


### PR DESCRIPTION
## Reason for change

- Adding paginator component to news page

## Required checklist

- [x] Provide TP3 link: [#109872
Base - Pagination, Next/Previous links to page numbers](https://waynedotedu.tpondemand.com/entity/109872-base-pagination-nextprevious-links-to-page)
- [x] Screen shot or video of before/after

## Reminders

- Update package version number
- SiteImprove accessibility check
- Verified each page looks good on each viewport size
- Add an example to the styleguide if applicable
- Add tests to prove the code works
- Provide CMS site link if applicable

## Screenshots / Videos

| Before  | After |
| ------------- | ------------- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/89077791/183977596-b3f95207-a747-44b9-9b1e-4fc40a23447a.png">  | <img width="400" alt="image" src="https://user-images.githubusercontent.com/89077791/183977461-5816ffad-3123-4cf4-b402-55a311d17ba1.png"> |