### PR TITLE
Feature/slate

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9060,5 +9060,5 @@
         "php": "^8.0.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/resources/scss/components/_slate.scss
+++ b/resources/scss/components/_slate.scss
@@ -6,12 +6,16 @@
 
 .form_response {
     @apply border-0;
+
+    label {
+        @apply border-0;
+    }
 }
 
 .form_responses div[id*="maxlength"] {
     @apply border-0;
 }
 
-button.default {
-    @extend button;
+.form_button_submit {
+    @extend .button;
 }


### PR DESCRIPTION
Remove border on checkbox items on slate forms. 
target slate form class `form_button_submit`
Before
![screencapture-base-wayne-edu-styleguide-forms-slate-2023-02-03-16_44_11](https://user-images.githubusercontent.com/41925609/216718108-feb2ba1e-532f-4d67-912b-d4b03342d722.png)

After
![screencapture-base-wayne-local-styleguide-forms-slate-2023-02-03-16_42_05](https://user-images.githubusercontent.com/41925609/216718174-0a48437a-a2a8-4950-9486-7c0b561a9914.png)
