### PR TITLE
Middle name now part of the full_name creation

### DIFF
--- a/app/Repositories/PeopleRepository.php
+++ b/app/Repositories/PeopleRepository.php
@@ -333,6 +333,7 @@ class PeopleRepository implements ProfileRepositoryContract
                 'Suffix',
                 'Honorific',
                 'First Name',
+                'Middle Name',
                 'Last Name',
                 'Picture',
                 'Photo Download',
@@ -342,6 +343,7 @@ class PeopleRepository implements ProfileRepositoryContract
             'name_fields' => [
                 'Honorific',
                 'First Name',
+                'Middle Name',
                 'Last Name',
                 'Suffix',
             ],

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -315,6 +315,7 @@ class ProfileRepository implements ProfileRepositoryContract
                 'Suffix',
                 'Honorific',
                 'First Name',
+                'Middle name',
                 'Last Name',
                 'Picture',
                 'Photo Download',
@@ -324,6 +325,7 @@ class ProfileRepository implements ProfileRepositoryContract
             'name_fields' => [
                 'Honorific',
                 'First Name',
+                'Middle name',
                 'Last Name',
                 'Suffix',
             ],

--- a/factories/People.php
+++ b/factories/People.php
@@ -26,6 +26,7 @@ class People implements FactoryContract
         for ($i = 1; $i <= $limit; $i++) {
             $accessid = $this->faker->randomLetter().$this->faker->randomLetter().$this->faker->randomNumber(4, true);
             $first_name = $this->faker->firstName();
+            $middle_name = $this->faker->firstName();
             $last_name = $this->faker->lastName();
             $suffix = $this->faker->suffix();
             $email = $this->faker->email();
@@ -46,6 +47,7 @@ class People implements FactoryContract
             $data[$i] = [
                 'id' => $i,
                 'first_name' => $first_name,
+                'middle_name' => $middle_name,
                 'last_name' => $last_name,
                 'accessid' => $accessid,
                 'email' => $email,
@@ -60,6 +62,14 @@ class People implements FactoryContract
                         'value' => $first_name,
                         'field' => [
                             'name' => 'First Name',
+                            'type' => 'text',
+                            'global' => 1,
+                        ],
+                    ],
+                    [
+                        'value' => $middle_name,
+                        'field' => [
+                            'name' => 'Middle Name',
                             'type' => 'text',
                             'global' => 1,
                         ],
@@ -141,10 +151,11 @@ class People implements FactoryContract
                     $groups->random(),
                 ],
                 'link' => '/styleguide/profile/aa0000',
-                'full_name' => $first_name . ' ' . $last_name,
+                'full_name' => $first_name . ' ' . $middle_name . ' ' . $last_name,
                 'data' => [
                     'AccessID' => $accessid,
                     'First Name' => $first_name,
+                    'Middle Name' => $middle_name,
                     'Last Name' => $last_name,
                     'Email' => $email,
                     'Title' => $this->faker->sentence(3),

--- a/resources/views/contact-tables.blade.php
+++ b/resources/views/contact-tables.blade.php
@@ -36,7 +36,7 @@
                     <tbody>
                     @foreach($profile_list as $profile)
                         <tr>
-                            <td>@if(isset($profile['data']['Email']))<a href="mailto:{{$profile['data']['Email']}}">@endif{{$profile['data']['First Name']}} {{$profile['data']['Last Name']}}@if(isset($profile['data']['Email']))</a>@endif</td>
+                            <td>@if(isset($profile['data']['Email']))<a href="mailto:{{$profile['data']['Email']}}">@endif{{$profile['full_name']}}@if(isset($profile['data']['Email']))</a>@endif</td>
                             <td>@if(isset($profile['data']['Title'])){{$profile['data']['Title']}}@endif</td>
                             <td>@if(isset($profile['data']['Office Location'])){{$profile['data']['Office Location']}}@endif</td>
                             <td>@if(isset($profile['data']['Phone'])){{$profile['data']['Phone']}}@endif</td>

--- a/tests/Unit/Repositories/PeopleRepositoryTest.php
+++ b/tests/Unit/Repositories/PeopleRepositoryTest.php
@@ -52,6 +52,7 @@ final class PeopleRepositoryTest extends TestCase
             'name_fields' => [
                 'Honorific',
                 'First Name',
+                'Middle Name',
                 'Last Name',
                 'Suffix',
             ],
@@ -60,6 +61,7 @@ final class PeopleRepositoryTest extends TestCase
         $return['profile']['data'] = [
             'Honorific' => 'Dr.',
             'First Name' => 'Anthony',
+            'Middle Name' => 'M.',
             'Last Name' => 'Wayne',
             'Suffix' => 'Jr.',
         ];
@@ -72,7 +74,7 @@ final class PeopleRepositoryTest extends TestCase
         $pageTitle = $people->getPageTitleFromName($return);
 
         // Make sure the page title equals all the name fields
-        $this->assertEquals('Dr. Anthony Wayne, Jr.', $pageTitle);
+        $this->assertEquals('Dr. Anthony M. Wayne, Jr.', $pageTitle);
     }
 
     #[Test]

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -52,6 +52,7 @@ final class ProfileRepositoryTest extends TestCase
             'name_fields' => [
                 'Honorific',
                 'First Name',
+                'Middle name',
                 'Last Name',
                 'Suffix',
             ],
@@ -60,6 +61,7 @@ final class ProfileRepositoryTest extends TestCase
         $return['profile']['data'] = [
             'Honorific' => 'Dr.',
             'First Name' => 'Anthony',
+            'Middle name' => 'M.',
             'Last Name' => 'Wayne',
             'Suffix' => 'Jr.',
         ];
@@ -72,7 +74,7 @@ final class ProfileRepositoryTest extends TestCase
         $pageTitle = $profile->getPageTitleFromName($return);
 
         // Make sure the page title equals all the name fields
-        $this->assertEquals('Dr. Anthony Wayne, Jr.', $pageTitle);
+        $this->assertEquals('Dr. Anthony M. Wayne, Jr.', $pageTitle);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for change

Bringing consistency into each location profile names are viewed. This change also includes their "middle name" field.

## Demo

| Before | After |
|--------|--------|
| ![Screenshot 2024-11-19 at 2 33 28 PM](https://github.com/user-attachments/assets/fd688061-9052-4c18-8bd5-b20f78e5d653) | ![Screenshot 2024-11-19 at 2 33 08 PM](https://github.com/user-attachments/assets/a7a92f2d-21a8-452b-b701-46d85d137575) |