### PR TITLE
Full name now consistent on listing and individual views to include Suffix if available

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -106,7 +106,7 @@ class ProfileController extends Controller
         $fields = $this->profile->getFields();
 
         // Change page title to profile name
-        $request->data['base']['page']['title'] = $this->profile->getPageTitleFromName($profile);
+        $request->data['base']['page']['title'] = $profile['profile']['full_name'] ?? '';
         $request->data['base']['page']['canonical'] = $request->data['base']['server']['url'] ?? '';
 
         // Set the back URL

--- a/app/Repositories/PeopleRepository.php
+++ b/app/Repositories/PeopleRepository.php
@@ -61,6 +61,7 @@ class PeopleRepository implements ProfileRepositoryContract
                 }
 
                 $profile['data']['AccessID'] = $profile['accessid'];
+                $profile['full_name'] = $this->getPageTitleFromName(['profile' => $profile]);
 
                 $profile['groups'] = collect($profile['groups'])->keyBy('id')->toArray();
 
@@ -352,6 +353,10 @@ class PeopleRepository implements ProfileRepositoryContract
      */
     public function getPageTitleFromName($profile)
     {
+        if (empty($profile)) {
+            return '';
+        }
+
         $name_fields = $this->getFields()['name_fields'];
 
         $name = collect($profile['profile']['data'])->filter(function ($value, $key) use ($name_fields) {

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -54,6 +54,7 @@ class ProfileRepository implements ProfileRepositoryContract
         if (empty($profile_listing['error'])) {
             $profile_listing = collect($profile_listing)->map(function ($item) {
                 $item['link'] = '/profile/'.$item['data']['AccessID'];
+                $item['full_name'] = $this->getPageTitleFromName(['profile' => $item]);
 
                 return $item;
             })->toArray();
@@ -334,6 +335,10 @@ class ProfileRepository implements ProfileRepositoryContract
      */
     public function getPageTitleFromName($profile)
     {
+        if (empty($profile)) {
+            return '';
+        }
+
         $name_fields = $this->getFields()['name_fields'];
 
         $name = collect($profile['profile']['data'])->filter(function ($value, $key) use ($name_fields) {

--- a/factories/People.php
+++ b/factories/People.php
@@ -27,6 +27,7 @@ class People implements FactoryContract
             $accessid = $this->faker->randomLetter().$this->faker->randomLetter().$this->faker->randomNumber(4, true);
             $first_name = $this->faker->firstName();
             $last_name = $this->faker->lastName();
+            $suffix = $this->faker->suffix();
             $email = $this->faker->email();
             $title = $this->faker->sentence(3);
             $picture = '/styleguide/image/600x800?text=600x800%20('.$i.')';
@@ -140,6 +141,7 @@ class People implements FactoryContract
                     $groups->random(),
                 ],
                 'link' => '/styleguide/profile/aa0000',
+                'full_name' => $first_name . ' ' . $last_name,
                 'data' => [
                     'AccessID' => $accessid,
                     'First Name' => $first_name,
@@ -163,6 +165,21 @@ class People implements FactoryContract
                     ],
                 ],
             ];
+
+            // Randomly include a suffix
+            if (rand(0, 1) === 1) {
+                $data[$i]['suffix'] = $suffix;
+                $data[$i]['field_data'][] = [
+                    'value' => $suffix,
+                    'field' => [
+                        'name' => 'Suffix',
+                        'type' => 'text',
+                        'global' => 1,
+                    ],
+                ];
+                $data[$i]['data']['Suffix'] = $suffix;
+                $data[$i]['full_name'] = $first_name . ' ' . $last_name . ', ' . $suffix;
+            }
 
             $data[$i] = array_replace_recursive($data[$i], $options);
         }

--- a/factories/Profile.php
+++ b/factories/Profile.php
@@ -53,6 +53,11 @@ class Profile implements FactoryContract
                 'link' => '/styleguide/profile/aa0000',
             ];
 
+            // Randomly include a suffix
+            if (rand(0, 1) === 1) {
+                $data[$i]['data']['Suffix'] = $this->faker->suffix();
+            }
+
             $data[$i] = array_replace_recursive($data[$i], $options);
         }
 

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -5,7 +5,7 @@
     <div class="aspect-portrait mb-1">
         @image(!empty($profile['data']['Picture']['url']) ? $profile['data']['Picture']['url'] : '/_resources/images/no-photo.svg', $profile['data']['First Name'].' '.$profile['data']['Last Name'], 'h-full w-full object-cover object-center')
     </div>
-    <div class="underline group-hover:no-underline group-focus:no-underline font-bold">{{ $profile['data']['First Name'] }} {{ $profile['data']['Last Name'] }}</div>
+    <div class="underline group-hover:no-underline group-focus:no-underline font-bold">{{ $profile['full_name'] }}</div>
     @if(!empty($profile['data']['Title']))
         <div class="text-black text-sm">{{ $profile['data']['Title'] }}</div>
     @endif

--- a/tests/Unit/Repositories/PeopleRepositoryTest.php
+++ b/tests/Unit/Repositories/PeopleRepositoryTest.php
@@ -195,6 +195,7 @@ final class PeopleRepositoryTest extends TestCase
         // Remove Factory (Styleguide data) to test against the getProfiles
         $return['data'] = collect($return['data'])->map(function ($profile) {
             unset($profile['link']);
+            unset($profile['full_name']);
             unset($profile['data']);
 
             return $profile;
@@ -208,6 +209,7 @@ final class PeopleRepositoryTest extends TestCase
 
         collect($profiles['profiles'])->each(function ($item) {
             $this->assertNotEmpty($item['link']);
+            $this->assertNotEmpty($item['full_name']);
             $this->assertNotEmpty($item['data']['Picture']['url']);
         });
     }
@@ -228,6 +230,10 @@ final class PeopleRepositoryTest extends TestCase
         // Mock the connector and set the return
         $peopleApi = Mockery::mock(PeopleApi::class);
         $peopleApi->shouldReceive('request')->andReturn($return);
+
+        // Ensure the full name function requires a profile
+        $blank_full_name = app(PeopleRepository::class, ['peopleApi' => $peopleApi])->getPageTitleFromName([]);
+        $this->assertTrue(empty($blank_full_name));
 
         $profile = app(PeopleRepository::class, ['peopleApi' => $peopleApi])->getProfile($site_id, $accessid);
 

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -226,6 +226,28 @@ final class ProfileRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function getting_profiles_should_append_full_name(): void
+    {
+        // Fake return
+        $return = app(Profile::class)->create(5);
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.listing', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('nextRequestProduction')->once();
+
+        // Ensure the full name function requires a profile
+        $blank_full_name = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getPageTitleFromName([]);
+        $this->assertTrue(empty($blank_full_name));
+
+        $profiles = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfiles($this->faker->numberBetween(1, 10));
+
+        collect($profiles['profiles'])->each(function ($item) {
+            $this->assertTrue(!empty($item['full_name']));
+        });
+    }
+
+    #[Test]
     public function getting_profile_group_ids_should_return_correct_string(): void
     {
         // Fake a dropdown array of group_id => group name


### PR DESCRIPTION
## Reason for change

To ensure a consistent display of faculty profile names with and without a suffix, this change creates a `full_name` field for the profile listing and individual view.

## Relevant links
- https://base.wayne.edu/styleguide/profiles
- https://base.wayne.edu/styleguide/profile/aa0000


## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-08-28 at 6 48 49 AM](https://github.com/user-attachments/assets/e44d8037-42c7-4dee-8f43-2b333f1d15cb) | ![Screenshot 2024-08-28 at 6 48 37 AM](https://github.com/user-attachments/assets/10636fde-82f1-4b50-af19-af09c8b931b3) |
