### PR TITLE
Feature | Config | Allow local config override through .env values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ APP_TIMEZONE=America/Detroit
 APP_LOG_LEVEL=debug
 APP_URL=http://base.wayne.localhost
 
+CONFIG_OVERRIDE=
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -3,9 +3,15 @@
 use Symfony\Component\Process\Process;
 
 /**
+ * Pull in environment
+ */
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$dotenv->load();
+
+/**
  * Application name
  */
-$appname = ''; // domain
+$appname = env('APP_NAME');
 
 /**
  * Remote server connection string

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -96,3 +96,26 @@ function using_styleguide()
 {
     return (config('app.env') == 'testing' || (!empty($_SERVER['REQUEST_URI']) && substr($_SERVER['REQUEST_URI'], 0, 11) == '/styleguide'));
 }
+
+/**
+ * Recursively merge two arrays, with values from array2 replacing values from array1.
+ * Indexed arrays are completely replaced, while associative arrays are merged recursively.
+ *
+ * @param array $array1
+ * @param array $array2
+ * @return array
+ */
+function array_replace_recursive_distinct(array &$array1, array &$array2)
+{
+    $merged = $array1;
+
+    foreach ($array2 as $key => &$value) {
+        if (is_array($value) && isset($merged[$key]) && is_array($merged[$key]) && !array_is_list($merged[$key])) {
+            $merged[$key] = array_replace_recursive_distinct($merged[$key], $value);
+        } else {
+            $merged[$key] = $value;
+        }
+    }
+
+    return $merged;
+}

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,9 @@
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi",
+            "@php artisan package:discover --ansi"
+        ],
+        "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ]
     },

--- a/config/base.php
+++ b/config/base.php
@@ -3,7 +3,7 @@
 use App\Http\Controllers\ArticleController;
 use App\Http\Controllers\TopicController;
 
