### PR TITLE
Fix | Hero | Styleguide hero was overwritten by potential component hero

### DIFF
--- a/styleguide/Http/Controllers/ComponentHeroController.php
+++ b/styleguide/Http/Controllers/ComponentHeroController.php
@@ -50,6 +50,7 @@ class ComponentHeroController extends Controller
                             'Link' => 'URL',
                             'Description' => 'Formattable text. If the link field is set, description links will be stripped out.',
                             'Filename' => '1600x580px or 3200x1160px saved at low quality',
+                            'Secondary image' => 'SVG Overlay: 1600x580px or 3200x1160px svg<br />Logo overlay: >600px jpg, png',
                             'Options' => 'Banner small, Banner large, Text overlay, Half, Logo overlay, SVG overlay',
                         ],
                     ],

--- a/styleguide/Repositories/PromoRepository.php
+++ b/styleguide/Repositories/PromoRepository.php
@@ -80,6 +80,7 @@ class PromoRepository extends Repository
             105100106 => app(HeroImage::class)->create(1, false, [
                 'option' => 'SVG Overlay',
                 'relative_url' => '/styleguide/image/3200x1160',
+                'secondary_relative_url' => '/_resources/images/youtube-play.svg',
             ]),
             // Logo overlay
             105100107 => app(HeroImage::class)->create(1, false, [
@@ -99,7 +100,7 @@ class PromoRepository extends Repository
             // Childpage
             101100 => app(HeroImage::class)->create(1, false),
             // Layout small banner hero
-            120100100 => app(HeroImage::class)->create(1, false, [
+            105100108 => app(HeroImage::class)->create(1, false, [
                 'option' => 'Banner small',
                 'relative_url' => '/styleguide/image/3200x600?text=Small+banner+hero+image',
             ]),
@@ -110,7 +111,7 @@ class PromoRepository extends Repository
         ];
 
         // Only pull hero promos if they match the page ids that are specificed
-        $hero = !empty($hero_page_ids[$data['page']['id']]) ? $hero_page_ids[$data['page']['id']] : null;
+        $styleguide_hero = !empty($hero_page_ids[$data['page']['id']]) ? $hero_page_ids[$data['page']['id']] : null;
 
         // Full width page IDs
         $hero_full_width_ids = [
@@ -181,7 +182,7 @@ class PromoRepository extends Repository
         $global_promos =  merge([
             'contact' => app(FooterContact::class)->create(1),
             'social' => $social,
-            'hero' => $hero,
+            'hero' => $styleguide_hero ?? $hero ?? [],
             'under_menu' => $under_menu,
             'components' => $components,
         ]);


### PR DESCRIPTION
Styleguide hero was overwritten by potential component hero. Assigned separate variables temporarily while I reevaluate how the promo repository and the styleguide promo repository should interact. 
<img width="1159" alt="image" src="https://github.com/user-attachments/assets/5d36120e-2c20-48c4-a36d-c3cb2c43d3dc" />
