### PR TITLE
FIX | Menu Top - Heading Title Single/Double | Wrapper Height Consistency

### DIFF
--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -4,7 +4,12 @@
 --}}
 <div class="menu-top-container bg-green-600 print:bg-transparent">
     <div class="row flex justify-between">
-        <div class="grow-0 mx-4 py-2" data-short-title="{{ $site['short-title'] }}">
+        <div class="grow-0 mx-4 {{ (
+                (config('base.surtitle') !== null &&
+                ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) ||
+                ($site['parent']['id'] !== null && config('base.surtitle') !== null)) &&
+                !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
+            ) ? 'py-[5px]' : 'py-2' }}" data-short-title="{{ $site['short-title'] }}">
             @if(
                 (
                     config('base.surtitle') !== null &&

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -2,28 +2,28 @@
     $site => array // ['short-title', 'title', 'subsite-folder']
     $top_menu_output => string // '<ul></ul>'
 --}}
+
+@php
+    $hasSurtitle = (
+        (config('base.surtitle') !== null &&
+        ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) ||
+        ($site['parent']['id'] !== null && config('base.surtitle') !== null)) &&
+        !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
+    );
+@endphp
+
 <div class="menu-top-container bg-green-600 print:bg-transparent">
     <div class="row flex justify-between">
-        <div class="grow-0 mx-4 {{ (
-                (config('base.surtitle') !== null &&
-                ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) ||
-                ($site['parent']['id'] !== null && config('base.surtitle') !== null)) &&
-                !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
-            ) ? 'py-[5px]' : 'py-2' }}" data-short-title="{{ $site['short-title'] }}">
-            @if(
-                (
-                    config('base.surtitle') !== null &&
-                    ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) ||
-                    ($site['parent']['id'] !== null && config('base.surtitle') !== null)
-                ) &&
-                !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
-            )
+        <div class="grow-0 mx-4 {{ $hasSurtitle ? 'py-[5px]' : 'py-2' }}" data-short-title="{{ $site['short-title'] }}">
+            @if($hasSurtitle)
                 <div class="text-base mb-0 font-normal leading-tight">
-                    <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
+                    <a href="{{ config('base.surtitle_url') }}"
+                       class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
                 </div>
 
                 <div class="font-normal mb-1 text-2xl leading-none">
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}"
+                       class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
                             <span class="hidden mt:inline">{{ $site['title'] }}</span>
@@ -34,7 +34,8 @@
                 </div>
             @else
                 <div class="font-normal mb-0 text-2xl leading-none py-3">
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}"
+                       class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
                             <span class="top_menu_hidden mt:inline">{{ $site['title'] }}</span>
@@ -55,7 +56,9 @@
         @endif
 
         <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
-            <button class="menu-toggle menu-icon text-white print:text-black text-3xl mt:hidden" data-toggle="menu" aria-controls="menu" aria-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
+            <button class="menu-toggle menu-icon text-white print:text-black text-3xl mt:hidden" data-toggle="menu"
+                    aria-controls="menu" aria-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span>
+            </button>
         </div>
     </div>
 </div>

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -17,13 +17,11 @@
         <div class="grow-0 mx-4 {{ $hasSurtitle ? 'py-[5px]' : 'py-2' }}" data-short-title="{{ $site['short-title'] }}">
             @if($hasSurtitle)
                 <div class="text-base mb-0 font-normal leading-tight">
-                    <a href="{{ config('base.surtitle_url') }}"
-                       class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
+                    <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
                 </div>
 
                 <div class="font-normal mb-1 text-2xl leading-none">
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}"
-                       class="text-white print:text-black">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
                             <span class="hidden mt:inline">{{ $site['title'] }}</span>
@@ -34,8 +32,7 @@
                 </div>
             @else
                 <div class="font-normal mb-0 text-2xl leading-none py-3">
-                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}"
-                       class="text-white print:text-black">
+                    <a href="/{{ $site['subsite-folder'] !== null ? rtrim($site['subsite-folder'], '/') : '' }}" class="text-white print:text-black">
                         @if($site['short-title'] !== '')
                             <span class="mt:hidden">{{ $site['short-title'] }}</span>
                             <span class="top_menu_hidden mt:inline">{{ $site['title'] }}</span>
@@ -56,9 +53,7 @@
         @endif
 
         <div class="flex flex-1 justify-end items-center mx-4 mt:hidden">
-            <button class="menu-toggle menu-icon text-white print:text-black text-3xl mt:hidden" data-toggle="menu"
-                    aria-controls="menu" aria-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span>
-            </button>
+            <button class="menu-toggle menu-icon text-white print:text-black text-3xl mt:hidden" data-toggle="menu" aria-controls="menu" aria-label="Menu" tabindex="0"><span class="visually-hidden">Menu</span></button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Reason for change
 
### Why this change is taking place?
Padding updates made for the sur-title from #777 added height to the _menu-top_ wrapper.
[Basecamp reference](https://3.basecamp.com/5750155/buckets/37389969/todos/8291633997#__recording_8292346278)

### Updates
- Added conditional wrapper padding adjustment based on presence of sur-title for menu-top
 
## Relevant links
 
- Styleguide (header titile double): [https://base.wayne.edu/styleguide/layout/header/title/double](https://base.wayne.edu/styleguide/layout/header/title/double)
- Styleguide (header titile single): [https://base.wayne.edu/styleguide/layout/header/title/single](https://base.wayne.edu/styleguide/layout/header/title/single)
 
## Reminders
 
- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes
 
## Demo
 
| Before | After |
|--------|--------|
![conditional-padding-before](https://github.com/user-attachments/assets/333324ed-1931-4c91-96ea-3c39e4575b3f)|![conditional-padding-after](https://github.com/user-attachments/assets/1d32d353-517f-4d25-982b-329d8b2a4be4)
