### PR TITLE
Allow line breaks only in the Title profile field

### DIFF
--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -7,6 +7,6 @@
     </div>
     <div class="underline group-hover:no-underline group-focus:no-underline font-bold">{{ $profile['full_name'] }}</div>
     @if(!empty($profile['data']['Title']))
-        <div class="text-black text-sm">{{ $profile['data']['Title'] }}</div>
+        <div class="text-black text-sm">{!! strip_tags($profile['data']['Title'], '<br>') !!}</div>
     @endif
 </a>

--- a/resources/views/profile-view.blade.php
+++ b/resources/views/profile-view.blade.php
@@ -13,7 +13,7 @@
 
             <div class="content">
                 @if(!empty($profile['data']['Title']))
-                    <p>{{ $profile['data']['Title'] }}</p>
+                    <p>{!! strip_tags($profile['data']['Title'], '<br>') !!}</p>
                 @endif
 
                 @foreach($profile['data'] as $field=>$data)


### PR DESCRIPTION
## Reason for change

After reviewing a number of School of Medicine sites, faculty often have more than one title in the single field.

We are already allowing linebreaks in the Title field on the main university directory, we should allow it on the individual sites to match.

This change allows `<br>` tags only in the Title field.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Listing page

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-04 at 3 29 17 PM](https://github.com/user-attachments/assets/8b04b27c-3320-49a0-83d4-802034de21a8) | ![Screenshot 2024-10-04 at 3 30 52 PM](https://github.com/user-attachments/assets/a825a18e-80ce-45ad-a501-f71d0bf6bbe5) |

## Individual view

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-04 at 3 31 44 PM](https://github.com/user-attachments/assets/4b10bfbf-0c3e-41af-843b-94a2245c9538) | ![Screenshot 2024-10-04 at 3 31 25 PM](https://github.com/user-attachments/assets/014d8240-738c-4d53-82e2-b9a6212d7bfd) |