### PR TITLE
Feature/contain breadcrumbs

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -2,7 +2,7 @@
     $breadcrumbs => array // ['display_name', 'relative_url']
 --}}
 <nav id="breadcrumbs-menu" class="breadcrumbs mt-6 mb-2 print:mt-0 max-w-screen-3xl px-4 mx-auto" aria-label="Breadcrumbs">
-    <ul class="text-sm">
+    <ul class="text-sm @if(!empty($base['banner']))mt:w-4/5 @endif">
         @foreach($breadcrumbs as $key=>$crumb)
             @if($key == 0)
                 <li class="inline">


### PR DESCRIPTION
Setting the breadcrumbs to be contained when banner flag is present. this issue occurred on CLAS https://bitbucket.org/waynestate/clas/pull-requests/340/overview.

Below the example from clas with a before and after.
<img width="670" alt="3497721042-Screenshot 2024-06-28 at 9 58 14 AM" src="https://github.com/user-attachments/assets/930f86ce-ddcd-4fda-b6ff-39813977f250">
<img width="479" alt="2060587443-Screenshot 2024-06-28 at 10 28 22 AM" src="https://github.com/user-attachments/assets/0f765e27-97e5-4046-9cf5-8aff3a87f47f">
