### PR TITLE
fix: Remove hamburger menu icon hover state

### DIFF
--- a/resources/scss/components/_menu-icon.scss
+++ b/resources/scss/components/_menu-icon.scss
@@ -15,7 +15,3 @@
     height: 2px;
     content: '';
 }
-
-.menu-icon:hover::after {
-    @apply bg-gray-400 shadow-gray;
-}


### PR DESCRIPTION
Remove hamburger menu icon hover state

Before:
<img width="494" alt="Screenshot 2024-12-13 at 10 13 32 AM" src="https://github.com/user-attachments/assets/98683b49-0d1f-4b0d-a737-c7a2ccd653cf" />

After:
<img width="495" alt="Screenshot 2024-12-13 at 10 57 26 AM" src="https://github.com/user-attachments/assets/ec0590c2-e3fe-4260-871d-d0e1128226f0" />
