### PR TITLE
base:module command line now in place

### DIFF
--- a/app/Console/Commands/BaseModule.php
+++ b/app/Console/Commands/BaseModule.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class BaseModule extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'base:module {name}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Scaffold out files for a new modular component, use singular form of module name, e.g. "spotlight-row"';
+
+    protected $stub; // Stub file contents
+    protected $lowercase; // dummy-component
+    protected $singleword; // dummycomponent
+    protected $camelcase; // DummyComponent
+    protected $titlecase; // Dummy Component
+
+    /**
+     * Scaffold files.
+     */
+    public function handle(): void
+    {
+        $this->setModule($this->argument('name'));
+
+        $this->component();
+        $this->styleguideController();
+        $this->styleguideMenu();
+        $this->styleguidePage();
+
+        $this->newLine();
+        $this->info('"modular-' . $this->lowercase . '" is now ready to use. 🚀');
+    }
+
+    protected function setModule($module)
+    {
+        $this->lowercase = strtolower($module);
+        $this->camelcase = str_replace('-', '', ucwords($module, '-'));
+        $this->singleword = strtolower($this->camelcase);
+        $this->titlecase = str_replace('-', ' ', ucwords($module, '-'));
+
+        if (Storage::disk('base')->exists('resources/views/components/'.$this->lowercase.'.blade.php')) {
+            die($this->error('Module "'.$this->lowercase.'" already exists, please use another name.'));
+        }
+    }
+
+    protected function initializeStub($type)
+    {
+        $this->stub = Storage::disk('base')->get('stubs/'.$type.'.stub');
+    }
+
+    protected function localizeStub()
+    {
+        $this->stub = str_replace('dummy-component', $this->lowercase, $this->stub);
+        $this->stub = str_replace('dummycomponent', $this->singleword, $this->stub);
+        $this->stub = str_replace('DummyComponent', $this->camelcase, $this->stub);
+        $this->stub = str_replace('Dummy Component', $this->titlecase, $this->stub);
+    }
+
+    protected function getMenu()
+    {
+        return json_decode(Storage::disk('base')->get('styleguide/menu.json'), true);
+    }
+
+    protected function component()
+    {
+        $this->initializeStub('component');
+        $this->localizeStub();
+
+        Storage::disk('base')->put('resources/views/components/'.$this->lowercase.'.blade.php', $this->stub);
+        $this->line('resources/views/components/'.$this->lowercase.'.blade.php written successfully.');
+    }
+
+    protected function styleguideController()
+    {
+        $this->initializeStub('component-controller');
+        $this->localizeStub();
+
+        Storage::disk('base')->put('styleguide/Http/Controllers/Component'.$this->camelcase.'Controller.php', $this->stub);
+        $this->line('styleguide/Http/Controllers/Component'.$this->camelcase.'Controller.php written successfully.');
+    }
+
+    protected function styleguideMenu()
+    {
+        $menu = $this->getMenu();
+
+        $item = end($menu[102]['submenu'][9999]['submenu']);
+        if (empty($item)) {
+            $item = end($menu[102]['submenu']);
+        }
+
+        $item['menu_item_id']++;
+        $item['page_id'] = $item['menu_item_id'];
+        $item['display_name'] = $this->titlecase;
+        $item['relative_url'] = '/styleguide/component/'.$this->singleword;
+
+        $menu[102]['submenu'][9999]['submenu'][$item['menu_item_id']] = $item;
+
+        Storage::disk('base')->put('styleguide/menu.json', json_encode($menu, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $this->line('styleguide/menu.json written successfully.');
+    }
+
+    protected function styleguidePage()
+    {
+        $menu = $this->getMenu();
+
+        $this->initializeStub('component-page');
+        $this->localizeStub();
+
+        $this->stub = str_replace('DummyId', end($menu[102]['submenu'][9999]['submenu'])['menu_item_id'], $this->stub);
+
+        Storage::disk('base')->put('styleguide/Pages/Component'.$this->camelcase.'.php', $this->stub);
+        $this->line('styleguide/Pages/Component'.$this->camelcase.'.php written successfully.');
+    }
+}

--- a/stubs/component-controller.stub
+++ b/stubs/component-controller.stub
@@ -1,0 +1,78 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use Illuminate\View\View;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Faker\Factory;
+use Factories\GenericPromo;
+
+class ComponentDummyComponentController extends Controller
+{
+    /**
+     * Construct the controller.
+     */
+    public function __construct(Factory $faker)
+    {
+        $this->faker['faker'] = $faker->create();
+    }
+
+    /**
+     * Article Listing Controller
+     */
+    public function index(Request $request): View
+    {
+        $request->data['base']['page']['content']['main'] = '';
+
+        $components = [
+            'accordion' => [
+                'data' => [
+                    0 => [
+                        'title' => 'Component configuration',
+                        'promo_item_id' => 'componentConfiguration',
+                        'description' => '',
+                        'tr1' => [
+                            'Page field' => 'modular-dummy-component-1',
+                            'Data' => '{
+"id":000000,
+"heading":"Dummy Component",
+"config":"randomize|limit:1|youtube"
+}',
+                        ],
+                    ],
+                    1 => [
+                        'title' => 'Promotion group details',
+                        'promo_item_id' => 'promotionGroupDetails',
+                        'description' => '',
+                        'table' => [
+                            'Title' => 'Bold text.',
+                            'Link' => 'Optional external link.<br /> Component flag "singlePromoView" sets the link to the individual promo item view.',
+                            'Excerpt' => 'Optional smaller text under the title.',
+                            'Description' => 'Optional smaller text under the title and/or excerpt. <br /> You might use this area on a singe promo view page and hide it from the catalog component.',
+                            'Primary image' => 'Minimum width of 600px jpg, png.',
+                        ],
+                    ],
+                ],
+                'component' => [
+                    'filename' => 'accordion-styleguide',
+                ],
+            ],
+            'dummy-component-1' => [
+                'data' => app(GenericPromo::class)->create(4, false, [
+                    'excerpt' => '',
+                    'link' => '#',
+                ]),
+                'component' => [
+                    'heading' => 'Dummy Component Component',
+                    'filename' => 'dummy-component',
+                ],
+            ],
+        ];
+
+        // Assign components globally
+        $request->data['base']['components'] = $components;
+
+        return view('childpage', merge($request->data));
+    }
+}

