### PR TITLE
Default back to profiles link now returns 200 response

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -138,7 +138,7 @@ return [
     | "Return to Listing" link.
     |
     */
-    'profile_default_back_url' => '/profiles/',
+    'profile_default_back_url' => '/profiles',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Reason for change

A little clean-up before the next release. This default URL was causing a redirect to remove the trailing slash. 

This change removes that extra redirect for new sites.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-04 at 10 33 23 AM](https://github.com/user-attachments/assets/0d6a4f33-a889-4e74-b25c-d126f5754ac3) | ![Screenshot 2024-10-04 at 11 11 12 AM](https://github.com/user-attachments/assets/f21f4211-286c-4988-937f-361a0de38026) |