### PR TITLE
Updated profile listing dropdown area to use native select arrow

### DIFF
--- a/resources/views/profile-listing.blade.php
+++ b/resources/views/profile-listing.blade.php
@@ -8,13 +8,13 @@
             <label for="filter-group" class="text-black block mb-2">View by department:</label>
             <div class="row -mx-4">
                 <div class="w-5/6 px-4 inline-block relative w-64 mb-6 flex items-center text-black">
-                    <svg class="fill-current h-4 w-4 absolute mr-4 right-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
-                    <select name="group" id="filter-group">
-                        @foreach($dropdown_groups as $key=>$value)
-                            <option value="{{ $key }}"@if($key == $selected_group) selected="selected"@endif>{{ $value }}</option>
-                        @endforeach
-                    </select>
-                </div>
+                    <div class="border-gray-400 border select">
+                        <select name="group" id="filter-group">
+                            @foreach($dropdown_groups as $key=>$value)
+                                <option value="{{ $key }}"@if($key == $selected_group) selected="selected"@endif>{{ $value }}</option>
+                            @endforeach
+                        </select>
+                    </div>
                 <div class="w-1/6 px-4">
                     <input type="submit" value="Filter" class="postfix button expanded" />
                 </div>


### PR DESCRIPTION
## Reason for change

Updated profile listing dropdown area to use native select arrow to match other forms and omit double arrow

## Demo

| Before | After |
| ------------- | ------------- |
| ![Screen Shot 2023-04-24 at 10 58 19 AM](https://user-images.githubusercontent.com/5089876/234080249-57cc883b-4e12-423b-b5a4-a5f49faa11e4.png)  | ![Screen Shot 2023-04-24 at 10 57 56 AM](https://user-images.githubusercontent.com/5089876/234080318-336830d7-77b3-46b1-9f4a-f82e10bfaae6.png)  |
| ![Screen Shot 2023-04-24 at 10 32 42 AM](https://user-images.githubusercontent.com/5089876/234080391-cb952fe2-6d5e-4a65-ab26-ac133420ea31.png)  | ![Screen Shot 2023-04-24 at 10 57 28 AM](https://user-images.githubusercontent.com/5089876/234080415-5f23da9c-64a4-453f-bb15-90e7c3a4fc88.png)  |
