### PR TITLE
Ensuring profiles and news have profiles to have canonical URLs defined

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -88,8 +88,8 @@ class ArticleController extends Controller
         }
 
         $request->data['base']['page']['title'] = $article['article']['data']['title'];
-
         $request->data['page']['description'] = $article['article']['data']['meta_description'];
+        $request->data['page']['canonical'] = $request->data['server']['url'];
 
         if (!empty($article['article']['data']['hero_image']['url'])) {
             $request->data['base']['hero'][]['relative_url'] = $article['article']['data']['hero_image']['url'];

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -113,6 +113,7 @@ class ProfileController extends Controller
 
         // Change page title to profile name
         $request->data['base']['page']['title'] = $this->profile->getPageTitleFromName($profile);
+        $request->data['page']['canonical'] = $request->data['server']['url'];
 
         // Set the back URL
         $request->data['back_url'] = $this->profile->getBackToProfileListUrl($request->server->get('HTTP_REFERER'), $request->server->get('REQUEST_SCHEME'), $request->server->get('HTTP_HOST'), $request->server->get('REQUEST_URI'));


### PR DESCRIPTION
## Reason for change

Ensures Google is only indexing the preferred URLs for pages even after redirects.