### PR TITLE
Feature | Profiles | Hide dropdown options if only one group is available

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -14,6 +14,9 @@ use Illuminate\Http\Request;
 
 class ProfileController extends Controller
 {
+    /** @var ProfileRepositoryContract */
+    protected $profile;
+
     /**
      * Construct the controller.
      */
@@ -42,14 +45,14 @@ class ProfileController extends Controller
         // Set the selected group
         $selected_group = $request->query('group') !== '' ? $request->query('group') : null;
 
-        // Get the options for the dropdown
-        $dropdown_group_options = $this->profile->getDropdownOptions($selected_group, $forced_profile_group_id);
-
         // Determine which group(s) to filter by
         $group_ids = $this->profile->getGroupIds($selected_group, $forced_profile_group_id, $dropdown_groups['dropdown_groups']);
 
         // Get the profiles
         $profiles = $this->profile->getProfiles($site_id, $group_ids);
+
+        // Get the options for the dropdown (pass profiles to determine if filtering should be hidden)
+        $dropdown_group_options = $this->profile->getDropdownOptions($selected_group, $forced_profile_group_id, $profiles);
 
         // Disable hero images
         $request->data['base']['hero'] = false;

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -23,6 +23,9 @@ class ProfileRepository implements ProfileRepositoryContract
     /** @var Repository */
     protected $cache;
 
+    /** @var News */
+    protected $newsApi;
+
     /**
      * Construct the repository.
      */
@@ -147,7 +150,7 @@ class ProfileRepository implements ProfileRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getDropdownOptions($selected_group = null, $forced_profile_group_id = null)
+    public function getDropdownOptions($selected_group = null, $forced_profile_group_id = null, $profiles = [])
     {
         // Default Options
         $options['selected_group'] = $selected_group;
@@ -157,6 +160,14 @@ class ProfileRepository implements ProfileRepositoryContract
         if ($forced_profile_group_id !== null) {
             $options['selected_group'] = $forced_profile_group_id;
             $options['hide_filtering'] = true;
+        }
+
+        // Hide filtering if all profiles belong to the same group
+        if (!$options['hide_filtering'] && !empty($profiles['profiles'])) {
+            $unique_groups = $this->getUniqueGroupsFromProfiles($profiles['profiles']);
+            if (count($unique_groups) <= 1) {
+                $options['hide_filtering'] = true;
+            }
         }
 
         return $options;
@@ -422,5 +433,25 @@ class ProfileRepository implements ProfileRepositoryContract
         if (!empty($data['data']['table_of_contents']) && empty($profile_config['table_of_contents'])) {
             Config::set('profile.table_of_contents', $data['data']['table_of_contents']);
         }
+    }
+
+    /**
+     * Get unique groups from a collection of profiles.
+     *
+     * @param array $profiles
+     * @return array
+     */
+    protected function getUniqueGroupsFromProfiles(array $profiles): array
+    {
+        return collect($profiles)
+            ->filter(function ($profile) {
+                return !empty($profile['groups']) && is_array($profile['groups']);
+            })
+            ->flatMap(function ($profile) {
+                return array_values($profile['groups']);
+            })
+            ->unique()
+            ->values()
+            ->toArray();
     }
 }

--- a/contracts/Repositories/ProfileRepositoryContract.php
+++ b/contracts/Repositories/ProfileRepositoryContract.php
@@ -27,9 +27,10 @@ interface ProfileRepositoryContract
      *
      * @param int|null $selected_group
      * @param int|null $forced_profile_group_id
+     * @param array $profiles
      * @return array
      */
-    public function getDropdownOptions($selected_group, $forced_profile_group_id);
+    public function getDropdownOptions($selected_group, $forced_profile_group_id, $profiles = []);
 
     /**
      * Get the dropdown of groups.
@@ -98,4 +99,14 @@ interface ProfileRepositoryContract
      * @param array $data
      */
     public function parseProfileConfig(array $data): void;
+
+    /**
+     * Get the group IDs to filter by.
+     *
+     * @param string|null $selected_group
+     * @param string|null $forced_profile_group_id
+     * @param array $dropdown_groups
+     * @return string
+     */
+    public function getGroupIds($selected_group, $forced_profile_group_id, $dropdown_groups);
 }

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -458,4 +458,104 @@ final class ProfileRepositoryTest extends TestCase
         $this->assertEquals($site_id, config('profile.site_id'));
         $this->assertEquals($group_id, config('profile.group_id'));
     }
