### PR TITLE
Gitignore the previously included tools directory to avoid confusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,9 @@ npm-debug.log
 yarn-error.log
 cs_fixer_tmp*
 .php_cs.cache
+.php-cs-fixer.cache
 /public/mix-manifest.json
 /*.diff
 .phpunit.result.cache
 .env.backup
+/tools


### PR DESCRIPTION
To avoid file commits if upgrading an existing repo without doing a clean clone.