### PR TITLE
Hotfix/8.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.11.0",
+  "version": "8.11.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/styleguide/Pages/ComponentHeroCarousel.php
+++ b/styleguide/Pages/ComponentHeroCarousel.php
@@ -13,7 +13,7 @@ class ComponentHeroCarousel extends Page
     {
         return app(PageFactory::class)->create(1, true, [
             'page' => [
-                'controller' => 'componentHeroController',
+                'controller' => 'ComponentHeroController',
                 'title' => 'Hero carousel',
                 'id' => 105100104,
                 'content' => [


### PR DESCRIPTION
- fix: correct capitalization for classname to load the proper filename casing
