### PR TITLE
Canonical URL for individual news articles based on permalink

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -93,7 +93,7 @@ class ArticleController extends Controller
 
         $request->data['base']['page']['title'] = $article['article']['data']['title'];
         $request->data['base']['page']['description'] = $article['article']['data']['meta_description'];
-        $request->data['base']['page']['canonical'] = $request->data['base']['server']['url'] ?? '';
+        $request->data['base']['page']['canonical'] = $this->article->getCanonicalUrl($article['article']['data'], $request->data['base']);
 
         if (!empty($article['article']['data']['hero_image']['url'])) {
             $request->data['base']['hero'][]['relative_url'] = $article['article']['data']['hero_image']['url'];

--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -77,6 +77,29 @@ class ArticleRepository implements ArticleRepositoryContract
     /**
      * {@inheritdoc}
      */
+    public function getCanonicalUrl(array $article, array $request)
+    {
+        // Fallback if there is no route path defined for news
+        if (empty($article) || empty($request['site']['news']['route_path'])) {
+            return $request['server']['url'] ?? '';
+        }
+
+        // Use the domain of the current page
+        $uri = parse_url($request['server']['url']);
+
+        // Build up the fully qualified URL for the article
+        return
+            trim($uri['scheme'] . '://' . $uri['host'] . '/' . $request['site']['subsite-folder'], '/') .
+            str_replace(
+                ['{$permalink}', '{$id}'],
+                [$article['permalink'], $article['id']],
+                $request['site']['news']['route_path']
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSocialImage($article)
     {
         if (!empty($article['social_image'])) {

--- a/contracts/Repositories/ArticleRepositoryContract.php
+++ b/contracts/Repositories/ArticleRepositoryContract.php
@@ -26,6 +26,15 @@ interface ArticleRepositoryContract
     public function find($id, $application_ids, $preview);
 
     /**
+     * Build the fully qualified URI for the article
+     *
+     * @param array $article
+     * @param array $request
+     * @return array
+     */
+    public function getCanonicalUrl(array $article, array $request);
+
+    /**
      * Get the image for the meta data.
      *
      * @param array $article

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.10.5",
+  "version": "8.10.6",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ArticleRepositoryTest.php
+++ b/tests/Unit/Repositories/ArticleRepositoryTest.php
@@ -210,4 +210,29 @@ final class ArticleRepositoryTest extends TestCase
         $this->assertEquals($article['data']['featured']['url'], $imageUrl['url']);
         $this->assertEquals($article['data']['featured']['alt_text'], $imageUrl['alt_text']);
     }
+
+    #[Test]
+    public function article_with_news_route_should_return_canonical_url(): void
+    {
+        $article = app(Article::class)->create(
+            1,
+            true,
+            [
+            'permalink' => 'permalink',
+            'id' => 123,
+        ]
+        );
+
+        $request = [
+            'server' => ['url' => 'https://example.com/subsite/news/slug-id'],
+            'site' => [
+                'subsite-folder' => 'subsite/',
+                'news' => ['route_path' => '/news/{$permalink}-{$id}'],
+            ],
+        ];
+
+        $url = app(ArticleRepository::class)->getCanonicalUrl($article['data'], $request);
+
+        $this->assertEquals($url, 'https://example.com/subsite/news/permalink-123');
+    }
 }


### PR DESCRIPTION
## Reason for change

Because articles can be renamed and potentially accessed at different URLs, the Canonical URL assumes the current URL is the most up-to-date and uses that URL as the canonical. 

This causes a situation where the same article could be accessed at multiple URLs, each with its own canonical URL. Search engines complained the same content was pointing to different canonical URLs. 

This change forces the most up-to-date title (slug) to be used as the canonical URL so search engines index the correct URL.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-08-06 at 7 20 39 AM](https://github.com/user-attachments/assets/40700d64-7151-42ec-ae69-2c527b722b28) | ![Screenshot 2024-08-06 at 7 21 07 AM](https://github.com/user-attachments/assets/dedfa403-3993-4d7c-a35c-e10f16de95df) | 