### PR TITLE
Fix | Styleguide accordions displaying configuration data again

### DIFF
--- a/resources/views/components/accordion-styleguide.blade.php
+++ b/resources/views/components/accordion-styleguide.blade.php
@@ -9,7 +9,7 @@
                 {!! $item['description'] !!}
 
                 <table style="cell-padding: 5px;" class="mt-4 no-stripe">
-                    @if(Str::contains($item['promo_item_id'], 'component-config'))
+                    @if(Str::contains($item['promo_item_id'], 'component_config'))
                         <thead>
                             <tr>
                                 <th class="md:w-2/5">Page field</th>
@@ -28,7 +28,7 @@
                         </tbody>
                     @endif
 
-                    @if($item['promo_item_id'] === 'promo-details')
+                    @if($item['promo_item_id'] === 'promo_details')
                         <thead>
                             <tr>
                                 <th colspan="2">Available fields</th>

--- a/resources/views/components/accordion-styleguide.blade.php
+++ b/resources/views/components/accordion-styleguide.blade.php
@@ -8,7 +8,7 @@
             <div class="content">
                 {!! $item['description'] !!}
 
-                <table style="cell-padding: 5px;" class="mt-4 {{ Str::contains($item['promo_item_id'], 'component-config') ? 'no-stripe' : '' }}">
+                <table style="cell-padding: 5px;" class="mt-4 no-stripe">
                     @if(Str::contains($item['promo_item_id'], 'component-config'))
                         <thead>
                             <tr>

