### PR TITLE
Fix | Code style | Replaced ternary operators in blade templates

### DIFF
--- a/resources/views/components/hero/half.blade.php
+++ b/resources/views/components/hero/half.blade.php
@@ -19,7 +19,7 @@
             <div class="hero__description text-lg 3xl:text-xl text-green-700 content">
                 @if(!empty($hero['description']))
                     @if(!empty($hero['link']))
-                        {!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $hero['description']) !!}
+                        {!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $hero['description']) !!}
                     @else
                         {!! $hero['description'] !!}
                     @endif

--- a/resources/views/components/hero/text-overlay.blade.php
+++ b/resources/views/components/hero/text-overlay.blade.php
@@ -6,20 +6,28 @@
     <div class="hero__primary-image aspect-hero max-h-hero w-full bg-cover bg-center relative{{ $loop->first !== true ? ' lazy' : '' }}" @if($loop->first === true) style="background-image: url('{{ $hero['relative_url'] }}')" @else data-src="{{ $hero['relative_url'] }}"@endif></div>
     <div class="hero__content-position relative lg:absolute print:relative p-6 lg:p-0 lg:bottom-0 lg:inset-x-0 lg:bg-gradient-darkest lg:pt-20">
         <div class="row">
-            <{{ !empty($hero['link']) ? 'a href='.$hero['link'] : 'div' }} class="hero__content relative block {{ !empty($hero['link']) ? 'group no-underline ' : '' }} p-4 lg:pb-2 pl-6 lg:pl-4 pb-8 border-l-12 border-gold border-solid lg:border-0 text-green-900 lg:text-white lg:white-links">
+            @if (!empty($hero['link']))
+                <a href="{{ $hero['link'] }}" class="hero__content relative block group no-underline p-4 lg:pb-2 pl-6 lg:pl-4 pb-8 border-l-12 border-gold border-solid lg:border-0 text-green-900 lg:text-white lg:white-links">
+            @else
+                <div class="hero__content relative block p-4 lg:pb-2 pl-6 lg:pl-4 pb-8 border-l-12 border-gold border-solid lg:border-0 text-green-900 lg:text-white lg:white-links">
+            @endif
                 <div class="hero__title lg:drop-shadow-px leading-tight mt-4 text-3xl mb-4 lg:text-5xl group-hover:underline">
                     {!! strip_tags($hero['title'], ['em', 'strong']) !!}
                 </div>
                 @if(!empty($hero['description']))
                     <div class="hero__description text-lg content -mt-2">
                         @if(!empty($hero['link']))
-                            {!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $hero['description']) !!}
+                            {!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $hero['description']) !!}
                         @else
                             {!! $hero['description'] !!}
                         @endif
                     </div>
                 @endif
-            {!! !empty($hero['link']) ? '</a>' : '</div>' !!}
+            @if (!empty($hero['link']))
+                </a>
+            @else
+                </div>
+            @endif
             <div class="relative px-4 -mt-4 mb-4">
                 @yield('hero-buttons')
             </div>

--- a/resources/views/components/icons-column.blade.php
+++ b/resources/views/components/icons-column.blade.php
@@ -4,16 +4,28 @@
 <ul class="grid grid-cols-1 items-start gap-6 lg:gap-8 mt-2 mb-8 lg:my-8">
     @foreach($data as $item)
         <li>
-            <{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="flex items-start gap-x-4 {{ !empty($item['link']) ? 'group' : '' }}">
+            @if (!empty($item['link']))
+                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group">
+            @else
+                <div class="flex items-start gap-x-4">
+            @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'grow-0 shrink-0 w-16')
                 <div>
                     <div class="font-bold text-xl mt-0 mb-1 text-green no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
