### PR TITLE
feature/cms-layout

### DIFF
--- a/styleguide/Views/styleguide-basic-layouts.blade.php
+++ b/styleguide/Views/styleguide-basic-layouts.blade.php
@@ -66,7 +66,7 @@
 
         <div class="two-col-layout">
             <div class="md:w-1/3 flex-shrink-0">
-                <img src="/styleguide/image/300x200" alt="Image left placeholder image">
+                <img src="/styleguide/image/600x400" alt="Image left placeholder image">
             </div>
             <div class="w-full">
                 <p>{{ $faker->text(250) }}</p>
@@ -76,7 +76,7 @@
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
     <div class="md:w-1/3 flex-shrink-0">
-        <img src="https://base.wayne.edu/styleguide/image/300x200" alt="Your image description">
+        <img src="https://via.placeholder.com/600x400" alt="Your image description">
     </div>
     <div>
         <p>'.$faker->text(60).'</p>
@@ -92,7 +92,7 @@
                 <p>{{ $faker->text(250) }}</p>
             </div>
             <div class="md:w-1/3 flex-shrink-0">
-                <img src="/styleguide/image/300x200" alt="Image right placeholder image">
+                <img src="/styleguide/image/600x400" alt="Image right placeholder image">
             </div>
         </div>
 <pre class="code-block" tabindex="0">
@@ -102,7 +102,7 @@
         <p>'.$faker->text(60).'</p>
     </div>
     <div class="md:w-1/3 flex-shrink-0">
-        <img src="https://base.wayne.edu/styleguide/image/300x200" alt="Your image description">
+        <img src="https://via.placeholder.com/600x400" alt="Your image description">
     </div>
 </div>')!!}
 </pre>

--- a/styleguide/Views/styleguide-basic-layouts.blade.php
+++ b/styleguide/Views/styleguide-basic-layouts.blade.php
@@ -66,7 +66,7 @@
 
         <div class="two-col-layout">
             <div class="md:w-1/3 flex-shrink-0">
-                <img src="/styleguide/image/600x400" alt="Image left placeholder image">
+                <img src="/styleguide/image/600x400" alt="Left placeholder image">
             </div>
             <div class="w-full">
                 <p>{{ $faker->text(250) }}</p>
@@ -92,7 +92,7 @@
                 <p>{{ $faker->text(250) }}</p>
             </div>
             <div class="md:w-1/3 flex-shrink-0">
-                <img src="/styleguide/image/600x400" alt="Image right placeholder image">
+                <img src="/styleguide/image/600x400" alt="Right placeholder image">
             </div>
         </div>
 <pre class="code-block" tabindex="0">

--- a/styleguide/Views/styleguide-basic-layouts.blade.php
+++ b/styleguide/Views/styleguide-basic-layouts.blade.php
@@ -68,7 +68,7 @@
             <div class="md:w-1/3 flex-shrink-0">
                 <img src="/styleguide/image/300x200" alt="Image left placeholder image">
             </div>
-            <div>
+            <div class="w-full">
                 <p>{{ $faker->text(250) }}</p>
                 <p>{{ $faker->text(250) }}</p>
             </div>
@@ -87,7 +87,7 @@
         <h2 class="mt-10 mb-4">Two columns image right</h2>
 
         <div class="two-col-layout">
-            <div>
+            <div class="w-full">
                 <p>{{ $faker->text(250) }}</p>
                 <p>{{ $faker->text(250) }}</p>
             </div>
@@ -97,7 +97,7 @@
         </div>
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
-    <div>
+    <div class="w-full">
         <p>'.$faker->text(60).'</p>
         <p>'.$faker->text(60).'</p>
     </div>
@@ -109,7 +109,7 @@
 
         <h2 class="mt-10 mb-4">Two columns with a list</h2>
         <div class="two-col-layout">
-            <div>
+            <div class="w-full">
                 <p>{{ $faker->text(400) }}</p>
                 <p><a href="#" class="button">{{ ucfirst(implode(' ',$faker->words(2))) }}</a></p>
             </div>
@@ -126,7 +126,7 @@
 
 <pre class="code-block" tabindex="0">
 {!! htmlspecialchars('<div class="two-col-layout">
-    <div>
+    <div class="w-full">
         <p>'.$faker->text(60).'</p>
         <p><a href="#" class="button">'.ucfirst(implode(' ',$faker->words(2))).'</a></p>
     </div>


### PR DESCRIPTION
## Reason for change

If there isn't enough text, the div doesn't expand to full width


## Screenshots / Videos

| Before | After |
|--------|--------|
|<img width="1243" alt="Screenshot 2023-03-06 at 8 39 04 PM" src="https://user-images.githubusercontent.com/2616607/223296982-1228cd61-3054-4fa3-85a9-4859b5af2916.png">|<img width="1221" alt="Screenshot 2023-03-06 at 8 38 56 PM" src="https://user-images.githubusercontent.com/2616607/223296998-4635e5fa-a880-423b-bceb-4fa234bd9ad8.png">|

