### PR TITLE
fix: Setting the base page controller data to array.

### DIFF
--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -208,7 +208,7 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
         if(!empty($hero)) {
             $hero_key = array_key_first($hero);
             $promos['hero'] = $promos['components'][$hero_key]['data'];
-            config(['base.hero_full_controllers' => $data['page']['controller']]);
+            config(['base.hero_full_controllers' => [$data['page']['controller']]]);
             unset($promos['components'][$hero_key]);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.11.1",
+  "version": "8.11.2",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
issue with hero page info coming in as string when array is expected

This issue shows up when trying to contained hero pages to full-width via modular component.