### PR TITLE
refactor: convert `//` incompatible comments to be `/* */` proper css comments

### DIFF
--- a/resources/scss/components/_accordion.scss
+++ b/resources/scss/components/_accordion.scss
@@ -18,7 +18,7 @@
             cursor: pointer;
             user-select: none;
 
-            // Open symbol
+            /* Open symbol */
             & span::before {
                 @apply absolute left-0 pl-4 top-0 pt-4;
 
@@ -30,12 +30,12 @@
             @apply outline outline-0;
         }
 
-        // Close symbol
+        /* Close symbol */
         &.open > a span::before {
             content: '\2013';
         }
 
-        // Content area
+        /* Content area */
         > .fold {
             @apply p-4 pt-0 pl-8 border-t-0;
 

--- a/resources/scss/components/_bg-gradient.scss
+++ b/resources/scss/components/_bg-gradient.scss
@@ -1,5 +1,5 @@
 @layer utilities {
-    // Gradient overlay
+    /* Gradient overlay */
     .bg-gradient-darkest::before {
         @apply absolute inset-0;
 
@@ -11,7 +11,7 @@
         }
     }
 
-    // Backgrounds
+    /* Backgrounds */
     .bg-gradient-green {
         @apply bg-green-600;
 

--- a/resources/scss/components/_content.scss
+++ b/resources/scss/components/_content.scss
@@ -1,4 +1,4 @@
-// Content returning from CMS
+/* Content returning from CMS */
 .content {
     ul {
         @apply list-disc;
@@ -56,19 +56,21 @@
         @apply mb-0;
     }
 
-    // Tailwind preflight sets images to block
+    /* Tailwind preflight sets images to block */
     img {
         @apply inline;
     }
 
-    // TODO wtf stylelint
-    // Do not rearrange any of this link and heading link css
-    // Underline all content links
+    /*
+    TODO wtf stylelint
+    Do not rearrange any of this link and heading link css
+    Underline all content links
+    */
     a {
         @apply underline;
     }
 
-    // Bottom border instead of underline all heading links
+    /* Bottom border instead of underline all heading links */
     h1,
     h2,
     h3,
@@ -78,7 +80,8 @@
         a {
             @apply no-underline border-b border-green;
         }
-        // Prevent users from having gold text
+
+        /* Prevent users from having gold text */
         &.text-gold {
             @apply text-black;
         }

--- a/resources/scss/components/_external-icon.scss
+++ b/resources/scss/components/_external-icon.scss
@@ -14,7 +14,7 @@
     left: 0.25em;
 }
 
-// Strictly inline-block anchors
+/* Strictly inline-block anchors */
 .main-menu .external a,
 .content a.external[class*="button"],
 .under-menu a.external[class*="button"] div:first-of-type {
@@ -27,7 +27,7 @@
     }
 }
 
-// Strictly inline anchors
+/* Strictly inline anchors */
 .content a.external {
     @apply relative;
 

--- a/resources/scss/components/_flag.scss
+++ b/resources/scss/components/_flag.scss
@@ -34,7 +34,7 @@
                 @apply row relative;
             }
 
-            // Pointy bottom
+            /* Pointy bottom */
             &::after {
                 @apply bg-gold absolute duration-500;
 

--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -64,22 +64,22 @@
         }
     }
 
-    // Fieldsets
+    /* Fieldsets */
     fieldset {
         @apply m-0 p-0 border-0;
     }
 
-    // Textareas
+    /* Textareas */
     textarea {
         @apply h-32;
     }
 
-    // Description and text blocks size
+    /* Description and text blocks size */
     p {
         @apply text-base mb-4 leading-normal;
     }
 
-    // Errors
+    /* Errors */
     .error {
         p {
             @apply text-red-500 mx-auto mt-1 mb-4 text-sm;
@@ -97,7 +97,7 @@
         }
     }
 
-    // Labels
+    /* Labels */
     label {
         @apply font-normal;
 
@@ -108,7 +108,7 @@
         }
     }
 
