### PR TITLE
hotfix/8.8.4 - Need base version in the header on sites, not 'version'

### DIFF
--- a/factories/Page.php
+++ b/factories/Page.php
@@ -28,7 +28,7 @@ class Page implements FactoryContract
             $data[$i] = [
                 'site' => [
                     'id' => 2,
-                    'title' => 'Base - Style guide (v'.$base_info['version'].')',
+                    'title' => 'Base - Style guide (v'.($base_info['baseVersion'] ?? $base_info['version']).')',
                     'short-title' => '',
                     'keywords' => '',
                     'subsite-folder' => null,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.8.3",
+  "version": "8.8.4",
   "description": "",
   "scripts": {
     "dev": "npm run development",
@@ -48,5 +48,6 @@
     "stylelint-config-standard": "^22.0.0",
     "tailwindcss": "^3.2.4",
     "vue-template-compiler": "^2.6.14"
-  }
+  },
+  "baseVersion": "8.8.4"
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,5 @@
     "stylelint-config-standard": "^22.0.0",
     "tailwindcss": "^3.2.4",
     "vue-template-compiler": "^2.6.14"
-  },
-  "baseVersion": "8.8.4"
+  }
 }


### PR DESCRIPTION
After upgrading another site and seeing that site's version in the header and not the version of Base, I realized I needed 'base version' not 'version'