### PR TITLE
FIX | Menu Top - Header Title Double | Padding For Accesibility

### DIFF
--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -14,7 +14,7 @@
                 !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
             )
                 <div class="text-base mb-0 font-normal leading-tight">
-                    <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black">{{ config('base.surtitle') }}</a>
+                    <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
                 </div>
 
                 <div class="font-normal mb-1 text-2xl leading-none">


### PR DESCRIPTION
## Reason for change
 
_Why this change is taking place?_
[Update the header title double to be 24 px high to meet accessibility requirement](https://3.basecamp.com/5750155/buckets/37389969/todos/8291633997/)

- Added padding to the sur-title to ensure that appropriate interactive element size is applied
 
## Relevant links
 
- Styleguide: [https://base.wayne.edu/styleguide/layout/header/title/double](https://base.wayne.edu/styleguide/layout/header/title/double)
 
## Reminders
 
- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes
 
## Demo
 
| Before | After |
<img width="1440" alt="before" src="https://github.com/user-attachments/assets/814cf52c-b481-419d-a1ec-c0c08b7e9231" />
|--------|--------|
<img width="1440" alt="after" src="https://github.com/user-attachments/assets/59fffab9-1dad-444b-b617-fb2f251bc6b9" />
|