-return [
+$global_config = [
 
     /*
     |--------------------------------------------------------------------------
@@ -252,23 +252,23 @@ return [
         'all' => [
             'promos' => [
                 'main_contact' => [
-                    'id' => 2908,
+                    'id' => null,
                     'config' => 'limit:4',
                 ],
                 'main_social' => [
-                    'id' => 2907,
+                    'id' => null,
                     'config' => null,
                 ],
                 'main_under_menu' => [
-                    'id' => 2909,
+                    'id' => null,
                     'config' => 'page_id:{$page_id}',
                 ],
                 'hero' => [
-                    'id' => 3001,
+                    'id' => null,
                     'config' => 'page_id:{$page_id}|randomize|limit:1',
                 ],
                 'flag' => [
-                    'id' => 4246,
+                    'id' => null,
                     'config' => 'page_id:{$page_id}|first',
                 ],
             ],
@@ -301,3 +301,11 @@ return [
         ],
     ],
 ];
+
+// Override any config with local file
+if (!empty(getenv('CONFIG_OVERRIDE')) && file_exists(__DIR__ . '/' . getenv('CONFIG_OVERRIDE'))) {
+    $local_config = include(__DIR__ . '/' . getenv('CONFIG_OVERRIDE'));
+    return array_replace_recursive_distinct($global_config, $local_config);
+}
+
+return $global_config;

--- a/tests/Unit/Support/BaseConfigTest.php
+++ b/tests/Unit/Support/BaseConfigTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BaseConfigTest extends TestCase
+{
+    private string $configPath;
+    private string $testOverrideFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->configPath = config_path();
+        $this->testOverrideFile = 'test-override.php';
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up test files
+        if (File::exists($this->configPath . '/' . $this->testOverrideFile)) {
+            File::delete($this->configPath . '/' . $this->testOverrideFile);
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_returns_global_config_when_no_override_is_set(): void
+    {
+        // Ensure CONFIG_OVERRIDE is not set
+        config(['app.env' => 'testing']);
+        putenv('CONFIG_OVERRIDE=');
+
+        $config = include config_path('base.php');
+
+        $this->assertIsArray($config);
+        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
+        $this->assertEquals('main', $config['layout']);
+        $this->assertFalse($config['top_menu_enabled']);
+    }
+
+    #[Test]
+    public function config_returns_global_config_when_override_file_does_not_exist(): void
+    {
+        // Set CONFIG_OVERRIDE to non-existent file
+        putenv('CONFIG_OVERRIDE=non-existent-file.php');
+
+        $config = include config_path('base.php');
+
+        $this->assertIsArray($config);
+        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
+        $this->assertEquals('main', $config['layout']);
+    }
+
+    #[Test]
+    public function config_merges_override_file_when_it_exists(): void
+    {
+        // Create a test override file
+        $overrideContent = '<?php
+return [
+    "gtm_code" => "GTM-OVERRIDE",
+    "layout" => "custom",
+    "top_menu_enabled" => true,
+    "new_config_key" => "test_value",
+];';
+
+        File::put($this->configPath . '/' . $this->testOverrideFile, $overrideContent);
+
+        // Set CONFIG_OVERRIDE environment variable
+        putenv('CONFIG_OVERRIDE=' . $this->testOverrideFile);
+
+        $config = include config_path('base.php');
+
+        $this->assertIsArray($config);
+        $this->assertEquals('GTM-OVERRIDE', $config['gtm_code']);
+        $this->assertEquals('custom', $config['layout']);
+        $this->assertTrue($config['top_menu_enabled']);
+        $this->assertEquals('test_value', $config['new_config_key']);
+
+        // Ensure non-overridden values remain
+        $this->assertEquals('@waynestate', $config['twitter_handle']);
+    }
+
+    #[Test]
+    public function config_recursively_merges_nested_arrays(): void
+    {
+        // Create override file with nested array modifications
+        $overrideContent = '<?php
+return [
+    "hero_full_controllers" => [
+        "HomepageController",
+        "CustomController"
+    ],
+    "global" => [
+        "all" => [
+            "promos" => [
+                "main_contact" => [
+                    "id" => 123,
+                    "config" => "limit:2",
+                ],
+                "custom_promo" => [
+                    "id" => 456,
+                    "config" => "test",
+                ],
+            ],
+        ],
+        "sites" => [
+            1 => [
+                "promos" => [
+                    "contact" => [
+                        "id" => 789,
+                    ],
+                ],
+            ],
+        ],
+    ],
+];';
+
+        File::put($this->configPath . '/' . $this->testOverrideFile, $overrideContent);
+        putenv('CONFIG_OVERRIDE=' . $this->testOverrideFile);
+
+        $config = include config_path('base.php');
+
+        // Check that nested arrays are properly merged
+        $this->assertEquals(['HomepageController', 'CustomController'], $config['hero_full_controllers']);
+        $this->assertEquals(123, $config['global']['all']['promos']['main_contact']['id']);
+        $this->assertEquals('limit:2', $config['global']['all']['promos']['main_contact']['config']);
+        $this->assertEquals(456, $config['global']['all']['promos']['custom_promo']['id']);
+        $this->assertEquals(789, $config['global']['sites'][1]['promos']['contact']['id']);
+
+        // Ensure other nested values are preserved
+        $this->assertNotNull($config['global']['all']['promos']['main_social']);
+        $this->assertNotNull($config['global']['all']['callbacks']);
+    }
+
+    #[Test]
+    public function config_handles_empty_override_file(): void
+    {
+        // Create empty override file
+        $overrideContent = '<?php
+return [];';
+
+        File::put($this->configPath . '/' . $this->testOverrideFile, $overrideContent);
+        putenv('CONFIG_OVERRIDE=' . $this->testOverrideFile);
+
+        $config = include config_path('base.php');
+
+        // Should return the global config unchanged
+        $this->assertIsArray($config);
+        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
+        $this->assertEquals('main', $config['layout']);
+    }
+
+    #[Test]
+    public function config_override_completely_replaces_array_values(): void
+    {
+        // Test that array values are completely replaced, not merged
+        $overrideContent = '<?php
+return [
+    "hero_full_controllers" => [
+        "OnlyCustomController"
+    ],
+];';
+
+        File::put($this->configPath . '/' . $this->testOverrideFile, $overrideContent);
+        putenv('CONFIG_OVERRIDE=' . $this->testOverrideFile);
+
+        $config = include config_path('base.php');
+
+        // The original array should be completely replaced
+        $this->assertEquals(['OnlyCustomController'], $config['hero_full_controllers']);
+        $this->assertNotContains('HomepageController', $config['hero_full_controllers']);
+        $this->assertNotContains('FullWidthController', $config['hero_full_controllers']);
+    }
+}


### PR DESCRIPTION
Bringing the ability to define site config values from a local file.

This allows the same code to be deployed to multiple sites where only the configuration values are different. Since the config file is a nested set of complex key => values, creating `.env` values for every one of them is not possible.

A new `CONFIG_OVERRIDE` field is defined in the `.env` file, which points to a file to replace any `config()` value. Because the config is cached after deploy, this update does not impact performance.

## Example override

```
# .env

APP_URL=https://somesite.wayne.localhost
CONFIG_OVERRIDE=/directory/to/override.config.php
APP_LOCALE=en
```

```
# override.config.php

<?php
return [
    "gtm_code" => "GTM-OVERRIDE",
    "layout" => "custom",
    "top_menu_enabled" => true,
    "new_config_key" => "test_value",
];
```


| Before                                                                                            | After                                                                                                                                    |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| ...<br>"gtm_code" => "GTM-NCBVKQ2",<br>"layout" => "main",<br>"top_menu_enabled" => false,<br>... | ...<br>"gtm_code" => "GTM-OVERRIDE",<br>"layout" => "custom",<br>"top_menu_enabled" => true,<br>"new_config_key" => "test_value",<br>... |

## Custom replacement function

A custom recursive replacement function was required to allow for non-associative arrays to be replaced wholesale. Alternatively, the native `array_replace_recursive()` function would only replace individual items from the original array with their indexed numbered counterparts from the new array.

## Cleanup

- This also cleans up when the `.env` file is copied from the `.env.example` to ensure it only happens on initial composer install
- The `APP_NAME` is used in the deployment to allow the deploy paths to be relative to the config values
- The hardcoded ID's are now removed from the promotion configuration