-    // Checkboxes and radio
+    /* Checkboxes and radio */
     div.checkbox input,
     div.radio input {
         @apply m-0 p-0;
@@ -134,7 +134,7 @@
         @apply mb-0;
     }
 
-    // The subit button
+    /* The subit button */
     #formy-button {
         @extend .button;
     }
@@ -146,13 +146,13 @@
         border-radius: 0 !important;
     }
 
-    // Text Headings
+    /* Text Headings */
     h2,
     .field_group h2 {
         @apply border-b border-gray-300 text-xl;
     }
 
-    // Login
+    /* Login */
     .login-info li {
         @apply border-b border-solid border-gray-400 text-sm px-0 py-2;
     }
@@ -175,7 +175,7 @@
         @apply text-right;
     }
 
-    // Required
+    /* Required */
     label em {
         @apply text-red-500;
     }

--- a/resources/scss/components/_global-headings.scss
+++ b/resources/scss/components/_global-headings.scss
@@ -31,7 +31,7 @@ h6 {
     @apply text-base;
 }
 
-// Heading styles
+/* Heading styles */
 .divider-gold {
     @apply relative overflow-hidden;
 

--- a/resources/scss/components/_global-tables.scss
+++ b/resources/scss/components/_global-tables.scss
@@ -54,7 +54,7 @@ table {
     @media (max-width: theme('screens.md')) {
         @apply w-full;
 
-        // Hide table head
+        /* Hide table head */
         thead tr {
             @apply absolute;
 
@@ -70,7 +70,7 @@ table {
             @apply flex px-4 pt-0 pb-1 my-2;
         }
 
-        // Add data labels
+        /* Add data labels */
         td::before {
             @apply block font-bold pr-1.5;
 

--- a/resources/scss/components/_global.scss
+++ b/resources/scss/components/_global.scss
@@ -1,4 +1,4 @@
-// Restricts the embedded font from combining two characters like "fi"
+/* Restricts the embedded font from combining two characters like "fi" */
 html {
     font-feature-settings: "liga" 0;
     text-rendering: optimizelegibility;
@@ -8,7 +8,7 @@ body {
     @apply min-h-screen flex flex-col;
 }
 
-// Links outside of content aren't underlined
+/* Links outside of content aren't underlined */
 a {
     @apply text-green no-underline;
 }
@@ -27,12 +27,12 @@ p {
     @apply mb-4;
 }
 
-// To maintain consistent spacing when using paragraphs inside of grid
+/* To maintain consistent spacing when using paragraphs inside of grid */
 .grid p:last-of-type {
     @apply mb-0;
 }
 
-// Tailwind preflight sets this to .5 which isn't ADA compliant
+/* Tailwind preflight sets this to .5 which isn't ADA compliant */
 input::placeholder,
 textarea::placeholder {
     @apply opacity-100 text-gray-500;
@@ -77,8 +77,9 @@ figure {
     }
 }
 
-// Images remain at their specified width
-// Text appears above and below for small
+/* Images remain at their specified width */
+
+/* Text appears above and below for small */
 @media (max-width: theme('screens.mt')) {
     figure {
         @apply block my-0 mx-auto;
@@ -92,7 +93,7 @@ figure {
     }
 }
 
-// Floated images can only be 50% of column width for readability
+/* Floated images can only be 50% of column width for readability */
 @screen mt {
     img {
         &[style*="float:right"],
@@ -110,7 +111,7 @@ figure {
     }
 }
 
-// Firefox uses the outline focus color as the text color. Since our overall background is white we need to change it.
+/* Firefox uses the outline focus color as the text color. Since our overall background is white we need to change it. */
 a.text-white:-moz-focusring {
     outline-color: #000;
 }
@@ -124,7 +125,7 @@ pre,
     @apply inline-block bg-gray-100 overflow-x-scroll text-sm p-2 my-2 rounded max-w-full;
 }
 
-// Keep footer at the bottom of the browser
+/* Keep footer at the bottom of the browser */
 footer {
     @apply mt-auto;
 }

--- a/resources/scss/components/_menu-slideout.scss
+++ b/resources/scss/components/_menu-slideout.scss
@@ -12,17 +12,17 @@
             @apply text-white;
         }
 
-        // Indent second level now since first level is shown
+        /* Indent second level now since first level is shown */
         li > ul > li a {
             @apply pl-8;
         }
 
-        // Indent third level now since first level is shown
+        /* Indent third level now since first level is shown */
         li > ul > li > ul > li a {
             @apply pl-12;
         }
 
-        // Selected State
+        /* Selected State */
         .selected > a {
             @apply text-gold;
         }
@@ -34,7 +34,7 @@
         }
     }
 
-    // Main Menu within slideout
+    /* Main Menu within slideout */
     .slideout-main-menu {
         @apply block;
 
@@ -48,7 +48,7 @@
             cursor: pointer;
         }
 
-        // Menu Header top level (MAIN MENU)
+        /* Menu Header top level (MAIN MENU) */
         ul ul {
             @apply border-solid border-b-4 border-green-800;
         }

--- a/resources/scss/components/_pdf.scss
+++ b/resources/scss/components/_pdf.scss
@@ -1,4 +1,4 @@
-// pdf.js appends a span for styling
+/* pdf.js appends a span for styling */
 a[href$=".pdf"] img + span {
     @apply bg-green-600 text-white rounded-sm absolute right-0 bottom-0 pt-0.5 pb-1 px-2 mr-1 mb-1 leading-none font-bold text-sm tracking-wide;
 }

--- a/resources/scss/components/_policy-numbering.scss
+++ b/resources/scss/components/_policy-numbering.scss
@@ -1,4 +1,4 @@
-// Policy numbering style
+/* Policy numbering style */
 .content > ol.policy-numbering {
     counter-reset: section;
     list-style-type: none;
@@ -30,7 +30,7 @@
         }
     }
 
-    // Reset the counter for nested lists
+    /* Reset the counter for nested lists */
     ol {
         counter-reset: section;
         list-style-type: none;
@@ -52,7 +52,8 @@
             content: counters(section, ".") " ";
         }
     }
-    // Avoid incremeting ul bullets
+
+    /* Avoid incremeting ul bullets */
     ul {
         counter-reset: section;
         margin-left: 1rem;
@@ -100,7 +101,7 @@
         }
     }
 
-    // Third level
+    /* Third level */
     ol li ol li {
         padding-left: 4rem;
         margin-top: 1rem;
@@ -109,7 +110,7 @@
         list-style-type: none;
     }
 
-    // Fourth level
+    /* Fourth level */
     ol li ol li ol li {
         padding-left: 4rem;
         margin-top: 1rem;

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -1,4 +1,4 @@
-// Global print styles
+/* Global print styles */
 @screen print {
     *,
     *::before,

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -1,4 +1,4 @@
-// Combination of normalize and tailwind resets
+/* Combination of normalize and tailwind resets */
 @tailwind base;
 
 @import "~mediabox/dist/mediabox";
@@ -35,10 +35,10 @@
 @import "components/full-width-styleguide-hero";
 @import "components/policy-numbering";
 
-// Site specific
+/* Site specific */
 @import "site-specific/theme";
 
-// Tailwind
+/* Tailwind */
 @tailwind components;
 @tailwind utilities;
 

--- a/resources/scss/site-specific/_theme.scss
+++ b/resources/scss/site-specific/_theme.scss
@@ -1,4 +1,4 @@
-// The site-theme class encompasses the content-area component.
+/* The site-theme class encompasses the content-area component. */
 
 .site-theme {
     /* h1, h2 { @extend .divider-gold;  @apply text-green; } */


### PR DESCRIPTION
Comments in CSS can only be `/* */` syntax
https://developer.mozilla.org/en-US/docs/Web/CSS/Comments

This cleans up any `//` comments and allows `make stylelintfix` run without any odd results