### PR TITLE
Fixed article and profile tests with server url fallback

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -89,7 +89,7 @@ class ArticleController extends Controller
 
         $request->data['base']['page']['title'] = $article['article']['data']['title'];
         $request->data['page']['description'] = $article['article']['data']['meta_description'];
-        $request->data['page']['canonical'] = $request->data['server']['url'];
+        $request->data['page']['canonical'] = $request->data['server']['url'] ?? '';
 
         if (!empty($article['article']['data']['hero_image']['url'])) {
             $request->data['base']['hero'][]['relative_url'] = $article['article']['data']['hero_image']['url'];

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -113,7 +113,7 @@ class ProfileController extends Controller
 
         // Change page title to profile name
         $request->data['base']['page']['title'] = $this->profile->getPageTitleFromName($profile);
-        $request->data['page']['canonical'] = $request->data['server']['url'];
+        $request->data['page']['canonical'] = $request->data['server']['url'] ?? '';
 
         // Set the back URL
         $request->data['back_url'] = $this->profile->getBackToProfileListUrl($request->server->get('HTTP_REFERER'), $request->server->get('REQUEST_SCHEME'), $request->server->get('HTTP_HOST'), $request->server->get('REQUEST_URI'));
@@ -123,6 +123,7 @@ class ProfileController extends Controller
 
         // Disable hero images
         $request->data['base']['hero'] = false;
+
 
         return view('profile-view', merge($request->data, $profile, $fields));
     }


### PR DESCRIPTION
🤦  Added a fallback for server variables which are not available in the Article and Profile styleguide tests. This also ensures these pages don't error in the event the server variable isn't available on a regular request.