### PR TITLE
Google Font embed code update to help with page speed

### DIFF
--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -8,9 +8,9 @@
     <link rel="icon" type="image/x-icon" href="https://wayne.edu/favicon.ico">
     <link rel="stylesheet" href="{{ mix('_resources/css/main.css') }}">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com/" crossorigin>
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com/">
-    <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
     
     @if(!empty($base['page']['canonical']))<link rel="canonical" href="{{ $base['page']['canonical'] }}">@endif
 


### PR DESCRIPTION
## Reason for change

An update to the Google Fonts embed code

## Relevant links

- https://fonts.google.com/

## Resolves

<img width="723" alt="Google Lighthouse score" src="https://user-images.githubusercontent.com/37359/218891163-8daa3b6d-bcf0-4b3b-9353-f63419f90ffe.png">