### PR TITLE
feat: use subsite-folder to determine how to build profile link.

### DIFF
--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -34,9 +34,9 @@ class DirectoryController extends Controller
         $site_id = $this->profile->getSiteID($request->data['base']);
 
         if (!empty(config('profile.group_id'))) {
-            $profiles = $this->profile->getProfilesByGroupOrder($site_id, config('profile.group_id'));
+            $profiles = $this->profile->getProfilesByGroupOrder($site_id, config('profile.group_id'), $request->data['base']['site']['subsite-folder']);
         } else {
-            $profiles = $this->profile->getProfilesByGroup($site_id);
+            $profiles = $this->profile->getProfilesByGroup($site_id, $request->data['base']['site']['subsite-folder']);
         }
 
         return view('directory', merge($request->data, $profiles));

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -37,7 +37,7 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getProfiles(int $site_id, ?string $selected_group = null): array
+    public function getProfiles(int $site_id, ?string $selected_group = null, $subsite_url = null): array
     {
         $params = [
             'method' => 'profile.users.listing',
@@ -53,8 +53,9 @@ class ProfileRepository implements ProfileRepositoryContract
 
         // Build the link
         if (empty($profile_listing['error'])) {
-            $profile_listing = collect($profile_listing)->map(function ($item) {
-                $item['link'] = '/profile/'.$item['data']['AccessID'];
+            $profile_listing = collect($profile_listing)->map(function ($item) use ($subsite_url) {
+                $item['link'] = '/'.$subsite_url.'profile/'.$item['data']['AccessID'];
+
                 $item['full_name'] = $this->getPageTitleFromName(['profile' => $item]);
 
                 return $item;
@@ -70,7 +71,7 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getProfilesByGroup($site_id)
+    public function getProfilesByGroup($site_id, $subsite_url = null): array
     {
         // Get the groups for the dropdown
         $dropdown_groups = $this->getDropdownOfGroups($site_id);
@@ -79,7 +80,7 @@ class ProfileRepository implements ProfileRepositoryContract
         $group_ids = $this->getGroupIds(null, null, $dropdown_groups['dropdown_groups']);
 
         // Get all the profiles
-        $all_profiles = $this->getProfiles($site_id, $group_ids);
+        $all_profiles = $this->getProfiles($site_id, $group_ids, $subsite_url);
 
         // Organize profiles by the group they are in keyed by accessid
         $grouped = collect($all_profiles['profiles'])->keyBy('data.AccessID')
@@ -120,9 +121,9 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getProfilesByGroupOrder($site_id, $groups)
+    public function getProfilesByGroupOrder($site_id, $groups, $subsite_url = null): array
     {
-        $profile_listing = $this->getProfiles($site_id);
+        $profile_listing = $this->getProfiles($site_id, null, $subsite_url);
 
         $group_order = preg_split('/[\s,|]+/', $groups);
 

--- a/contracts/Repositories/ProfileRepositoryContract.php
+++ b/contracts/Repositories/ProfileRepositoryContract.php
@@ -11,7 +11,7 @@ interface ProfileRepositoryContract
      * @param string|null $selected_group
      * @return array
      */
-    public function getProfiles(int $site_id, ?string $selected_group = null): array;
+    public function getProfiles(int $site_id, ?string $selected_group = null, $subsite_url = null): array;
 
     /**
      * Gets the profiles based on promo_group_id custom field and generates anchors for each group
@@ -20,7 +20,7 @@ interface ProfileRepositoryContract
      * @param string $groups
      * @return array
      */
-    public function getProfilesByGroupOrder($site_id, $groups);
+    public function getProfilesByGroupOrder($site_id, $groups, $subsite_url = null): array;
 
     /**
      * Get the dropdown config options.

--- a/styleguide/Repositories/ProfileRepository.php
+++ b/styleguide/Repositories/ProfileRepository.php
@@ -13,7 +13,7 @@ class ProfileRepository extends Repository
     /**
      * {@inheritdoc}
      */
-    public function getProfiles(int $site_id, ?string $selected_group = null): array
+    public function getProfiles(int $site_id, ?string $selected_group = null, $subsite_url = null): array
     {
         $limit = is_int($selected_group) ? rand(2, 5) : 20;
 


### PR DESCRIPTION
creating this as an alternative option to simply removing the first slash. https://github.com/waynestate/base-site/pull/771

Realized that after looking into this longer and at a few other situations that checking for subsite-folder, is a better way of handling there profile links on subsite and nested urls, without the need to create addtional pages. 

During an upgrade from Base upgrade from 4 to 5, when the [profile link creation was moved to the repository](https://github.com/waynestate/base-site/commit/b01c60c16c138df80efda7008c87b17a336921c5#diff-ab5a25447b98b9683b19e8a6e86a3c06eb033d2277d198cdc0b11ca425a32fe7R55), The a slash was added to the front of profile/.

This corrects this issue.