### PR TITLE
Hotfix 8.13.3 - Re-add Trusted Proxies for production

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -293,6 +293,7 @@ echo "RemoteRelease Environment file setup Done.";
     echo "RemoteRelease Prepare...";
     mv {{ $source_dir }} {{ $release_dir }}/{{ $release }}
     chmod -R g+s {{ $release_dir }}/{{ $release }}
+    chmod -R 02770 {{ $release_dir }}/{{ $release }}/bootstrap/cache
     echo "RemoteRelease Prepare Done.";
 @endtask
 

--- a/composer.lock
+++ b/composer.lock
@@ -1997,12 +1997,12 @@
             "version": "3.8.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/briannesbitt/Carbon.git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
                 "reference": "e1268cdbc486d97ce23fef2c666dc3c6b6de9947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/e1268cdbc486d97ce23fef2c666dc3c6b6de9947",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e1268cdbc486d97ce23fef2c666dc3c6b6de9947",
                 "reference": "e1268cdbc486d97ce23fef2c666dc3c6b6de9947",
                 "shasum": ""
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.13.2",
+  "version": "8.13.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Upgrade to Laravel v11 changed the way that Trusted Proxies is handled.

fix: due to production being behind the load balancer and the TrustProxies getting moved to the $middleware under the bootstrap, re-add it

old class
https://github.com/waynestate/base-site/blob/8.10.6/app/Http/Middleware/TrustProxies.php