### PR TITLE
Tests passing again after generating a new feature

### DIFF
--- a/stubs/view.stub
+++ b/stubs/view.stub
@@ -1,11 +1,13 @@
-@extends('components.content-area')
-
+@extends('layouts.' . (!empty($base['layout']) ? $base['layout'] : 'main'))
+    
 @section('content')
     @include('components.page-title', ['title' => $base['page']['title']])
 
-    <div class="content">
-        {!! $base['page']['content']['main'] !!}
-    </div>
+    @if(empty($base['components']['page-content-row']) && empty($base['components']['page-content-column']))
+        <div class="content">
+            {!! $base['page']['content']['main'] !!}
+        </div>
+    @endif
 
     @if(!empty($dummyitems))
         <ul class="list-disc">
@@ -14,4 +16,6 @@
             @endforeach
         </ul>
     @endif
+
+    @include('partials.component-loop')
 @endsection


### PR DESCRIPTION
## Reason for change

With the update to the childpage.blade.php file, it wasn't reflected in the stub for new features.

New features would fail tests immediately. 

This change brings the stub inline with the new childpage and regains passing tests post-feature generation.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![base-feature-before](https://github.com/user-attachments/assets/93bdffb5-2f2b-458d-bdf3-e5bae885b62e) | ![base-feature-after](https://github.com/user-attachments/assets/2585323b-bf49-42b2-bf4c-9e3ce7eb48b6) |