+
+    #[Test]
+    public function getting_dropdown_options_should_hide_filtering_when_all_profiles_in_same_group(): void
+    {
+        // Test with profiles all in the same group
+        $profiles_same_group = [
+            'profiles' => [
+                ['groups' => ['1' => 'Engineering']],
+                ['groups' => ['1' => 'Engineering']],
+                ['groups' => ['1' => 'Engineering']],
+            ],
+        ];
+
+        $options = app(ProfileRepository::class)->getDropdownOptions(null, null, $profiles_same_group);
+        $this->assertEquals(['selected_group' => null, 'hide_filtering' => true], $options);
+
+        // Test with profiles in multiple groups
+        $profiles_multiple_groups = [
+            'profiles' => [
+                ['groups' => ['1' => 'Engineering']],
+                ['groups' => ['2' => 'Business']],
+                ['groups' => ['1' => 'Engineering']],
+            ],
+        ];
+
+        $options = app(ProfileRepository::class)->getDropdownOptions(null, null, $profiles_multiple_groups);
+        $this->assertEquals(['selected_group' => null, 'hide_filtering' => false], $options);
+
+        // Test with empty profiles array
+        $profiles_empty = ['profiles' => []];
+        $options = app(ProfileRepository::class)->getDropdownOptions(null, null, $profiles_empty);
+        $this->assertEquals(['selected_group' => null, 'hide_filtering' => false], $options);
+
+        // Test with profiles that have no groups
+        $profiles_no_groups = [
+            'profiles' => [
+                ['data' => ['name' => 'John Doe']],
+                ['groups' => []],
+            ],
+        ];
+
+        $options = app(ProfileRepository::class)->getDropdownOptions(null, null, $profiles_no_groups);
+        $this->assertEquals(['selected_group' => null, 'hide_filtering' => true], $options);
+
+        // Test that forced group ID still takes precedence
+        $random_group_id = $this->faker->numberBetween(1, 9);
+        $options = app(ProfileRepository::class)->getDropdownOptions(null, $random_group_id, $profiles_multiple_groups);
+        $this->assertEquals(['selected_group' => $random_group_id, 'hide_filtering' => true], $options);
+    }
+
+    #[Test]
+    public function getting_unique_groups_from_profiles_should_return_unique_group_names(): void
+    {
+        $repository = app(ProfileRepository::class);
+
+        // Test with profiles having multiple groups
+        $profiles_multiple_groups = [
+            ['groups' => ['1' => 'Engineering', '2' => 'Computer Science']],
+            ['groups' => ['2' => 'Computer Science', '3' => 'Mathematics']],
+            ['groups' => ['1' => 'Engineering']],
+        ];
+
+        // Use reflection to access the protected method
+        $reflection = new \ReflectionClass($repository);
+        $method = $reflection->getMethod('getUniqueGroupsFromProfiles');
+        $method->setAccessible(true);
+
+        $unique_groups = $method->invokeArgs($repository, [$profiles_multiple_groups]);
+        $expected = ['Engineering', 'Computer Science', 'Mathematics'];
+
+        $this->assertCount(3, $unique_groups);
+        $this->assertEquals($expected, array_values($unique_groups));
+
+        // Test with profiles all in same group
+        $profiles_same_group = [
+            ['groups' => ['1' => 'Engineering']],
+            ['groups' => ['1' => 'Engineering']],
+            ['groups' => ['1' => 'Engineering']],
+        ];
+
+        $unique_groups = $method->invokeArgs($repository, [$profiles_same_group]);
+        $this->assertCount(1, $unique_groups);
+        $this->assertEquals(['Engineering'], $unique_groups);
+
+        // Test with profiles having no groups or invalid groups
+        $profiles_no_groups = [
+            ['data' => ['name' => 'John Doe']],
+            ['groups' => []],
+            ['groups' => null],
+        ];
+
+        $unique_groups = $method->invokeArgs($repository, [$profiles_no_groups]);
+        $this->assertCount(0, $unique_groups);
+        $this->assertEquals([], $unique_groups);
+
+        // Test with empty profiles array
+        $unique_groups = $method->invokeArgs($repository, [[]]);
+        $this->assertCount(0, $unique_groups);
+        $this->assertEquals([], $unique_groups);
+    }
 }


### PR DESCRIPTION
## Reason for change

Profile listing with a single group do not need to show the dropdown. Changing the selection will not change the content on the page.

This removes the dropdown if all profiles on the page are in the same group.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Before | After |
|--------|------|
| <img width="667" alt="Screenshot 2025-06-25 at 8 55 29 AM" src="https://github.com/user-attachments/assets/1df8a1be-a3c7-471e-81ac-94cf2efdb4dd" /> | <img width="693" alt="Screenshot 2025-06-25 at 8 55 56 AM" src="https://github.com/user-attachments/assets/b78ae969-4319-4f5e-98a7-883d92906909" /> |
