### PR TITLE
feature/events-listing -  #162609 Base - Events style error

### DIFF
--- a/resources/views/components/events-listing.blade.php
+++ b/resources/views/components/events-listing.blade.php
@@ -17,7 +17,7 @@
                     </div>
                 @endif
 
-                <div class="mx-2 grow-0{{ ! $loop->first ? ' ml-19' :'' }}">
+                <div class="mx-2 grow{{ ! $loop->first ? ' ml-19' :'' }}">
                     <div class="mb-2 pb-2 border-b border-solid border-gray-300">
                         <a class="block hover:underline" href="{{ $event['url'] }}">{{ $event['title'] }}
                             <span class="visually-hidden"> on {{ apdatetime(date('M d, Y' , strtotime($key))) }}


### PR DESCRIPTION
## Reason for change

- Distribute leftover space proportionally

## Required checklist

- [ x ] TP3 link: [#162609 Base - Events style error](https://waynedotedu.tpondemand.com/entity/162609-base-events-style-error)
- [ x ] Related CMS link: [https://content.wayne.edu/site.php?project=1561](https://content.wayne.edu/site.php?project=1561)
- [ x ] Screen shot or video of before/after

## Reminders

- Update package version number
- Duque Axe accessibility check
- Verified each page looks good on each viewport size
- Add an example to the styleguide if applicable
- Add tests to prove the code works
- Provide CMS site link if applicable

## Screenshots / Videos

| Before | After |
|![image](https://user-images.githubusercontent.com/89077791/217318104-825b3924-19aa-4959-afe3-4267ac988b4c.png)|![image](https://user-images.githubusercontent.com/89077791/217318528-3336f09a-9e71-4cb9-b31e-d35a22c59995.png)|
|