### PR TITLE
Hotfix/7.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "7.1.17",
+  "version": "7.1.18",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/scss/components/_cms-layouts.scss
+++ b/resources/scss/components/_cms-layouts.scss
@@ -12,7 +12,7 @@
 
 .grid-two-col-layout,
 .grid-three-col-layout {
-    @apply gap-x-6 gap-y-4 grid md:grid-cols-2 mb-6 items-start;
+    @apply gap-6 grid md:grid-cols-2 mb-6 items-start;
 
     p {
         @apply my-2;

--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -1,10 +1,8 @@
 {{--
     $events => array // ['title', 'url', 'date', 'start_time', 'is_all_day']
-    $heading => string // 'Events'
     $cal_name => string // 'main/'
     $link_text => string // 'More events'
 --}}
-<h2{!! !empty($class) ? ' class="'.$class.'"' : '' !!}>{{ $heading ?? 'Events' }}</h2>
 
 <ul>
     @foreach($events as $key => $dates)

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -17,7 +17,7 @@
                     <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black">{{ config('base.surtitle') }}</a>
                 </h1>
 
-                <h2 class="font-normal mb-1 text-2xl">
+                <h2 class="font-normal mb-1 text-2xl leading-none">
                     <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>

--- a/resources/views/homepage.blade.php
+++ b/resources/views/homepage.blade.php
@@ -11,14 +11,14 @@
         <div class="row -mx-4 flex flex-wrap">
             @if(!empty($articles['data']))
                 <div class="w-full md:w-1/2 px-4">
-                    <h2>News articles</h2>
+                    <h2 class="mb-2">News articles</h2>
                     @include('components/article-listing', ['articles' => $articles['data'], 'url' => ($base['site']['subsite-folder'] !== null ? $base['site']['subsite-folder'] : '').config('base.news_listing_route').'/'])
                 </div>
             @endif
 
             @if(!empty($events))
                 <div class="w-full md:w-1/2 px-4">
-                    <h2>Events</h2>
+                    <h2 class="mb-2">Events</h2>
                     @include('components/events-listing', ['events' => $events, 'cal_name' => !empty($base['site']['events']['path']) ? $base['site']['events']['path'] : null])
                 </div>
             @endif

--- a/styleguide/Pages/BasicLayouts.php
+++ b/styleguide/Pages/BasicLayouts.php
@@ -14,7 +14,7 @@ class BasicLayouts extends Page
         return app(PageFactory::class)->create(1, true, [
             'page' => [
                 'controller' => 'BasicLayoutsController',
-                'title' => 'Basic layouts',
+                'title' => 'Basic responsive layouts',
                 'id' => 100200,
             ],
         ]);

--- a/styleguide/Views/styleguide-basic-layouts.blade.php
+++ b/styleguide/Views/styleguide-basic-layouts.blade.php
@@ -4,11 +4,69 @@
     @include('components.page-title', ['title' => $base['page']['title']])
 
     <div class="content">
-        <h2 class="my-4">Two columns image left</h2>
+        <p>Use these examples to style your content in the CMS editor</p>
+    </div>
+
+    <div class="content">
+        <h2 class="my-4">Two equal columns</h2>
+        <h3 class="mb-0">Example columns with text</h3>
+
+        <div class="grid-two-col-layout">
+            <div>
+                <p>{{ $faker->text(400) }}</p>
+            </div>
+
+            <div>
+                <p>{{ $faker->text(400) }}</p>
+            </div>
+        </div>
+
+        <h3 class="mt-0">Example grid</h3>
+
+        <div class="grid-two-col-layout mt-4">
+            <div>
+                <img src="/styleguide/image/425x240" alt="Two column placeholder image 1">
+                <p>{{ $faker->text(60) }}</p>
+            </div>
+
+            <div>
+                <img src="/styleguide/image/425x240" alt="Two column placeholder image 2">
+                <p>{{ $faker->text(60) }}</p>
+            </div>
+
+            <div>
+                <img src="/styleguide/image/425x240" alt="Two column placeholder image 3">
+                <p>{{ $faker->text(60) }}</p>
+            </div>
+
+            <div>
+                <img src="/styleguide/image/425x240" alt="Two column placeholder image 4">
+                <p>{{ $faker->text(60) }}</p>
+            </div>
+        </div>
+
+<pre class="code-block" tabindex="0">
+{!! htmlspecialchars('<div class="grid-two-col-layout">
+    <!-- Item one -->
+    <div>
+        <img src="https://base.wayne.edu/styleguide/image/425x240" alt="Placeholder image">
+        <p>'.$faker->text(30).'</p>
+    </div>
+
+    <!-- Item two -->
+    <div>
+        <img src="https://base.wayne.edu/styleguide/image/425x240" alt="Placeholder image">
+        <p>'.$faker->text(30).'</p>
+    </div>
+
+    <!-- Add more items to make a grid -->
+</div>') !!}
+</pre>
+        <h2 class="mt-10 my-4">Two columns image left</h2>
 
         <div class="two-col-layout">
-            <div class="flex-shrink-0">
-                <img src="/styleguide/image/300x200" alt="">
+            <div class="md:w-1/3 flex-shrink-0">
+                <img src="/styleguide/image/300x200" alt="Image left placeholder image">
             </div>
             <div>
                 <p>{{ $faker->text(250) }}</p>
@@ -17,12 +75,12 @@
         </div>
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
-    <div class="flex-shrink-0">
-        <img src="/styleguide/image/300x200" alt="Your image description">
+    <div class="md:w-1/3 flex-shrink-0">
+        <img src="https://base.wayne.edu/styleguide/image/300x200" alt="Your image description">
     </div>
     <div>
-        <p>'.$faker->paragraph.'</p>
-        <p>'.$faker->paragraph.'</p>
+        <p>'.$faker->text(60).'</p>
+        <p>'.$faker->text(60).'</p>
     </div>
 </div>')!!}
 </pre>
@@ -33,33 +91,33 @@
                 <p>{{ $faker->text(250) }}</p>
                 <p>{{ $faker->text(250) }}</p>
             </div>
-            <div class="flex-shrink-0">
-                <img src="/styleguide/image/300x200" alt="">
+            <div class="md:w-1/3 flex-shrink-0">
+                <img src="/styleguide/image/300x200" alt="Image right placeholder image">
             </div>
         </div>
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
     <div>
-        <p>'.$faker->paragraph.'</p>
-        <p>'.$faker->paragraph.'</p>
+        <p>'.$faker->text(60).'</p>
+        <p>'.$faker->text(60).'</p>
     </div>
-    <div>
-        <img src="/styleguide/image/300x200" alt="Your image description">
+    <div class="md:w-1/3 flex-shrink-0">
+        <img src="https://base.wayne.edu/styleguide/image/300x200" alt="Your image description">
     </div>
 </div>')!!}
 </pre>
 
         <h2 class="mt-10 mb-4">Two columns with a list</h2>
         <div class="two-col-layout">
-            <div class="md:w-2/3">
+            <div>
                 <p>{{ $faker->text(400) }}</p>
                 <p><a href="#" class="button">{{ ucfirst(implode(' ',$faker->words(2))) }}</a></p>
             </div>
-            <div class="md:w-1/3">
+            <div class="md:w-1/3 flex-shrink-0">
                 <ul>
-                    <li><a href="#">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
-                    <li><a href="#">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
-                    <li><a href="#">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
+                    <li><a href="/">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
+                    <li><a href="/">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
+                    <li><a href="/">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
                     <li><a href="#">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
                     <li><a href="#">{{ ucfirst(implode(' ',$faker->words(4))) }}</a></li>
                 </ul>
@@ -68,11 +126,11 @@
 
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
-    <div class="md:w-2/3">
-        <p>'.$faker->text(400).'</p>
+    <div>
+        <p>'.$faker->text(60).'</p>
         <p><a href="#" class="button">'.ucfirst(implode(' ',$faker->words(2))).'</a></p>
     </div>
-    <div class="md:w-1/3">
+    <div class="md:w-1/3 flex-shrink-0">
         <ul>
             <li><a href="#">'.ucfirst(implode(' ',$faker->words(4))).'</a></li>
             <li><a href="#">'.ucfirst(implode(' ',$faker->words(4))).'</a></li>
@@ -80,45 +138,9 @@
     </div>
 </div>') !!}
 </pre>
-        <h2 class="mt-10 mb-4">Two column grid</h2>
+        <h2 class="mt-10">Three equal columns</h2>
 
-        <div class="grid-two-col-layout">
-            <div>
-                <img src="/styleguide/image/450x250?text=450x250" alt="">
-                <p>{{ $faker->text(50) }}</p>
-            </div>
-
-            <div>
-                <img src="/styleguide/image/450x250" alt="">
-                <p>{{ $faker->text(50) }}</p>
-            </div>
-
-            <div>
-                <img src="/styleguide/image/450x250" alt="">
-                <p>{{ $faker->text(50) }}</p>
-            </div>
-
-            <div>
-                <img src="/styleguide/image/450x250" alt="">
-                <p>{{ $faker->text(50) }}</p>
-            </div>
-        </div>
-
-<pre class="code-block" tabindex="0">
-{!! htmlspecialchars('<div class="grid-two-col-layout">
-    <!-- Item one -->
-    <div>
-        <img src="/styleguide/image/450x250" alt="">
-        <p>'.$faker->paragraph.'</p>
-    </div>
-
-    <!-- Duplicate this item as many times as necessary -->
-</div>') !!}
-</pre>
-
-        <h2 class="mt-10 mb-4">Three column grid</h2>
-
-        <div class="grid-three-col-layout">
+        <div class="grid-three-col-layout mt-4">
             <div>
                 <img src="/styleguide/image/268x200" alt="">
                 <p>{{ $faker->text(60) }}</p>
@@ -151,10 +173,22 @@
     <!-- Item one -->
     <div>
         <img src="/styleguide/image/268x268" alt="">
-        <p>'.$faker->paragraph.'</p>
+        <p>'.$faker->text(60).'</p>
     </div>
 
-    <!-- Duplicate this item as many times as necessary -->
+    <!-- Item two -->
+    <div>
+        <img src="/styleguide/image/268x268" alt="">
+        <p>'.$faker->text(60).'</p>
+    </div>
+
+    <!-- Item three -->
+    <div>
+        <img src="/styleguide/image/268x268" alt="">
+        <p>'.$faker->text(60).'</p>
+    </div>
+
+    <!-- Add more items to make a grid -->
 </div>') !!}
 </pre>
     </div>

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -18,6 +18,16 @@
                 "relative_url": "/styleguide",
                 "submenu": []
             },
+            "100200": {
+                "menu_item_id": 100200,
+                "is_active": 1,
+                "page_id": 100200,
+                "target": "",
+                "display_name": "Basic layouts",
+                "class_name": "",
+                "relative_url": "/styleguide/basiclayouts",
+                "submenu": []
+            },
             "100900": {
                 "menu_item_id": 100900,
                 "is_active": 1,
@@ -66,16 +76,6 @@
                 "display_name": "Figure",
                 "class_name": "",
                 "relative_url": "/styleguide/figure",
-                "submenu": []
-            },
-            "100200": {
-                "menu_item_id": 100200,
-                "is_active": 1,
-                "page_id": 100200,
-                "target": "",
-                "display_name": "Basic layouts",
-                "class_name": "",
-                "relative_url": "/styleguide/basiclayouts",
                 "submenu": []
             },
             "100800": {


### PR DESCRIPTION
- Reducing menu top height by removing the line height on the title
- Fixed doubled-up events header on the homepage template 
- Clarified how to use a two column responsive layout in the CMS 

|Before|After|
|-----|-----|
|![image](https://user-images.githubusercontent.com/2616607/184986690-7ddb40f6-f319-4671-8fdf-a25981f593ea.png)|![image](https://user-images.githubusercontent.com/2616607/184986736-a15b470f-e0c0-4e3c-99c5-cc6293f0d352.png)|
|![screencapture-base-wayne-edu-2022-08-16-17_20_10](https://user-images.githubusercontent.com/2616607/184987248-48cf3557-239f-41b0-8a49-b0260de81dc5.jpg)|![image](https://user-images.githubusercontent.com/2616607/184986834-db526629-a57e-4a97-b167-55a75681936f.png)|

