### PR TITLE
Under-menu buttons injection into content fixed, now adjustable

### DIFF
--- a/resources/js/modules/under-menu.js
+++ b/resources/js/modules/under-menu.js
@@ -1,27 +1,36 @@
 (function () {
     "use strict";
+
+    // Only move the under menu buttons if the menu is hidden
     const menu_button = document.querySelector(".menu-toggle");
 
-    // Only move the under menu buttons if the menu is hidden 
-    if (menu_button.offsetHeight !== 0) {
-        const under_menu_dom = document.querySelector(".under-menu");
-        const body_content = document.querySelector("#content .content");
+    if (!menu_button || !menu_button.checkVisibility()) {
+        return;
+    }
 
-        // If the elements exist
-        if (under_menu_dom && body_content) {
+    // Ensure baseline elements exist
+    const under_menu_dom = document.querySelector(".under-menu");
+    const body_content_dom = document.querySelector("#content .content");
 
-            // Remove the visible bullets
-            let under_menu_list = under_menu_dom.querySelector("ul");
-            under_menu_list.setAttribute("style", "list-style:none;margin:0;");
+    if (!under_menu_dom || !body_content_dom) {
+        return;
+    }
 
-            // Inject the elements into the page
-            const first_content_p = body_content.getElementsByTagName("p");
+    // Ensure there is a place to move the buttons
+    const insert_position =
+        document.querySelector("#mobile-cta-buttons") ||
+        body_content_dom.querySelector("p");
 
-            if (first_content_p.length > 0) {
-                first_content_p[0].after(under_menu_list);
-            } else {
-                body_content.appendChild(under_menu_list);
-            }
-        }
+    if (!insert_position) {
+        return;
+    }
+
+    // Get the buttons to move
+    const buttons_under_menu = under_menu_dom.querySelector("ul");
+    buttons_under_menu.classList.add("ml-0", "my-3");
+
+    // Insert the buttons into the new location
+    if (buttons_under_menu.children.length > 0) {
+        insert_position.after(buttons_under_menu);
     }
 })();

--- a/resources/views/layouts/contained-hero.blade.php
+++ b/resources/views/layouts/contained-hero.blade.php
@@ -73,7 +73,9 @@
                 @yield('below_menu')
 
                 @if(!empty($base['under_menu']))
-                    @include('components.button-column', ['data' => $base['under_menu']])
+                    <div class="under-menu">
+                        @include('components.button-column', ['data' => $base['under_menu']])
+                    </div>
                 @endif
             </nav>
         </div>

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -73,7 +73,9 @@
                 @yield('below_menu')
 
                 @if(!empty($base['under_menu']))
-                    @include('components.button-column', ['data' => $base['under_menu']])
+                    <div class="under-menu">
+                        @include('components.button-column', ['data' => $base['under_menu']])
+                    </div>
                 @endif
             </nav>
         </div>

--- a/styleguide/Views/styleguide-component-buttons.blade.php
+++ b/styleguide/Views/styleguide-component-buttons.blade.php
@@ -21,9 +21,17 @@
         </div>
         <div class="col-span-full content">
             <hr />
+            <h2>Mobile CTA buttons</h2>
+            <p>By default, under menu the button(s) will be injected into the page after the first <code>.content</code> paragraph.</p>
+            <p>To control where the buttons are added in the page, add the ID <code>mobile-cta-buttons</code> to any element and the buttons will be injected after that element.</p>
+            <h3>Example</h3>
+            <p id="mobile-cta-buttons">This is the element with the ID <code>mobile-cta-buttons</code>, the buttons will be injected after this element when the menu is collapsed.</p>
+        </div>
+        <div class="col-span-full content">
+            <hr />
             <h2 id="button-appearance-examples">Button appearance examples</h2>
             <p>A button's appearance depends on which fields you add to the promotion item.</p>
-            <p>For "Default" and "Green" buttons, the excerpt displays as a second line line of text, and the primary image displays as a small icon next to either one or two lines of text. 
+            <p>For "Default" and "Green" buttons, the excerpt displays as a second line line of text, and the primary image displays as a small icon next to either one or two lines of text.</p>
             <p class="mb-0">For "Image" buttons, a primary and secondary image create a layered effect. None of the text fields are used when "Image" is selected.</p> 
         </div>
         <div class="col-span-1">


### PR DESCRIPTION
## Reason for change

This fixes the under-menu buttons move to page content on a small screen bug. 

In addition to the fix, this allows the under-menu buttons placement to be adjustable. An ID `#mobile-cta-buttons` can be placed anywhere on the page to have the buttons injected right after that element. 

This is manual at the moment, but can be integrated into a CMS button once most sites have this functionality. 

## Relevant links

- Preview: https://base.wayne.localhost/styleguide/component/buttons

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After | Middle of page |
|--------|--------|--------|
| ![base-button-current](https://github.com/user-attachments/assets/edf30cea-1eed-4030-b03b-24cd52c1292b) | ![base-button-fixed](https://github.com/user-attachments/assets/a5820fc5-decb-40b7-8663-17598a89a94b) | <img width="515" alt="Screenshot 2025-04-21 at 6 19 03 AM" src="https://github.com/user-attachments/assets/844b8792-0261-44cd-986a-8f77e0b9f11d" /> |

