### PR TITLE
fix redis keys for caching from getting the default `base:base_cache...` within the cache config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'prefix' => null,
+
     'ttl' => env('TTL'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     'migrations' => [
@@ -13,7 +15,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('APP_NAME', 'laravel').':',
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME')).':'),
         ],
 
         'default' => [


### PR DESCRIPTION
fix: due to the removal of the prefix from the cache config, the key was being ended up as `base:laravel_cache_...` which isn't what we initially had.