### PR TITLE
feature/headings - Dividers - adjust padding on heading dividers

### DIFF
--- a/resources/scss/components/_global-headings.scss
+++ b/resources/scss/components/_global-headings.scss
@@ -38,7 +38,7 @@ h6 {
     &::after {
         content: "";
 
-        @apply absolute inline w-full h-0.5 ml-4 top-1/2 bottom-auto bg-gold;
+        @apply absolute inline w-full h-0.5 ml-4 top-[60%] bottom-auto bg-gold;
     }
 }
 
@@ -48,7 +48,7 @@ h6 {
     &::after {
         content: "";
 
-        @apply absolute inline w-full h-0.5 ml-4 top-1/2 bottom-auto bg-green;
+        @apply absolute inline w-full h-0.5 ml-4 top-[60%] bottom-auto bg-green;
     }
 }
 

--- a/resources/views/partials/heading.blade.php
+++ b/resources/views/partials/heading.blade.php
@@ -1,7 +1,7 @@
 {{--
     "heading":"Heading text",
     "headingLevel":["h2", "h3", "h4"],
-    "headingClass":"text-green gold-divider"
+    "headingClass":"text-green divider-gold"
 --}}
 <{{ !empty($headingLevel) && strtolower($headingLevel) != 'h1' ? $headingLevel : 'h2' }} id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
     {!! strip_tags($heading, ['em', 'strong']) !!}


### PR DESCRIPTION
# Updates 

## Reason for change 
- Moving down the heading bars so they appear more centered with the heading text 

|Before|After|
|-----|-----|
|<img width="640" alt="image" src="https://github.com/user-attachments/assets/615da20f-ff54-4324-8036-26971d675dce">|<img width="640" alt="image" src="https://github.com/user-attachments/assets/e3e7b2c0-ddbe-4a6a-bfb0-9c74f2f34b36">



