### PR TITLE
fix: This change allow for subsites to have the correct path for prof…

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -54,7 +54,7 @@ class ProfileRepository implements ProfileRepositoryContract
         // Build the link
         if (empty($profile_listing['error'])) {
             $profile_listing = collect($profile_listing)->map(function ($item) {
-                $item['link'] = '/profile/'.$item['data']['AccessID'];
+                $item['link'] = 'profile/'.$item['data']['AccessID'];
                 $item['full_name'] = $this->getPageTitleFromName(['profile' => $item]);
 
                 return $item;


### PR DESCRIPTION
The extra slash was causing issues when subsites had profiles.

During an upgrade from Base upgrade from 4 to 5, when the [profile link creation was moved to the repository](https://github.com/waynestate/base-site/commit/b01c60c16c138df80efda7008c87b17a336921c5#diff-ab5a25447b98b9683b19e8a6e86a3c06eb033d2277d198cdc0b11ca425a32fe7R55), The a slash was added to the front of `profile/`.

This corrects this issue.