### PR TITLE
Hotfix/8.5.1 - News images, news/events config

### DIFF
--- a/app/Repositories/EventRepository.php
+++ b/app/Repositories/EventRepository.php
@@ -31,13 +31,13 @@ class EventRepository implements EventRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getEvents($site_id)
+    public function getEvents($site_id, $limit = 4)
     {
         $params = [
             'method' => 'calendar.events.listing',
             'site' => $site_id,
-            'limit' => 4,
-            'end_date' => date('Y-m-d', strtotime('+6 month')),
+            'limit' => $limit ?? 4,
+            'end_date' => $end_date ?? date('Y-m-d', strtotime('+6 month')),
         ];
 
         $events['events'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -63,10 +63,16 @@ class ModularPageRepository implements ModularPageRepositoryContract
                 $events = $this->event->getEvents($component['id']);
                 $modularComponents[$name]['data'] = $events['events'] ?? [];
                 $modularComponents[$name]['component'] = $components['components'][$name];
+                if (empty($modularComponents[$name]['component']['cal_name']) && !empty($data['site']['events']['path'])) {
+                    $modularComponents[$name]['component']['cal_name'] = $data['site']['events']['path'];
+                }
             } elseif(Str::startsWith($name, 'news') && !empty($component['id'])) {
                 $articles = $this->article->listing($component['id']);
                 $modularComponents[$name]['data'] = $articles['articles'] ?? [];
                 $modularComponents[$name]['component'] = $components['components'][$name];
+                if (empty($modularComponents[$name]['component']['news_route'])) {
+                    $modularComponents[$name]['component']['news_route'] = config('base.news_listing_route');
+                }
             } else {
                 $modularComponents[$name]['data'] = $promos[$name]['data'] ?? [];
                 $modularComponents[$name]['component'] = $promos[$name]['component'] ?? [];

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -59,20 +59,28 @@ class ModularPageRepository implements ModularPageRepositoryContract
         $promos = $this->getPromos($components);
 
         foreach($components['components'] as $name => $component) {
-            if(Str::startsWith($name, 'events') && !empty($component['id'])) {
-                $events = $this->event->getEvents($component['id']);
+            if(Str::startsWith($name, 'events')) {
+                $components['components'][$name]['id'] = $component['id'] ?? $data['site']['id'];
+                $events = $this->event->getEvents($component['id'] ?? $data['site']['id']);
                 $modularComponents[$name]['data'] = $events['events'] ?? [];
                 $modularComponents[$name]['component'] = $components['components'][$name];
                 if (empty($modularComponents[$name]['component']['cal_name']) && !empty($data['site']['events']['path'])) {
                     $modularComponents[$name]['component']['cal_name'] = $data['site']['events']['path'];
                 }
-            } elseif(Str::startsWith($name, 'news') && !empty($component['id'])) {
-                $articles = $this->article->listing($component['id']);
+            } elseif(Str::startsWith($name, 'news')) {
+                $components['components'][$name]['id'] = $component['id'] ?? $data['site']['news']['application_id'];
+                $components['components'][$name]['limit'] = $component['limit'] ?? 4;
+                $components['components'][$name]['news_route'] = $component['news_route'] ?? config('base.news_listing_route');
+                if (!empty($component['featured']) && $component['featured'] === true) {
+                    $articles = $this->article->listing($components['components'][$name]['id'], 50, 1, $component['topics'] ?? []);
+                    $articles['articles']['data'] = collect($articles['articles']['data'])->filter(function ($article) {
+                        return !empty($article['featured']['featured']) && $article['featured']['featured'] === 1;
+                    })->take($component['limit'] ?? 4)->toArray();
+                } else {
+                    $articles = $this->article->listing($components['components'][$name]['id'], $component['limit'] ?? 4, 1, $component['topics'] ?? []);
+                }
                 $modularComponents[$name]['data'] = $articles['articles'] ?? [];
                 $modularComponents[$name]['component'] = $components['components'][$name];
-                if (empty($modularComponents[$name]['component']['news_route'])) {
-                    $modularComponents[$name]['component']['news_route'] = config('base.news_listing_route');
-                }
             } else {
                 $modularComponents[$name]['data'] = $promos[$name]['data'] ?? [];
                 $modularComponents[$name]['component'] = $promos[$name]['component'] ?? [];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/modular/components/events-column.blade.php
+++ b/resources/views/modular/components/events-column.blade.php
@@ -37,7 +37,7 @@
             @endforeach
             @if($dates == end($data))
                 <li class="flex -mx-2 ml-17">
-                    <a href="//events.wayne.edu/{{ $dates[0]['calendar_url'] ?? 'main/' }}month/" class="hover:underline">{{ $link_text ?? 'More events' }}</a>
+                    <a href="//events.wayne.edu/{{ $component['cal_name'] ?? 'main/' }}month/" class="hover:underline">{{ $component['link_text'] ?? 'More events' }}</a>
                 </li>
             @endif
         @endforeach

--- a/resources/views/modular/components/events-column.blade.php
+++ b/resources/views/modular/components/events-column.blade.php
@@ -37,7 +37,7 @@
             @endforeach
             @if($dates == end($data))
                 <li class="flex -mx-2 ml-17">
-                    <a href="//events.wayne.edu/{{ $component['cal_name'] ?? 'main/' }}month/" class="hover:underline">{{ $component['link_text'] ?? 'More events' }}</a>
+                    <a href="//events.wayne.edu/{{ $component['cal_name'] ?? 'main/' }}upcoming" class="hover:underline">{{ $component['link_text'] ?? 'More events' }}</a>
                 </li>
             @endif
         @endforeach

--- a/resources/views/modular/components/news-column.blade.php
+++ b/resources/views/modular/components/news-column.blade.php
@@ -18,5 +18,5 @@
         </ul>
     @endif
 
-    <a href="/{{ $component['news_route'] ?? config('base.news_listing_route') }}/" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
+    <a href="/{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
 </div>

--- a/resources/views/modular/components/news-column.blade.php
+++ b/resources/views/modular/components/news-column.blade.php
@@ -18,5 +18,5 @@
         </ul>
     @endif
 
-    <a href="/{{ config('base.news_listing_route').'/' }}" class="block my-4 underline hover:no-underline">More news</a>
+    <a href="/{{ $component['news_route'] ?? config('base.news_listing_route') }}/" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
 </div>

--- a/resources/views/modular/components/news-row.blade.php
+++ b/resources/views/modular/components/news-row.blade.php
@@ -20,7 +20,7 @@
             @endforeach
         </ul>
         <div class="text-center lg:text-right mt-4">
-            <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}/" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
+            <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
         </div>
     @endif
 </div>

--- a/resources/views/modular/components/news-row.blade.php
+++ b/resources/views/modular/components/news-row.blade.php
@@ -1,0 +1,26 @@
+{{--
+    $news => array // [['news_id', 'slug', 'title', filename]]
+    $site => array // ['subsite-folder']
+    $heading => string // 'News'
+    $url => string '/news.php'
+    $link_text => string // 'More news'
+--}}
+<div class="col-span-2">
+    @if(!empty($component['heading']))<h2 class="mt-0">{{ $component['heading'] }}</h2>@endif
+
+    @if(!empty($data['data']))
+        <ul class="grid gap-x-6 gap-y-4 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-{{ !empty($component['limit']) ? $component['limit'] : '4' }}">
+            @foreach($data['data'] as $item)
+                <li class="group flex items-start md:block">
+                    <a class="group-hover:no-underline flex items-start md:block" href="{{ $item['link'] }}">
+                        @image($item['featured']['url'] ?? 'https://wayne.edu/opengraph/wsu-social-share.png', $item['featured']['alt_text'] ?? 'Wayne State University', 'block lazy w-1/3 shrink-0 mr-2 mb-2 md:w-full md:mr-0 md:shrink')
+                        <p class="group-hover:underline leading-snug font-bold">{{ $item['title'] }}</p>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+        <div class="text-center lg:text-right mt-4">
+            <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}/" class="block my-4 underline hover:no-underline">{{ $component['link_text'] ?? 'More news' }}</a>
+        </div>
+    @endif
+</div>

--- a/resources/views/modular/modularpage.blade.php
+++ b/resources/views/modular/modularpage.blade.php
@@ -10,7 +10,9 @@
     <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
         @if(!empty($components))
             @foreach($components as $componentName => $component)
-                @include('modular/components/'.$component['component']['filename'], ['data' => $component['data'], 'component' => $component['component']])
+                @if(!empty($component['data']) && !empty($component['component']['filename']))
+                    @include('modular/components/'.$component['component']['filename'], ['data' => $component['data'], 'component' => $component['component']])
+                @endif
             @endforeach
         @endif
     </div>

--- a/styleguide/Http/Controllers/ModularDocsController.php
+++ b/styleguide/Http/Controllers/ModularDocsController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use Illuminate\View\View;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Factories\GenericPromo;
+use Factories\Spotlight;
+use Factories\Article;
+use Factories\Event;
+
+class ModularDocsController extends Controller
+{
+    /**
+     * Display the banner at the top of the page.
+     */
+    public function index(Request $request): View
+    {
+        $components = [
+            'catalog_1' => [
+                'data' => app(GenericPromo::class)->create(7, false, [
+                    'description' => '',
+                ]),
+                'component' => [
+                    'heading' => 'Four-column catalog',
+                    'filename' => 'catalog',
+                    'columns' => '4',
+                    'showDescription' => false,
+                ],
+            ],
+
+            'catalog_2' => [
+                'data' => app(GenericPromo::class)->create(2, false, [
+                ]),
+                'component' => [
+                    'heading' => 'One-column catalog',
+                    'filename' => 'catalog',
+                    'columns' => '1',
+                    'showDescription' => false,
+                ],
+            ],
+
+            'content-row_1' => [
+                'data' => app(GenericPromo::class)->create(1, false, [
+                    'title' => 'Content from promos'
+                ]),
+                'component' => [
+                    'filename' => 'content-row',
+                ],
+            ],
+
+            'accordion_1' => [
+                'data' => app(GenericPromo::class)->create(4, false),
+                'component' => [
+                    'filename' => 'accordion',
+                ],
+            ],
+
+            'image-column_1'=> [
+                'data' => app(GenericPromo::class)->create(1, false, [
+                    'title' => 'Featured news (image column)',
+                    'filename_url' => '/styleguide/image/770x434',
+                ]),
+                'component' => [
+                    'heading' => '',
+                    'filename' => 'image-column',
+                ],
+            ],
+
+            'news-column' => [
+                'data' => app(Article::class)->create(3, false),
+                'component' => [
+                    'heading' => 'Base news',
+                    'filename' => 'news-column',
+                ],
+            ],
+
+            'events-column' => [
+                'data' => app(Event::class)->create(4, false),
+                'component' => [
+                    'heading' => 'Base events',
+                    'filename' => 'events-column',
+                    'calendar_url' => '/myurl'
+                ],
+            ],
+
+            'image-column_2' => [
+                'data' => app(GenericPromo::class)->create(1, false, [
+                    'title' => 'Featured event (image column)',
+                    'filename_url' => '/styleguide/image/600x600',
+                ]),
+                'component' => [
+                    'heading' => '',
+                    'filename' => 'image-column',
+                ],
+            ],
+
+            'icons-column' => [
+                'data' => app(GenericPromo::class)->create(4, false),
+                'component' => [
+                    'heading' => 'Icons column',
+                    'filename' => 'icons-column',
+                ],
+            ],
+
+            'button-column' => [
+                'data' => app(GenericPromo::class)->create(4, false),
+                'component' => [
+                    'heading' => 'Button column',
+                    'filename' => 'button-column',
+                ],
+            ],
+
+            'spotlight' => [
+                'data' => app(Spotlight::class)->create(1, false),
+                'component' => [
+                    'heading' => 'Spotlight',
+                    'filename' => 'spotlight',
+                ],
+            ],
+
+            'video-row' => [
+                'data' => app(GenericPromo::class)->create(1, false),
+                'component' => [
+                    'heading' => 'Video',
+                    'filename' => 'video-row',
+                ],
+            ],
+
+            'video-column_1' => [
+                'data' => app(GenericPromo::class)->create(1, false),
+                'component' => [
+                    'heading' => 'Video column 1',
+                    'filename' => 'video-column',
+                ],
+            ],
+
+            'video-column_2' => [
+                'data' => app(GenericPromo::class)->create(1, false),
+                'component' => [
+                    'heading' => 'Video column 2',
+                    'filename' => 'video-column',
+                ],
+            ],
+        ];
+        dump($components);
+        return view('styleguide-modular-docs', merge($request->data, $components));
+    }
+}

--- a/styleguide/Http/Controllers/ModularDocsController.php
+++ b/styleguide/Http/Controllers/ModularDocsController.php
@@ -41,7 +41,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'content-row_1' => [
+            'content_row_1' => [
                 'data' => app(GenericPromo::class)->create(1, false, [
                     'title' => 'Content from promos'
                 ]),
@@ -54,10 +54,11 @@ class ModularDocsController extends Controller
                 'data' => app(GenericPromo::class)->create(4, false),
                 'component' => [
                     'filename' => 'accordion',
+                    'heading' => 'Accordion',
                 ],
             ],
 
-            'image-column_1'=> [
+            'image_column_1'=> [
                 'data' => app(GenericPromo::class)->create(1, false, [
                     'title' => 'Featured news (image column)',
                     'filename_url' => '/styleguide/image/770x434',
@@ -68,7 +69,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'news-column' => [
+            'news_column' => [
                 'data' => app(Article::class)->create(3, false),
                 'component' => [
                     'heading' => 'Base news',
@@ -76,7 +77,15 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'events-column' => [
+            'news_row_1' => [
+                'data' => app(Article::class)->create(4, false),
+                'component' => [
+                    'heading' => 'Base news',
+                    'filename' => 'news-column',
+                ],
+            ],
+
+            'events_column_1' => [
                 'data' => app(Event::class)->create(4, false),
                 'component' => [
                     'heading' => 'Base events',
@@ -85,7 +94,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'image-column_2' => [
+            'image_column_2' => [
                 'data' => app(GenericPromo::class)->create(1, false, [
                     'title' => 'Featured event (image column)',
                     'filename_url' => '/styleguide/image/600x600',
@@ -96,7 +105,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'icons-column' => [
+            'icons_column' => [
                 'data' => app(GenericPromo::class)->create(4, false),
                 'component' => [
                     'heading' => 'Icons column',
@@ -104,7 +113,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'button-column' => [
+            'button_column' => [
                 'data' => app(GenericPromo::class)->create(4, false),
                 'component' => [
                     'heading' => 'Button column',
@@ -120,7 +129,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'video-row' => [
+            'video_row' => [
                 'data' => app(GenericPromo::class)->create(1, false),
                 'component' => [
                     'heading' => 'Video',
@@ -128,7 +137,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'video-column_1' => [
+            'video_column_1' => [
                 'data' => app(GenericPromo::class)->create(1, false),
                 'component' => [
                     'heading' => 'Video column 1',
@@ -136,7 +145,7 @@ class ModularDocsController extends Controller
                 ],
             ],
 
-            'video-column_2' => [
+            'video_column_2' => [
                 'data' => app(GenericPromo::class)->create(1, false),
                 'component' => [
                     'heading' => 'Video column 2',
@@ -144,7 +153,7 @@ class ModularDocsController extends Controller
                 ],
             ],
         ];
-        dump($components);
+
         return view('styleguide-modular-docs', merge($request->data, $components));
     }
 }

--- a/styleguide/Http/Controllers/ModularDocsController.php
+++ b/styleguide/Http/Controllers/ModularDocsController.php
@@ -72,7 +72,7 @@ class ModularDocsController extends Controller
             'news_column' => [
                 'data' => app(Article::class)->create(3, false),
                 'component' => [
-                    'heading' => 'Base news',
+                    'heading' => 'News',
                     'filename' => 'news-column',
                 ],
             ],
@@ -80,7 +80,7 @@ class ModularDocsController extends Controller
             'news_row_1' => [
                 'data' => app(Article::class)->create(4, false),
                 'component' => [
-                    'heading' => 'Base news',
+                    'heading' => 'News row',
                     'filename' => 'news-column',
                 ],
             ],
@@ -88,7 +88,7 @@ class ModularDocsController extends Controller
             'events_column_1' => [
                 'data' => app(Event::class)->create(4, false),
                 'component' => [
-                    'heading' => 'Base events',
+                    'heading' => 'Events column',
                     'filename' => 'events-column',
                     'calendar_url' => '/myurl'
                 ],

--- a/styleguide/Pages/ModularDocs.php
+++ b/styleguide/Pages/ModularDocs.php
@@ -18,7 +18,7 @@ class ModularDocs extends Page
                 'id' => 101110700,
                 'content' => [
                     'main' => '
-                        <p>Docs- Use this template to display multiple promo groups on a single page. Row components will be full width, column components will be half. You will want to pair two columns next to each other.</p>
+                        <p>Use this template to display multiple promo groups on a single page. Row components will be full width, column components will be half. You will want to pair two columns next to each other.</p>
                         <p class="mb-8">To change the order of the components, we currently have to replace or delete and re-add the custom field.</p>
                         <ul class="accordion mt-4">
                             <li>

--- a/styleguide/Pages/ModularDocs.php
+++ b/styleguide/Pages/ModularDocs.php
@@ -38,6 +38,7 @@ class ModularDocs extends Page
                                                 <li><code>modular-image-column-1</code></li>
                                                 <li><code>modular-video-column-1</code></li>
                                                 <li><code>modular-news-column-1</code></li>
+                                                <li><code>modular-news-row-1</code></li>
                                                 <li><code>modular-events-column-1</code></li>
                                             </ul>
                                         </li>

--- a/styleguide/Pages/ModularDocs.php
+++ b/styleguide/Pages/ModularDocs.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Styleguide\Pages;
+
+use Factories\Page as PageFactory;
+
+class ModularDocs extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app(PageFactory::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ModularDocsController',
+                'title' => 'Modular page',
+                'id' => 101110700,
+                'content' => [
+                    'main' => '
+                        <p>Docs- Use this template to display multiple promo groups on a single page. Row components will be full width, column components will be half. You will want to pair two columns next to each other.</p>
+                        <p class="mb-8">To change the order of the components, we currently have to replace or delete and re-add the custom field.</p>
+                        <ul class="accordion mt-4">
+                            <li>
+                                <a href="#definition-page-setup" id="definition-page-setup"><span aria-hidden="true"></span>Page setup</a>
+                                <div class="content">
+                                    <ul>
+                                        <li>Select template "Modular Page."</li>
+                                        <li>Select from the following custom page fields:
+                                            <ul class="columns-2">
+                                                <li><code>modular-accordion-1</code></li>
+                                                <li><code>modular-content-row-1</code></li>
+                                                <li><code>modular-video-row-1</code></li>
+                                                <li><code>modular-button-row-1</code></li>
+                                                <li><code>modular-catalog-1</code></li>
+                                                <li><code>modular-button-column-1</code></li>
+                                                <li><code>modular-icons-column-1</code></li>
+                                                <li><code>modular-image-column-1</code></li>
+                                                <li><code>modular-video-column-1</code></li>
+                                                <li><code>modular-news-column-1</code></li>
+                                                <li><code>modular-events-column-1</code></li>
+                                            </ul>
+                                        </li>
+                                        <li>Add a new page field and increase the number if you need to repeat that component, ex. modular-accordion-7.</li>
+                                        <li>Paste this JSON array into the page field and edit the values to set options:<br />
+<pre>
+{
+"id":00000,
+"heading":"My heading",
+"config":"randomize|limit:60|page_id",
+"columns":4,
+"singlePromoView":"true",
+"showExcerpt":"false",
+"showDescription":"true",
+}
+</pre>
+                                            <table class="mt-2">
+                                                <thead>
+                                                    <tr>
+                                                        <th colspan="2">JSON settings</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="font-bold">id</td>
+                                                        <td>Promo group ID. Required.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">heading</td>
+                                                        <td>Provide a heading(h2) for this component. Optional.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">config</td>
+                                                        <td>Promo group config, pipe delimited. Use \'page_id\' for per-page items. \'First\' is not allowed and will be removed. Optional.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">columns</td>
+                                                        <td>Only use with catalog component; 2, 3, or 4. Default/unset is 1. Optional.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">singlePromoView</td>
+                                                        <td>True or false. False (default) will use the promotion\'s link field. Optional.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">showExcerpt</td>
+                                                        <td>True or false. True is default. Optional.</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="font-bold">showDescription</td>
+                                                        <td>True or false. True is default. Optional.</td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                            <li>
+                                <a href="#definition-promo-setup" id="definition-promo-setup"><span aria-hidden="true"></span>Promo group setup</a>
+                                <div class="content">
+                                    <table class="mt-2">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="2">Available fields</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td class="font-bold">Title</td>
+                                                <td>Promo title. Will turn into a link if link field is used or single promo view is set.</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="font-bold">Link</td>
+                                                <td>External link. Do not set if using individual promo view.</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="font-bold">Excerpt</td>
+                                                <td>Single line of unformatted text, like a job title.</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="font-bold">Description</td>
+                                                <td>Formattable text. Main body content for single promo view.</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="font-bold">Filename</td>
+                                                <td>600x450px, or minimum width 600px any height.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </li>
+                        </ul>
+                    ',
+                ],
+            ],
+            'site' => [
+                'subsite-folder' => 'styleguide/',
+                'news' => [
+                    'application_id' => 1,
+                ],
+            ],
+            'data' => [
+                'modular-events-column-1' => 1,
+                'events_url' => '/main',
+                'modular-news-column-1' => 2,
+                'buttons' => '{}',
+                'image-promos' => '{}',
+                'spotlight' => '{}',
+                'steps' => '{}',
+                'text-promo' => '{}',
+                'video' => '{}',
+            ],
+        ]);
+    }
+}

--- a/styleguide/Repositories/EventRepository.php
+++ b/styleguide/Repositories/EventRepository.php
@@ -10,7 +10,7 @@ class EventRepository extends Repository
     /**
      * {@inheritdoc}
      */
-    public function getEvents($site_id)
+    public function getEvents($site_id, $limit = 4)
     {
         $events['events'] = app(Event::class)->create(5);
 

--- a/styleguide/Repositories/ModularPageRepository.php
+++ b/styleguide/Repositories/ModularPageRepository.php
@@ -68,6 +68,7 @@ class ModularPageRepository extends Repository
                 'component' => [
                     'heading' => 'Base events',
                     'filename' => 'events-column',
+                    'calendar_url' => '/myurl'
                 ],
             ],
 

--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -8,9 +8,6 @@
     </div>
 
     @if(!empty($base['accordion_page']))
-        @php
-        dump($base);
-    @endphp
         @include('components.accordion', ['items' => $base['accordion_page']])
     @endif
 

--- a/styleguide/Views/styleguide-accordion.blade.php
+++ b/styleguide/Views/styleguide-accordion.blade.php
@@ -8,6 +8,9 @@
     </div>
 
     @if(!empty($base['accordion_page']))
+        @php
+        dump($base);
+    @endphp
         @include('components.accordion', ['items' => $base['accordion_page']])
     @endif
 

--- a/styleguide/Views/styleguide-modular-docs.blade.php
+++ b/styleguide/Views/styleguide-modular-docs.blade.php
@@ -7,10 +7,11 @@
         {!! $base['page']['content']['main'] !!}
     </div>
 
+    <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
         @include('modular/components/catalog', ['data' => $catalog_1['data'], 'component' => $catalog_1['component']])
 
         <div class="col-span-2">
-            <h3>Configuration</h3>
+            <h3 class="mt-0">Configuration</h3>
             <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
                 <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
                 <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
@@ -36,7 +37,7 @@
         @include('modular/components/catalog', ['data' => $catalog_2['data'], 'component' => $catalog_2['component']])
 
         <div class="col-span-2">
-            <h3>Configuration</h3>
+            <h3 class="mt-0">Configuration</h3>
             <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
                 <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
                 <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
@@ -62,7 +63,7 @@
         @include('modular/components/accordion', ['data' => $accordion_1['data'], 'component' => $accordion_1['component']])
 
         <div class="col-span-2">
-            <h3>Configuration</h3>
+            <h3 class="mt-0">Configuration</h3>
             <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
                 <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
                 <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
@@ -83,7 +84,7 @@
         @include('modular/components/news-row', ['data' => $news_row_1['data'], 'component' => $news_row_1['component']])
 
         <div class="col-span-2">
-            <h3>Configuration</h3>
+            <h3 class="mt-0">Configuration</h3>
             <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
                 <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
                 <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
@@ -120,7 +121,7 @@ or configure with these options
         @include('modular/components/events-column', ['data' => $events_column_1['data'], 'component' => $events_column_1['component']])
 
         <div class="col-span-2">
-            <h3>Configuration</h3>
+            <h3 class="mt-0">Configuration</h3>
             <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
                 <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
                 <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
@@ -146,9 +147,11 @@ or configure with these options, ID optional
 "config":"limit:4",
 "cal_name": "myurl/",
 "link_text":"More events"
+}') !!}
 </pre>
                 </div>
             </div>
         </div>
+    </div>
 
 @endsection

--- a/styleguide/Views/styleguide-modular-docs.blade.php
+++ b/styleguide/Views/styleguide-modular-docs.blade.php
@@ -1,0 +1,48 @@
+@extends('components.content-area')
+
+@section('content')
+    @include('components.page-title', ['title' => $base['page']['title']])
+
+    <div class="content">
+        {!! $base['page']['content']['main'] !!}
+    </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
+            @include('modular/components/catalog', ['data' => $catalog_1['data'], 'component' => $catalog_1['component']])
+        </div>
+
+        <h3>Configuration</h3>
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"id":1234,
+"heading":"Four-column catalog",
+"columns":4,
+"showExcerpt":true,
+"showDescription":false,
+"singlePromoView":true,
+"config":"limit:8"
+}') !!}
+</pre>
+
+<hr />
+
+        <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
+            @include('modular/components/catalog', ['data' => $catalog_2['data'], 'component' => $catalog_2['component']])
+        </div>
+
+        <h3>Configuration</h3>
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"id":1234,
+"heading":"One-column catalog",
+"columns":1,
+"showExcerpt":true,
+"showDescription":true,
+"singlePromoView":true,
+"config":"limit:3"
+}') !!}
+</pre>
+
+<hr />
+
+@endsection

--- a/styleguide/Views/styleguide-modular-docs.blade.php
+++ b/styleguide/Views/styleguide-modular-docs.blade.php
@@ -7,11 +7,17 @@
         {!! $base['page']['content']['main'] !!}
     </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
-            @include('modular/components/catalog', ['data' => $catalog_1['data'], 'component' => $catalog_1['component']])
-        </div>
+        @include('modular/components/catalog', ['data' => $catalog_1['data'], 'component' => $catalog_1['component']])
 
-        <h3>Configuration</h3>
+        <div class="col-span-2">
+            <h3>Configuration</h3>
+            <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
+                <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
+                <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
+                <div class="lg:col-span-1 p-2 lg:border-r order-2 lg:order-none">
+                    <pre class="w-full">modular-catalog-1</pre>
+                </div>
+                <div class="lg:col-span-2 p-2 order-4 lg:order-none">
 <pre class="w-full" tabindex="0">
 {!! htmlspecialchars('{
 "id":1234,
@@ -23,14 +29,21 @@
 "config":"limit:8"
 }') !!}
 </pre>
-
-<hr />
-
-        <div class="grid grid-cols-1 md:grid-cols-2 items-start gap-y-8 sm:gap-x-4 lg:gap-x-8 mt-8 mb-4">
-            @include('modular/components/catalog', ['data' => $catalog_2['data'], 'component' => $catalog_2['component']])
+                </div>
+            </div>
         </div>
 
-        <h3>Configuration</h3>
+        @include('modular/components/catalog', ['data' => $catalog_2['data'], 'component' => $catalog_2['component']])
+
+        <div class="col-span-2">
+            <h3>Configuration</h3>
+            <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
+                <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
+                <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
+                <div class="lg:col-span-1 p-2 lg:border-r order-2 lg:order-none">
+                    <pre class="w-full">modular-catalog-2</pre>
+                </div>
+                <div class="lg:col-span-2 p-2 order-4 lg:order-none">
 <pre class="w-full" tabindex="0">
 {!! htmlspecialchars('{
 "id":1234,
@@ -42,7 +55,100 @@
 "config":"limit:3"
 }') !!}
 </pre>
+                </div>
+            </div>
+        </div>
 
-<hr />
+        @include('modular/components/accordion', ['data' => $accordion_1['data'], 'component' => $accordion_1['component']])
+
+        <div class="col-span-2">
+            <h3>Configuration</h3>
+            <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
+                <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
+                <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
+                <div class="lg:col-span-1 p-2 lg:border-r order-2 lg:order-none">
+                    <pre class="w-full">modular-accordion-1</pre>
+                </div>
+                <div class="lg:col-span-2 p-2 order-4 lg:order-none">
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"id":1234,
+"heading":"My accordion",
+}') !!}
+</pre>
+                </div>
+            </div>
+        </div>
+
+        @include('modular/components/news-row', ['data' => $news_row_1['data'], 'component' => $news_row_1['component']])
+
+        <div class="col-span-2">
+            <h3>Configuration</h3>
+            <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
+                <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
+                <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
+                <div class="lg:col-span-1 p-2 lg:border-r order-2 lg:order-none">
+                    <pre class="w-full">modular-news-row-1</pre>
+                </div>
+                <div class="lg:col-span-2 p-2 order-4 lg:order-none">
+                    For default settings use a blank array
+<pre class="w-full" tabindex="0">
+{}
+</pre>
+specify only a heading
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"heading":"News"
+}') !!}
+</pre>
+or configure with these options
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"id":null,
+"heading":"News",
+"link_text":"More news",
+"featured":null,
+"limit":4,
+"news_route":null,
+"topics":[]
+}') !!}
+</pre>
+                </div>
+            </div>
+        </div>
+
+        @include('modular/components/events-column', ['data' => $events_column_1['data'], 'component' => $events_column_1['component']])
+
+        <div class="col-span-2">
+            <h3>Configuration</h3>
+            <div class="grid grid-cols-1 lg:grid-cols-3 border-x border-b mb-16">
+                <div class="lg:col-span-1 p-2 bg-gray-100 font-bold lg:border-r border-y order-1 lg:order-none">Page field</div>
+                <div class="lg:col-span-2 p-2 bg-gray-100 font-bold border-y order-3 lg:order-none">Data</div>
+                <div class="lg:col-span-1 p-2 lg:border-r order-2 lg:order-none">
+                    <pre class="w-full">modular-events-column-1</pre>
+                </div>
+                <div class="lg:col-span-2 p-2 order-4 lg:order-none">
+                    For default settings use a blank array
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{}') !!}
+</pre>
+specify only a heading
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"heading":"Events"
+}') !!}
+</pre>
+or configure with these options, ID optional
+<pre class="w-full" tabindex="0">
+{!! htmlspecialchars('{
+"id":null,
+"heading":"Events",
+"config":"limit:4",
+"cal_name": "myurl/",
+"link_text":"More events"
+</pre>
+                </div>
+            </div>
+        </div>
 
 @endsection

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -688,6 +688,16 @@
                         "relative_url": "/styleguide/modularpage",
                         "submenu": []
                     },
+                    "101110700": {
+                        "menu_item_id": 101110700,
+                        "is_active": 1,
+                        "page_id": 101110700,
+                        "target": "",
+                        "display_name": "Modular docs",
+                        "class_name": "",
+                        "relative_url": "/styleguide/modulardocs",
+                        "submenu": []
+                    },
                     "101110100": {
                         "menu_item_id": 101110100,
                         "is_active": 1,

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -144,7 +144,7 @@ final class ModularPageRepositoryTest extends TestCase
     public function get_modular_page_components_news(): void
     {
         // Fake return
-        $return = app(Article::class)->create(5);
+        $return = app(Article::class)->create(4);
 
         // Mock the connector and set the return
         $newsApi = Mockery::mock(News::class);
@@ -156,7 +156,7 @@ final class ModularPageRepositoryTest extends TestCase
                 'controller' => 'ModularPage',
             ],
             'data' => [
-                'modular-news-1' => 1
+                'modular-news-column-1' => 1
             ],
         ]);
 
@@ -167,7 +167,7 @@ final class ModularPageRepositoryTest extends TestCase
         // Run the promos through the repository
         $modularComponents = app(ModularPageRepository::class, ['wsuApi' => $wsuApi])->getModularComponents($data);
 
-        $this->assertCount(count($return['data']), $modularComponents['news-1']['data']['data']);
+        $this->assertCount(count($return['data']), $modularComponents['news-column-1']['data']['data']);
     }
 
     #[Test]


### PR DESCRIPTION
* Added news row component that displays article images
* Allow a config to be passed through for news and events limit, also passing in a blank json array {} will use default news/events ids.