### PR TITLE
Hotfix/8.9.1 - More events, more news links broken 

### DIFF
--- a/resources/views/components/events-column.blade.php
+++ b/resources/views/components/events-column.blade.php
@@ -33,6 +33,6 @@
 </ul>
 @if(!empty($component['cal_name']) || !empty($base['site']['events']['path']))
     <div class="mt-4">
-        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'main/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
+        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
     </div>
 @endif

--- a/resources/views/components/events-featured-column.blade.php
+++ b/resources/views/components/events-featured-column.blade.php
@@ -19,6 +19,6 @@
 </ul>
 @if(!empty($component['cal_name']) || !empty($base['site']['events']['path']))
     <div class="mt-4">
-        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'main/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
+        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
     </div>
 @endif

--- a/resources/views/components/events-featured-row.blade.php
+++ b/resources/views/components/events-featured-row.blade.php
@@ -19,6 +19,6 @@
 </ul>
 @if(!empty($component['cal_name']) || !empty($base['site']['events']['path']))
     <div class="text-center mt-6">
-        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'main/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
+        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
     </div>
 @endif

--- a/resources/views/components/events-row.blade.php
+++ b/resources/views/components/events-row.blade.php
@@ -29,6 +29,6 @@
 
 @if(!empty($component['cal_name']) || !empty($base['site']['events']['path']))
     <div class="text-center mt-6">
-        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'main/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
+        <a class="button" href="//events.wayne.edu/{{ $component['cal_name'] ?? $base['site']['events']['path'].'/' }}upcoming">{{ $component['link_text'] ?? 'More events' }}</a>
     </div>
 @endif

--- a/resources/views/components/news-column.blade.php
+++ b/resources/views/components/news-column.blade.php
@@ -15,6 +15,6 @@
     </ul>
 
     <div class="mt-6">
-        <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
+        <a href="/{{ $base['site']['subsite-folder'] ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
     </div>
 @endif

--- a/resources/views/components/news-featured-column.blade.php
+++ b/resources/views/components/news-featured-column.blade.php
@@ -29,6 +29,6 @@
     </ul>
     
     <div class="mt-6">
-        <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
+        <a href="/{{ $base['site']['subsite-folder'] ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
     </div>
 @endif

--- a/resources/views/components/news-row.blade.php
+++ b/resources/views/components/news-row.blade.php
@@ -17,6 +17,6 @@
         @endforeach
     </ul>
     <div class="text-center mt-6">
-        <a href="/{{ !empty($base['site']['subsite-folder']) ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
+        <a href="/{{ $base['site']['subsite-folder'] ?? '' }}{{ $component['news_route'] ?? config('base.news_listing_route') }}" class="button">{{ $component['link_text'] ?? 'More news' }}</a>
     </div>
 @endif

--- a/styleguide/Pages/Homepage.php
+++ b/styleguide/Pages/Homepage.php
@@ -28,6 +28,9 @@ class Homepage extends Page
                 'news' => [
                     'application_id' => 1,
                 ],
+                'events' => [
+                    'path' => 'main'
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
* Fixed the paths where the more news and more events links go. (I remember checking them previously, so I am not sure how they became disfunctional.)