### PR TITLE
Removed Str helper class from database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -125,7 +123,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => Str::slug(env('APP_NAME', 'laravel')).':',
+            'prefix' => env('APP_NAME', 'laravel').':',
         ],
 
         'default' => [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.4.2",
+  "version": "8.4.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Removed Str helper class from database config to satisfy post-site creation Pint validation

Due to the `site-setup new...` process, the `prefix` keys are all replaced by the actual site name instead of using the `.env` variable. This causes the `Str` import to no longer be needed but the build script doesn't clean up that import and `make phplint` fails because `Str` is imported by not used.

This removes the import so Base passes Pint on its own and as a newly generated site.

## Demo

![Screenshot 2023-08-23 at 6 35 09 AM](https://github.com/waynestate/base-site/assets/37359/43560d8d-7d55-499c-b625-8bb2746bec05)