-                        <div class="text-sm text-black">{!! !empty($item['link']) ? preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) : $item['description'] !!}</div>
+                        @if (!empty($item['link']))
+                            <div class="text-sm text-black">{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>
+                        @else
+                            <div class="text-sm text-black">{!! $item['description'] !!}</div>
+                        @endif
                     @endif
                 </div>
-            <{{ !empty($item['link']) ? '/a' : '/div' }}>
+            @if (!empty($item['link']))
+                </a>
+            @else
+                </div>
+            @endif
         </li>
     @endforeach
 </ul>

--- a/resources/views/components/icons-row.blade.php
+++ b/resources/views/components/icons-row.blade.php
@@ -4,16 +4,28 @@
 <ul class="grid items-start gap-6 lg:gap-8 mt-2 mb-8 lg:my-8 md:grid-cols-2 lg:grid-cols-{{ !empty($component['columns']) && $component['columns'] >= 3 ? '3' : '2' }} xl:grid-cols-{{ !empty($component['columns']) ? $component['columns'] : '2' }}">
     @foreach($data as $item)
         <li>
-            <{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="flex items-start gap-x-4 {{ !empty($item['link']) ? 'group' : '' }}">
+            @if (!empty($item['link']))
+                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group">
+            @else
+                <div class="flex items-start gap-x-4">
+            @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'grow-0 shrink-0 w-16 '.(!empty($component['columns']) && $component['columns'] >= 3 ? ' xl:w-16' : ' xl:w-20'))
                 <div>
                     <div class="font-bold text-xl xl:text-2xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm lg:text-base text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
-                        <div class="text-sm xl:text-base text-black content">{!! !empty($item['link']) ? preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) : $item['description'] !!}</div>
+                        @if (!empty($item['link']))
+                            <div class="text-sm xl:text-base text-black content">{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>
+                        @else
+                            <div class="text-sm xl:text-base text-black content">{!! $item['description'] !!}</div>
+                        @endif
                     @endif
                 </div>
-            <{{ !empty($item['link']) ? '/a' : '/div' }}>
+            @if (!empty($item['link']))
+                </a>
+            @else
+                </div>
+            @endif
         </li>
     @endforeach
 </ul>

--- a/resources/views/components/icons-top-row.blade.php
+++ b/resources/views/components/icons-top-row.blade.php
@@ -4,16 +4,28 @@
 <ul class="grid items-start gap-6 gap-y-2 lg:gap-8 lg:gap-y-4 grid-cols-2 lg:grid-cols-{{ !empty($component['columns']) && count($data) % 2 == 0 ? '2' : '3' }} xl:grid-cols-{{ !empty($component['columns']) ? $component['columns'] : '2' }}">
     @foreach($data as $item)
         <li>
-            <{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="text-center {{ !empty($item['link']) ? ' group' : '' }}">
+            @if (!empty($item['link']))
+                <a href="{{ $item['link'] }}" class="text-center group">
+            @else
+                <div class="text-center">
+            @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'block mx-auto grow-0 shrink-0 mb-2 w-16'.(!empty($component['columns']) && $component['columns'] >= 5 ? ' xl:w-16' : ' xl:w-20'))
                 <div>
                     <div class="font-bold text-xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
-                        <div class="text-sm text-black content">{!! !empty($item['link']) ? preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) : $item['description'] !!}</div>
+                        @if (!empty($item['link']))
+                            <div class="text-sm text-black content">{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>
+                        @else
+                            <div class="text-sm text-black content">{!! $item['description'] !!}</div>
+                        @endif
                     @endif
                 </div>
-            <{{ !empty($item['link']) ? '/a' : '/div' }}>
+            @if (!empty($item['link']))
+                </a>
+            @else
+                </div>
+            @endif
         </li>
     @endforeach
 </ul>

--- a/resources/views/components/promo/grid-item.blade.php
+++ b/resources/views/components/promo/grid-item.blade.php
@@ -3,7 +3,11 @@
     $item => array // ['title', 'link', 'description', 'excerpt', 'relative_url', 'option']
 --}}
 
-<{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} {{ !empty($item['link']) ? 'group' : '' }} {{ $loop->last != true && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6 mb-8' : '' }}">
+@if (!empty($item['link']))
+    <a href="{{ $item['link'] }}" class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} group {{ $loop->last != true && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6 mb-8' : '' }}">
+@else
+    <div class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} {{ $loop->last != true && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6 mb-8' : '' }}">
+@endif
     <div class="{{ !empty($component['gradientOverlay']) ? '' : 'mb-2' }}">
         @if(!empty($item['youtube_id']))
             <div class="play-video-button">
@@ -31,7 +35,7 @@
                 @if(!empty($item['excerpt']))<p class="my-1">{!! strip_tags($item['excerpt'], ['em', 'strong']) !!}</p>@endif 
                 @if(!empty($item['description']))
                     @if (!empty($item['link']))
-                        <div>{!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) !!}</div>
+                        <div>{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>
                     @else
                         <div>{!! $item['description'] !!}</div>
                     @endif
@@ -39,4 +43,8 @@
             </div>
         </div>
     </div>
-{!! !empty($item['link']) ? '</a>' : '</div>' !!}
+@if (!empty($item['link']))
+    </a>
+@else
+    </div>
+@endif

--- a/resources/views/components/promo/list-item.blade.php
+++ b/resources/views/components/promo/list-item.blade.php
@@ -3,7 +3,11 @@
     $item => array // ['title', 'link', 'description', 'excerpt', 'relative_url', 'option']
 --}}
 
-<{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 {{ !empty($item['link']) ? 'group' : '' }} {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}">
+@if (!empty($item['link']))
+    <a href="{{ $item['link'] }}" class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 group {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}">
+@else
+    <div class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}">
+@endif
     @if(!empty($item['youtube_id']) || !empty($item['relative_url']))
         <div class="shrink-0 grow-0 {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'w-1/4' : 'md:w-2/5' }}  
             @if(!empty($component['imagePosition']) && ($component['imagePosition'] === 'right' || ($component['imagePosition'] === 'alternate' && $loop->even))) md:order-2 @endif">
@@ -31,11 +35,15 @@
             @if(!empty($item['excerpt']))<p class="my-1">{!! strip_tags($item['excerpt'], ['em', 'strong']) !!}</p>@endif 
             @if(!empty($item['description']))
                 @if (!empty($item['link']))
-                    <div>{!! preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) !!}</div>
+                    <div>{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>
                 @else
                     <div>{!! $item['description'] !!}</div>
                 @endif
             @endif
         </div>
     </div>
-{!! !empty($item['link']) ? '</a>' : '</div>' !!}
+@if (!empty($item['link']))
+    </a>
+@else
+    </div>
+@endif

--- a/resources/views/components/spotlight-column.blade.php
+++ b/resources/views/components/spotlight-column.blade.php
@@ -2,12 +2,20 @@
     $data => array // ['title', 'excerpt', 'description', 'relative_url', 'filename_alt_text', 'link']
 --}}
 @foreach($data as $item)
