### PR TITLE
Individual profile name now showing correctly as the page title

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -106,7 +106,7 @@ class ProfileController extends Controller
         $fields = $this->profile->getFields();
 
         // Change page title to profile name
-        $request->data['base']['page']['title'] = $profile['profile']['full_name'] ?? '';
+        $request->data['base']['page']['title'] = $this->profile->getPageTitleFromName(['profile' => $profile['profile']]);
         $request->data['base']['page']['canonical'] = $request->data['base']['server']['url'] ?? '';
 
         // Set the back URL


### PR DESCRIPTION
## Reason for change

Recover the full name as part of the page title. It was unintentionally removed in https://github.com/waynestate/base-site/pull/724

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-01 at 10 38 57 AM](https://github.com/user-attachments/assets/34a21d3a-5851-4476-add9-9d3762787722) | ![Screenshot 2024-10-01 at 10 38 38 AM](https://github.com/user-attachments/assets/7ea76494-d5eb-4eec-b5bb-4e7c0f2aaa86) |