### PR TITLE
Replace the site title H1 to ensure there is only one primary H1 on a page

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,7 +1,7 @@
 <div class="wsuheader">
     <div class="wsuheaderwrap">
         <div class="wsuwordmark">
-            <h1>
+            <div>
                 <a href="https://wayne.edu/" aria-labelledby="wsuheader-title">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 605 65" preserveAspectRatio="xMaxYMin meet">
                         <title id="wsuheader-title">Wayne State University</title>
@@ -14,7 +14,7 @@
                         <path class="wm6" d="M41.7 21.8l-2.1 4.8 2.1 4.7c7.4-5.3 8.7-10.7 8.7-10.7l-4.2-4.8h11.9c0 8.2-5.3 17.8-18.1 28.1l-4.3-11-4.3 11c-12.7-10.2-18-19.8-18-28h11.9L21 20.7s1.3 5.4 8.7 10.7l2.1-4.7-2.1-4.8h12v-.1z"/>
                     </svg>
                 </a>
-            </h1>
+            </div>
         </div>
 
         <div class="wsumenu">

--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -19,7 +19,7 @@
                 <div class="w-full relative text-white flex flex-col justify-center">
                     <div class="row w-full px-4 pt-10 pb-6 text-center md:white-links content">
                         @if(!empty($image['secondary_relative_url']))<img class="mx-auto mb-4" src="{{ $image['secondary_relative_url'] }}" alt="{{ $image['secondary_alt_text'] }}">@endif
-                        <h1 class="md:text-shadow-darkest leading-tight text-2xl mb-1 @if(in_array($base['page']['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</h1>
+                        <div class="md:text-shadow-darkest leading-tight text-2xl mb-1 @if(in_array($base['page']['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</div>
                         @if(!empty($image['description']))<div class="md:text-lg">{!! $image['description'] !!}</div>@endif
                     </div>
                 </div>
@@ -30,7 +30,7 @@
                 <div class="relative md:absolute print:relative md:bottom-0 md:inset-x-0 md:text-white md:white-links content md:bg-gradient-darkest">
                     <div class="row">
                         <div class="mx-4 relative pb-0 pt-4 @if(in_array($base['page']['controller'], config('base.hero_full_controllers'))) md:pb-2 md:pt-8 md:pt-20 @else md:pt-12 @endif">
-                            <h1 class="md:text-shadow-darkest leading-tight text-2xl mb-1 @if(in_array($base['page']['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</h1>
+                            <div class="md:text-shadow-darkest leading-tight text-2xl mb-1 @if(in_array($base['page']['controller'], config('base.hero_full_controllers')))xl:text-5xl @else xl:text-3xl @endif">{{ $image['title'] }}</div>
                             @if(!empty($image['description']))<div class="md:text-lg">{!! $image['description'] !!}</div>@endif
                         </div>
                     </div>
@@ -43,4 +43,3 @@
         @endif
     @endforeach
 </div>
-

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -13,11 +13,11 @@
                 ) &&
                 !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
             )
-                <h1 class="text-base mb-0 font-normal leading-tight">
+                <div class="text-base mb-0 font-normal leading-tight">
                     <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black">{{ config('base.surtitle') }}</a>
-                </h1>
+                </div>
 
-                <h2 class="font-normal mb-1 text-2xl leading-none">
+                <div class="font-normal mb-1 text-2xl leading-none">
                     <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
@@ -26,9 +26,9 @@
                             {{ $site['title'] }}
                         @endif
                     </a>
-                </h2>
+                </div>
             @else
-                <h1 class="font-normal mb-0 text-2xl leading-none py-3">
+                <div class="font-normal mb-0 text-2xl leading-none py-3">
                     <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
@@ -37,7 +37,7 @@
                             {{ $site['title'] }}
                         @endif
                     </a>
-                </h1>
+                </div>
             @endif
         </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,9 +1451,9 @@
   integrity sha512-d1DRATJmgLdmE7ne4k6IHhWjH4pv0ofFLjscgtvPCv+F0+bv4SHUwZDmkB6B9rHIqIwNXq8jegi+0IXocrtu4A==
 
 "@waynestate/wsuheader@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@waynestate/wsuheader/-/wsuheader-2.2.0.tgz#a74d4ad9e7fe4c01eb7e693fa2b6b0fb9ee0e7c1"
-  integrity sha512-MUulesTHg9zZMq5EwxXjgfpAnOBnmJKzHemsvFNbbXiksPL3qFq0sOXlXHXov8Xhpj9zAoGZDy05WTf5uOD0Ww==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@waynestate/wsuheader/-/wsuheader-2.2.1.tgz#d1f88552170ea535bf8509f8c2f6bb49654726cf"
+  integrity sha512-4dUCSgsVWZKvvc5KDuGnem+jB/83ibskWyf45KpUEQ7yMFRoLS27Fin5vV5DlDdWD3kybCAOEtAoV2u+qZBDlQ==
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"


### PR DESCRIPTION
## Reason for change

SEO enhancement. This upgrades the [wsuheader package](https://github.com/waynestate/wsuheader/pull/54) and removes the h1 tags for the site title. This results in only a single H1 tag on the site for the page title.

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-14 at 3 24 05 PM](https://github.com/waynestate/base-site/assets/37359/5d4d0520-a4c1-47c6-b08f-ac5c8f13d27d) | ![Screenshot 2023-07-14 at 3 41 24 PM](https://github.com/waynestate/base-site/assets/37359/5c13c829-4c1e-461e-97de-ec0fc90b753e) |

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-14 at 3 24 27 PM](https://github.com/waynestate/base-site/assets/37359/8e1b96d4-faa3-42a5-a322-fd4947c7e649) | ![Screenshot 2023-07-14 at 3 41 15 PM](https://github.com/waynestate/base-site/assets/37359/78189016-c357-4485-8bf3-c2df2349d561) |

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-14 at 3 41 50 PM](https://github.com/waynestate/base-site/assets/37359/2b48e094-bf0f-4c54-a010-368b30aa5d20) | ![Screenshot 2023-07-14 at 3 41 35 PM](https://github.com/waynestate/base-site/assets/37359/479fcb44-00ef-4180-a5bd-d0a1e082d50b) |

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-14 at 3 50 14 PM](https://github.com/waynestate/base-site/assets/37359/8e78d131-840b-4192-ac85-bbe8da79a299) | ![Screenshot 2023-07-14 at 3 50 27 PM](https://github.com/waynestate/base-site/assets/37359/a74a95fa-d688-4b67-8d1d-642c918daf74) |