--- a/styleguide/Http/Controllers/ComponentAccordionController.php
+++ b/styleguide/Http/Controllers/ComponentAccordionController.php
@@ -32,7 +32,7 @@ class ComponentAccordionController extends Controller
             'accordion' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'title' => 'Component configuration',
                         'description' => '',
                         'tr1' => [
@@ -44,7 +44,7 @@ class ComponentAccordionController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'title' => 'Promo group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentAccordionController.php
+++ b/styleguide/Http/Controllers/ComponentAccordionController.php
@@ -32,7 +32,7 @@ class ComponentAccordionController extends Controller
             'accordion' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'title' => 'Component configuration',
                         'description' => '',
                         'tr1' => [
@@ -44,7 +44,7 @@ class ComponentAccordionController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'title' => 'Promo group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentButtonsController.php
+++ b/styleguide/Http/Controllers/ComponentButtonsController.php
@@ -105,7 +105,7 @@ class ComponentButtonsController extends Controller
             'accordion' => [
                 'data' => [
                     2 => [
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'title' => 'Component configuration',
                         'description' => '',
                         'tr1' => [
@@ -127,7 +127,7 @@ class ComponentButtonsController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'title' => 'Promotion group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentButtonsController.php
+++ b/styleguide/Http/Controllers/ComponentButtonsController.php
@@ -105,7 +105,7 @@ class ComponentButtonsController extends Controller
             'accordion' => [
                 'data' => [
                     2 => [
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'title' => 'Component configuration',
                         'description' => '',
                         'tr1' => [
@@ -127,7 +127,7 @@ class ComponentButtonsController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'title' => 'Promotion group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentCatalogController.php
+++ b/styleguide/Http/Controllers/ComponentCatalogController.php
@@ -37,7 +37,7 @@ class ComponentCatalogController extends Controller
             'accordion' => [
                 'data' => [
                     2 => [
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'title' => 'Component configuration',
                         'description' => '<p>Image size can only be used with a one-column catalog.</p>',
                         'tr1' => [
@@ -57,7 +57,7 @@ class ComponentCatalogController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'title' => 'Promotion group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentCatalogController.php
+++ b/styleguide/Http/Controllers/ComponentCatalogController.php
@@ -37,7 +37,7 @@ class ComponentCatalogController extends Controller
             'accordion' => [
                 'data' => [
                     2 => [
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'title' => 'Component configuration',
                         'description' => '<p>Image size can only be used with a one-column catalog.</p>',
                         'tr1' => [
@@ -57,7 +57,7 @@ class ComponentCatalogController extends Controller
                         ],
                     ],
                     1 => [
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'title' => 'Promotion group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentEventListingController.php
+++ b/styleguide/Http/Controllers/ComponentEventListingController.php
@@ -35,7 +35,7 @@ class ComponentEventListingController extends Controller
             'accordion-1' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'title' => 'Component configuration',
                         'description' => '
 <table>

--- a/styleguide/Http/Controllers/ComponentEventListingController.php
+++ b/styleguide/Http/Controllers/ComponentEventListingController.php
@@ -35,7 +35,7 @@ class ComponentEventListingController extends Controller
             'accordion-1' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'title' => 'Component configuration',
                         'description' => '
 <table>

--- a/styleguide/Http/Controllers/ComponentFlagController.php
+++ b/styleguide/Http/Controllers/ComponentFlagController.php
@@ -32,7 +32,7 @@ class ComponentFlagController extends Controller
             'accordion' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'title' => 'Promo group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentFlagController.php
+++ b/styleguide/Http/Controllers/ComponentFlagController.php
@@ -32,7 +32,7 @@ class ComponentFlagController extends Controller
             'accordion' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'title' => 'Promo group details',
                         'description' => '',
                         'table' => [

--- a/styleguide/Http/Controllers/ComponentHeadingController.php
+++ b/styleguide/Http/Controllers/ComponentHeadingController.php
@@ -34,7 +34,7 @@ class ComponentHeadingController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-heading-1',

--- a/styleguide/Http/Controllers/ComponentHeadingController.php
+++ b/styleguide/Http/Controllers/ComponentHeadingController.php
@@ -34,7 +34,7 @@ class ComponentHeadingController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-heading-1',

--- a/styleguide/Http/Controllers/ComponentHeroController.php
+++ b/styleguide/Http/Controllers/ComponentHeroController.php
@@ -31,7 +31,7 @@ class ComponentHeroController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'description' => '<p>Note: Any limit above 1 will enable the carousel.</p>',
                         'tr1' => [
                             'Page field' => 'modular-hero-1',
@@ -43,7 +43,7 @@ class ComponentHeroController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Displayed using options "Text overlay," "Logo overlay" and will become a link if link field is used.',

--- a/styleguide/Http/Controllers/ComponentHeroController.php
+++ b/styleguide/Http/Controllers/ComponentHeroController.php
@@ -31,7 +31,7 @@ class ComponentHeroController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '<p>Note: Any limit above 1 will enable the carousel.</p>',
                         'tr1' => [
                             'Page field' => 'modular-hero-1',
@@ -43,7 +43,7 @@ class ComponentHeroController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Displayed using options "Text overlay," "Logo overlay" and will become a link if link field is used.',

--- a/styleguide/Http/Controllers/ComponentIconsController.php
+++ b/styleguide/Http/Controllers/ComponentIconsController.php
@@ -36,7 +36,7 @@ class ComponentIconsController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-icons-column-1',
@@ -65,7 +65,7 @@ class ComponentIconsController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Bold text.',

--- a/styleguide/Http/Controllers/ComponentIconsController.php
+++ b/styleguide/Http/Controllers/ComponentIconsController.php
@@ -36,7 +36,7 @@ class ComponentIconsController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-icons-column-1',
@@ -65,7 +65,7 @@ class ComponentIconsController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Bold text.',

--- a/styleguide/Http/Controllers/ComponentPageContentController.php
+++ b/styleguide/Http/Controllers/ComponentPageContentController.php
@@ -64,7 +64,7 @@ class ComponentPageContentController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component_config',
                         'description' => $component_configuration,
                     ],
                 ],

--- a/styleguide/Http/Controllers/ComponentSinglePromoController.php
+++ b/styleguide/Http/Controllers/ComponentSinglePromoController.php
@@ -34,7 +34,7 @@ class ComponentSinglePromoController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-promo-column-1',
@@ -63,7 +63,7 @@ class ComponentSinglePromoController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Bold text.',

--- a/styleguide/Http/Controllers/ComponentSinglePromoController.php
+++ b/styleguide/Http/Controllers/ComponentSinglePromoController.php
@@ -34,7 +34,7 @@ class ComponentSinglePromoController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-promo-column-1',
@@ -63,7 +63,7 @@ class ComponentSinglePromoController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Bold text.',

--- a/styleguide/Http/Controllers/ComponentSpotlightController.php
+++ b/styleguide/Http/Controllers/ComponentSpotlightController.php
@@ -36,7 +36,7 @@ class ComponentSpotlightController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-spotlight-column-1</pre><pre>modular-spotlight-row-1',
@@ -51,7 +51,7 @@ class ComponentSpotlightController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Displays as a cited name below the quote.',

--- a/styleguide/Http/Controllers/ComponentSpotlightController.php
+++ b/styleguide/Http/Controllers/ComponentSpotlightController.php
@@ -36,7 +36,7 @@ class ComponentSpotlightController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'componentConfiguration',
+                        'promo_item_id' => 'component-config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-spotlight-column-1</pre><pre>modular-spotlight-row-1',
@@ -51,7 +51,7 @@ class ComponentSpotlightController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promotionGroupDetails',
+                        'promo_item_id' => 'promo-details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Displays as a cited name below the quote.',


### PR DESCRIPTION
In an effort to keep our code style consistent, I updated the styleguide accordion variables to use snake case. This PR brings all of the styleguide controllers up to date so the configuration data displays once again. 

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/c215e73f-06d7-4685-a676-1cd53871b646" />
