### PR TITLE
Styleguide button elements now work when pasted into CMS WYSIWYG

### DIFF
--- a/styleguide/Views/styleguide-cms-buttons.blade.php
+++ b/styleguide/Views/styleguide-cms-buttons.blade.php
@@ -60,8 +60,8 @@
             </div>
 <pre class="code-block mb-0 w-full">
 {!! htmlspecialchars('<a href="#" class="button button--two-line w-full">
-    <div class="button__title">Two line button</div>
-    <div class="button__excerpt">Subtext</div>
+    <strong class="button__title">Two line button</strong>
+    <em class="button__excerpt">Subtext</em>
 </a>') !!}
 </pre>
         </div>
@@ -78,8 +78,8 @@
 <pre class="code-block mb-0 w-full">
 {!! htmlspecialchars('<a href="#" class="button button--two-line">
     <img src="/styleguide/image/50x50" alt="" class="button__image">
-    <div class="button__title">Two line button</div>
-    <div class="button__excerpt">Subtext</div>
+    <strong class="button__title">Two line button</strong>
+    <em class="button__excerpt">Subtext</em>
 </a>') !!}
 </pre>
         </div>


### PR DESCRIPTION
## Reason for change

This resolves the issue with `<div>` elements inside `<a>` elements being stripped when copy/pasted into the CMS.

This change only affects the visible code in the styleguide. The typical `<div>` child elements will still be used for the template component output as they don't need to change.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-06-28 at 2 07 33 PM](https://github.com/waynestate/base-site/assets/37359/5f276c9b-2500-43e2-b249-0e2fba3305c0) | ![Screenshot 2024-06-28 at 2 12 02 PM](https://github.com/waynestate/base-site/assets/37359/1c6206e0-5c53-4afa-af5a-a755d24e0df5) |