### PR TITLE
Fix: Accordion cutting off content

### DIFF
--- a/resources/scss/components/_accordion.scss
+++ b/resources/scss/components/_accordion.scss
@@ -40,6 +40,10 @@
             @apply p-4 pt-0 pl-8 border-t-0;
 
             transition: 0.3s ease all;
+
+            > * {
+                @apply mt-0;
+            }
         }
     }
 


### PR DESCRIPTION
Because of how browsers handle margins (margins of adjacent elements overlap) when the accordion.js is calcuating the inner height, it is not accounting for the top margin of the first heading/element.

This change removes the top margin of any first element within the "fold". 

| Before      | After      |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/ac6af972-697e-4303-a33f-64ee8f17cbcb)|![image](https://github.com/user-attachments/assets/4c92e549-2d98-4ecd-ac09-42872e818d1f)|