--- a/stubs/component-page.stub
+++ b/stubs/component-page.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace Styleguide\Pages;
+
+use Factories\Page as PageFactory;
+
+class ComponentDummyComponent extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app(PageFactory::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ComponentDummyComponentController',
+                'title' => 'Dummy Component',
+                'id' => DummyId,
+                'content' => [
+                    'main' => '<p>Dummy Component promos.</p>',
+                ],
+            ],
+        ]);
+    }
+}

--- a/stubs/component.stub
+++ b/stubs/component.stub
@@ -1,0 +1,18 @@
+{{--
+    $data => array [
+        ['title', 'link', 'excerpt', 'description']
+        ... Promotion items from "id" field
+    ]
+    $component => array [
+        "filename" => "dummy-component"
+        "id" => 1234
+        ... All key:values from the custom field config
+    ]
+
+    // Debug to see component config
+    @php dump($component) @endphp
+--}}
+
+@foreach($data as $item)
+    @php dump($item) @endphp
+@endforeach

--- a/styleguide/Pages/ComponentSiteSpecific.php
+++ b/styleguide/Pages/ComponentSiteSpecific.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Styleguide\Pages;
+
+use Factories\Page as PageFactory;
+
+class ComponentSiteSpecific extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app(PageFactory::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+                'title' => 'Creating site specific modules',
+                'id' => 999900,
+                'content' => [
+                    'main' => '<p>Module names should be singular and kebab-case.</p>
+                    <h2>Example new features</h2>
+                    <ul><li>"Spotlight" <code class="bg-gray-200 py-1 px-2 rounded text-sm">php artisan base:module spotlight</code></li>
+                    <li>"Expanding Grid" <code class="bg-gray-200 py-1 px-2 rounded text-sm">php artisan base:module expanding-grid</code></li></ul>
+                    <h3>"Expanding Grid" command result</h3>
+                    <pre class="code-block">$ php artisan base:module expanding-grid
+resources/views/components/expanding-grid.blade.php written successfully.
+styleguide/Http/Controllers/ComponentExpandingGridController.php written successfully.
+styleguide/menu.json written successfully.
+styleguide/Pages/ComponentExpandingGrid.php written successfully.
+
+"modular-expanding-grid" is now ready to use. 🚀</pre>
+                    <h3>Customizing the component</h3>
+                    <p><ol>
+                        <li>Update `styleguide/Pages/ComponentExpandingGrid.php` to provide a description of the modular component</li>
+                        <li>Update `styleguide/Http/Controllers/ComponentExpandingGridController.php` to include required fields and config options</li>
+                        <li>Update `resources/views/components/expanding-grid.blade.php` to create the HTML of the component</li>
+                        <li>Add the "modular-expanding-grid" custom page field to the CMS site to start using component on pages</li>
+                    </ol></p>',
+                ],
+            ],
+
+
+        ]);
+    }
+}

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -371,6 +371,16 @@
                 "class_name": "",
                 "relative_url": "/styleguide/component/spotlight",
                 "submenu": []
+            },
+            "9999": {
+                "menu_item_id": 9999,
+                "is_active": 1,
+                "page_id": 999900,
+                "target": "",
+                "display_name": "Site specific",
+                "class_name": "",
+                "relative_url": "/styleguide/component/sitespecific",
+                "submenu": []
             }
         }
     },


### PR DESCRIPTION
## Reason for change

As more functionality on sites is moving to the modular components instead of full templates, this change introduces the `php artisan base:module {name}` command line interface to generate the scaffolding for new modular components.

It works similarly to the `base:feature` and introduces a new "Site specific" menu item in the styleguide to ensure the site-specific modular components are isolated and do not slow down future codebase upgrades.

The stub component intentionally does not do anything other than dump the promotion items and config to the screen. 

The "Site specific" styleguide page walks through the process of creation and the next steps to update the styleguide pages with description, config and instructions.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

![Screenshot 2024-09-26 at 6 35 13 AM](https://github.com/user-attachments/assets/776e2257-d4de-4308-ac7b-a8d212d58609)

| Styleguide before | Styleguide after |
|--------|--------|
| ![Screenshot 2024-09-26 at 6 35 48 AM](https://github.com/user-attachments/assets/eac51c39-2cf1-4d5e-b0ec-cea33a086295) | ![Screenshot 2024-09-26 at 6 36 32 AM](https://github.com/user-attachments/assets/b5de1c25-cec1-49c0-a97b-6b96fb975fbf) |