### PR TITLE
Feature | .env | All site-specific ENV values now moved to the top of the file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,23 @@
+# Site specific configuration
 APP_NAME=base
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_TIMEZONE=America/Detroit
 APP_LOG_LEVEL=debug
-APP_URL=http://base.wayne.localhost
+APP_URL=https://base.wayne.localhost
+REDIS_PREFIX=base:
 
+WSUAPI_KEY=
+WSUAPI_ENDPOINT=https://api.wayne.edu/v1/
+
+NEWS_API_KEY=
+NEWS_API_CACHE=../storage/app/newsapi/
+NEWS_API_ENDPOINT=https://news.wayne.edu/api/v1/
+
+TTL=0
+
+# Global Laravel configuration
+APP_TIMEZONE=America/Detroit
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
@@ -17,7 +29,8 @@ LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DAILY_DAYS=7
 
-CACHE_STORE=redis
+CACHE_DRIVER=redis
+CACHE_STORE="${CACHE_DRIVER}"
 
 SESSION_DRIVER=redis
 SESSION_LIFETIME=180
@@ -32,18 +45,7 @@ REDIS_HOST=localhost
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 REDIS_DB=1
-REDIS_PREFIX=base:
 
 QUEUE_CONNECTION=sync
 MAIL_MAILER=smtp
 
-WSUAPI_KEY=
-WSUAPI_ENDPOINT=
-
-NEWS_API_KEY=
-NEWS_API_CACHE=../storage/app/newsapi/
-
-PEOPLE_API_KEY=
-PEOPLE_API_CACHE=../storage/app/peopleapi/
-
-TTL=0


### PR DESCRIPTION
## Reason for change

Because Laravel 11 requires more items to be defined directly in the `.env` file, the file has a mixture of default values for Laravel and unique values to each site.

## This change

Moves all the items specific to the site up top and separates the default values below.

This will allow for quick scanning and customization of a site without having to sift through every field in the file.

## Result

No visible change, not value changes, only re-organization.

## Schedule

This is scheduled for the 8.15 release. Hold merging until 8.14 is complete.