### PR TITLE
Hotfix/8.8.3 - Enhanced text-overlay design on mobile to match hero-half 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.8.2",
+  "version": "8.8.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/hero/half.blade.php
+++ b/resources/views/components/hero/half.blade.php
@@ -10,15 +10,19 @@
     </div>
 
     <div class="hero__content-position relative p-6 xl:px-12 2xl:px-16">
-        <div class="hero__content border-l-12 border-gold border-solid pl-4 2xl:pl-8 py-4">
+        <div class="hero__content border-l-12 border-gold border-solid pl-6 2xl:pl-8 pt-4 pb-8">
             <h2 class="hero__title text-green-700 3xl:text-4xl mb-1 font-black">
                 @if(!empty($hero['link']))<a href="{{ $hero['link'] }}" class="hero__link text-green-700 no-underline hover:underline focus:underline">@endif
-                    {{ $hero['title'] }}
+                    {!! strip_tags($hero['title'], ['em', 'strong']) !!}
                 @if(!empty($hero['link']))</a>@endif
             </h2>
-            <div class="hero__description text-lg 3xl:text-xl text-green-700">
+            <div class="hero__description text-lg 3xl:text-xl text-green-700 content">
                 @if(!empty($hero['description']))
-                    {!! $hero['description'] !!}
+                    @if(!empty($hero['link']))
+                        {!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $hero['description']) !!}
+                    @else
+                        {!! $hero['description'] !!}
+                    @endif
                 @endif
             </div>
         </div>

--- a/resources/views/components/hero/half.blade.php
+++ b/resources/views/components/hero/half.blade.php
@@ -11,7 +11,7 @@
 
     <div class="hero__content-position relative p-6 xl:px-12 2xl:px-16">
         <div class="hero__content border-l-12 border-gold border-solid pl-6 2xl:pl-8 pt-4 pb-8">
-            <h2 class="hero__title text-green-700 3xl:text-4xl mb-1 font-black">
+            <h2 class="hero__title text-green-700 3xl:text-4xl mb-3 font-black">
                 @if(!empty($hero['link']))<a href="{{ $hero['link'] }}" class="hero__link text-green-700 no-underline hover:underline focus:underline">@endif
                     {!! strip_tags($hero['title'], ['em', 'strong']) !!}
                 @if(!empty($hero['link']))</a>@endif

--- a/resources/views/components/hero/text-overlay.blade.php
+++ b/resources/views/components/hero/text-overlay.blade.php
@@ -4,13 +4,23 @@
 
 <div class="hero__wrapper w-full relative">
     <div class="hero__primary-image h-hero max-h-hero w-full bg-cover bg-center relative{{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $hero['relative_url'] }}')" @else data-src="{{ $hero['relative_url'] }}"@endif></div>
-    <div class="hero__content-position relative md:absolute print:relative md:bottom-0 md:inset-x-0 md:text-white md:white-links md:bg-gradient-darkest">
+    <div class="hero__content-position relative lg:absolute print:relative p-6 lg:p-0 lg:bottom-0 lg:inset-x-0 lg:bg-gradient-darkest lg:pt-20">
         <div class="row">
-            <div class="hero__content relative p-4 pb-0 md:pb-2 md:pt-8 md:pt-20">
-                <div class="hero__title md:drop-shadow-px leading-tight text-2xl mb-1 xl:text-5xl">{!! strip_tags($hero['title'], ['em', 'strong']) !!}</div>
-                @if(!empty($hero['description']))<div class="hero__description md:text-lg content">{!! $hero['description'] !!}</div>@endif
+            <{{ !empty($hero['link']) ? 'a href='.$hero['link'] : 'div' }} class="hero__content relative block {{ !empty($hero['link']) ? 'group no-underline ' : '' }} p-4 lg:pb-2 pl-6 lg:pl-4 pb-8 border-l-12 border-gold border-solid lg:border-0 text-green-900 lg:text-white lg:white-links">
+                <div class="hero__title lg:drop-shadow-px leading-tight mt-4 text-3xl font-bold mb-3 lg:text-5xl group-hover:underline">
+                    {!! strip_tags($hero['title'], ['em', 'strong']) !!}
+                </div>
+                @if(!empty($hero['description']))
+                    <div class="hero__description text-lg content">
+                        @if(!empty($hero['link']))
+                            {!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $hero['description']) !!}
+                        @else
+                            {!! $hero['description'] !!}
+                        @endif
+                    </div>
+                @endif
                 @yield('hero-buttons')
-            </div>
+            <{{ !empty($hero['link']) ? '/a' : '/div' }}>
         </div>
     </div>
 </div>

--- a/resources/views/components/hero/text-overlay.blade.php
+++ b/resources/views/components/hero/text-overlay.blade.php
@@ -7,7 +7,7 @@
     <div class="hero__content-position relative lg:absolute print:relative p-6 lg:p-0 lg:bottom-0 lg:inset-x-0 lg:bg-gradient-darkest lg:pt-20">
         <div class="row">
             <{{ !empty($hero['link']) ? 'a href='.$hero['link'] : 'div' }} class="hero__content relative block {{ !empty($hero['link']) ? 'group no-underline ' : '' }} p-4 lg:pb-2 pl-6 lg:pl-4 pb-8 border-l-12 border-gold border-solid lg:border-0 text-green-900 lg:text-white lg:white-links">
-                <div class="hero__title lg:drop-shadow-px leading-tight mt-4 text-3xl font-bold mb-3 lg:text-5xl group-hover:underline">
+                <div class="hero__title lg:drop-shadow-px leading-tight mt-4 text-3xl mb-3 lg:text-5xl group-hover:underline">
                     {!! strip_tags($hero['title'], ['em', 'strong']) !!}
                 </div>
                 @if(!empty($hero['description']))


### PR DESCRIPTION
I noticed Text-overlay mobile design was lacking, mirrored to the half-hero mobile appearhance (without a bold title)
|Half mobile|Text overlay mobile|
|-----------|-------------------|
|<img width="568" alt="Screenshot 2024-02-15 at 4 09 13 PM" src="https://github.com/waynestate/base-site/assets/2616607/5346baee-b49d-470d-875a-82a55c5898e9">|After <img width="569" alt="Screenshot 2024-02-15 at 4 09 33 PM" src="https://github.com/waynestate/base-site/assets/2616607/093bf960-1076-4ad4-910b-2760c3dd81ce">|
|x|Before <img width="568" alt="Screenshot 2024-02-15 at 4 12 42 PM" src="https://github.com/waynestate/base-site/assets/2616607/4f89bbba-2c08-49e2-8c22-d8f85bf0d022">|