-    <{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="{{ !empty($item['link']) ? 'group' : '' }}">
+    @if (!empty($item['link']))
+        <a href="{{ $item['link'] }}" class="group">
+    @else
+        <div>
+    @endif
         <blockquote class="border-0 m-0 p-0">
             <div class="flex flex-wrap content-center w-full">
                 <div class="content w-full text-black text-lg md:text-xl lg:leading-relaxed mb-4">
                     @if(!empty($item['description']) && !empty($component['showDescription']) && $component['showDescription'] === true)
-                        {!! (!empty($item['link']) ? preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) : $item['description']) !!}
+                        @if (!empty($item['link']))
+                            {!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}
+                        @else
+                            {!! $item['description'] !!}
+                        @endif
                     @else
                         @if(!empty($item['excerpt']))<p>{!! strip_tags($item['excerpt'], ['em', 'strong', 'br', '&ldquo;', '&rdquo;']) !!}</p>@endif
                     @endif
@@ -25,5 +33,9 @@
                 </div>
             </div>
         </blockquote>
-    <{{ !empty($item['link']) ? '/a' : '/div' }}>
+    @if (!empty($item['link']))
+        </a>
+    @else
+        </div>
+    @endif
 @endforeach

--- a/resources/views/components/spotlight-row.blade.php
+++ b/resources/views/components/spotlight-row.blade.php
@@ -2,12 +2,20 @@
     $data => array // ['title', 'excerpt', 'description', 'relative_url', 'filename_alt_text', 'link']
 --}}
 @foreach($data as $item)
-    <{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="{{ !empty($item['link']) ? 'group' : '' }}">
+    @if (!empty($item['link']))
+        <a href="{{ $item['link'] }}" class="group">
+    @else
+        <div>
+    @endif
         <blockquote class="flex gap-x-6 border-0 m-0 p-0 relative">
             <div class="flex flex-wrap content-center w-full">
                 <div class="content text-black w-full text-lg md:text-xl lg:leading-relaxed mb-4">
                     @if(!empty($item['description']) && !empty($component['showDescription']) && $component['showDescription'] === true)
-                        {!! (!empty($item['link']) ? preg_replace(array('"<a href(.*?)>"', '"</a>"'), array('',''), $item['description']) : $item['description']) !!}
+                        @if (!empty($item['link']))
+                            {!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}
+                        @else
+                            {!! $item['description'] !!}
+                        @endif
                     @else
                         @if(!empty($item['excerpt']))<p>{!! strip_tags($item['excerpt'], ['em', 'strong', 'br', '&ldquo;', '&rdquo;']) !!}</p>@endif
                     @endif
@@ -29,7 +37,11 @@
                 <div class="w-full pt-full">{{-- Absolutely positioned image placeholder --}}</div>
             </div>
         </blockquote>
-    <{{ !empty($item['link']) ? '/a' : '/div' }}>
+    @if (!empty($item['link']))
+        </a>
+    @else
+        </div>
+    @endif
     @if(!$loop->last)
         <hr class="mb-6" />
     @endif

--- a/resources/views/partials/heading.blade.php
+++ b/resources/views/partials/heading.blade.php
@@ -3,6 +3,12 @@
     "headingLevel":["h2", "h3", "h4"],
     "headingClass":"text-green divider-gold"
 --}}
-<{{ !empty($headingLevel) && strtolower($headingLevel) != 'h1' ? $headingLevel : 'h2' }} id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
-    {!! strip_tags($heading, ['em', 'strong']) !!}
-</{{ !empty($headingLevel) && strtolower($headingLevel) != 'h1' ? $headingLevel : 'h2' }}>
+@if (!empty($headingLevel) && strtolower($headingLevel) != 'h1')
+    <{{ $headingLevel }} id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
+        {!! strip_tags($heading, ['em', 'strong']) !!}
+    </{{ $headingLevel }}>
+@else
+    <h2 id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
+        {!! strip_tags($heading, ['em', 'strong']) !!}
+    </h2>
+@endif


### PR DESCRIPTION
## Reason for change

Consistency throughout the code.

```
<{{ !empty($item['link']) ? 'a href='.$item['link'] : 'div' }} class="{{ !empty($item['link']) ? 'group' : '' }}">
```
vs
```
@if (!empty($item['link']))  
  <a href="{{ $item['link'] }}" class="group">  
@else  
  <div>  
@endif
 ```

The second is preferred. It is easier to read and ensures HTML cannot be injected into the element. It is also consistent with the other conditionals thoughout the code.

## Changes 

- Replaced ternary operators in the middle of tags with expanded conditionals
- Updated the older array() style in blade templates

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

_No visual changes_