### PR TITLE
feature/dropdown-menu-arrow - remove overflow hidden and right padding

### DIFF
--- a/styleguide/Views/styleguide-forms.blade.php
+++ b/styleguide/Views/styleguide-forms.blade.php
@@ -65,7 +65,7 @@
                 </div>
                 <div class="xlarge-4 large-4 medium-12 small-12 columns field_country end">
                     <label for="country">Country <em>*</em></label>
-                    <div class="border-gray-400 border overflow-hidden pr-4 select">
+                    <div class="border-gray-400 border select">
                         <select name="country" id="country" class="required" aria-required="true">
                             <option value="">Please Select</option>
                             <option value="First Choice">First Choice</option>
@@ -136,7 +136,7 @@
             <div class="row">
                 <div class="xlarge-8 large-8 medium-12 small-12 columns field_f_7594">
                     <label for="f_7594">Drop Down (Single Answer)</label>
-                    <div class="select border-gray-400 border overflow-hidden pr-4">
+                    <div class="select border-gray-400 border">
                         <select name="f_7594" id="f_7594">
                             <option value="" selected="selected">Please Select</option>
                             <option value="First Choice">First Choice</option>


### PR DESCRIPTION
## Reason for change

- Accessibility.  Now the container is fully selected when tabbing through

## Reminders

- Update package version number
- Duque Axe accessibility check
- Verified each page looks good on each viewport size
- Add an example to the styleguide if applicable
- Add tests to prove the code works
- Provide CMS site link if applicable

## Screenshots / Videos

| Before | After |
|--------|--------|
|<img width="298" alt="image" src="https://user-images.githubusercontent.com/89077791/222773218-8729e83f-3d66-47a2-a3ba-927a7e626660.png">|<img width="308" alt="image" src="https://user-images.githubusercontent.com/89077791/222773287-7d030c91-299b-4b73-81e9-b049aaa4eae0.png">|