### PR TITLE
Fix | Dependencies | Removed 'replace-in-file' for native JS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "laravel-mix": "^6.0.49",
     "mediabox": "^1.1.3",
     "postcss": "^8.5.6",
-    "replace-in-file": "^8.3.0",
     "sass": "^1.89.2",
     "sass-loader": "^16.0.5",
     "slideout": "^1.0.1",

--- a/resources/js/modules/carousel.js
+++ b/resources/js/modules/carousel.js
@@ -1,4 +1,4 @@
-var Flickity = require('flickity');
+import Flickity from 'flickity';
 
 (function(Flickity) {
     "use strict";

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const path = require('path');
 const package = JSON.parse(fs.readFileSync('./package.json'));
 const ESLintPlugin = require('eslint-webpack-plugin');
-const { replaceInFileSync } = require('replace-in-file');
 
 /*
  |--------------------------------------------------------------------------
@@ -39,11 +38,13 @@ if (!mix.inProduction()) {
     fs.copyFileSync('hooks/pre-commit', '.git/hooks/pre-commit', fs.constants.COPYFILE_FICLONE);
 }
 
-replaceInFileSync({
-    files: 'resources/views/components/footer.blade.php',
-    from: /2\d{3}/g,
-    to: "{{ date('Y') }}",
-});
+// Replace year in footer file
+const footerPath = 'resources/views/components/footer.blade.php';
+if (fs.existsSync(footerPath)) {
+    let footerContent = fs.readFileSync(footerPath, 'utf8');
+    footerContent = footerContent.replace(/2\d{3}/g, "{{ date('Y') }}");
+    fs.writeFileSync(footerPath, footerContent);
+}
 
 
 // Error Files

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,7 +2690,6 @@ __metadata:
     laravel-mix: "npm:^6.0.49"
     mediabox: "npm:^1.1.3"
     postcss: "npm:^8.5.6"
-    replace-in-file: "npm:^8.3.0"
     sass: "npm:^1.89.2"
     sass-loader: "npm:^16.0.5"
     slideout: "npm:^1.0.1"
@@ -3141,13 +3140,6 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^5.3.0":
-  version: 5.4.1
-  resolution: "chalk@npm:5.4.1"
-  checksum: 10c0/b23e88132c702f4855ca6d25cb5538b1114343e41472d5263ee8a37cccfccd9c4216d111e1097c6a27830407a1dc81fecdf2a56f2c63033d4dbbd88c10b0dcef
   languageName: node
   linkType: hard
 
@@ -5010,7 +5002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.4.2":
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -8038,19 +8030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"replace-in-file@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "replace-in-file@npm:8.3.0"
-  dependencies:
-    chalk: "npm:^5.3.0"
-    glob: "npm:^10.4.2"
-    yargs: "npm:^17.7.2"
-  bin:
-    replace-in-file: bin/cli.js
-  checksum: 10c0/0862e36112c06be39ff2bb1f3448dc976adc89d1d80ca6613b4410683e62338fd83d69c2d291065d7603bd1361e52ff672406eeea2e38309b9368a8f6fcad7c0
-  languageName: node
-  linkType: hard
-
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
@@ -9943,7 +9922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.2.1, yargs@npm:^17.3.1, yargs@npm:^17.7.2":
+"yargs@npm:^17.2.1, yargs@npm:^17.3.1":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Reason for change

After the dependency updates:
https://github.com/waynestate/base-site/pull/802

GitHub Actions was successfully deploying:
https://github.com/waynestate/base-site/actions/runs/15934240581/job/44950327820

But Jenkins threw an error about the way 'replace-in-file' was being included.

```
[webpack-cli] Error [ERR_REQUIRE_ESM]: require() of ES Module node_modules/replace-in-file/index.js from webpack.mix.js not supported.
Instead change the require of index.js in webpack.mix.js to a dynamic import() which is available in all CommonJS modules.
```

After looking at what we were using it for, it is something that can be done in native JavaScript and we don't need a dependency for it.

This removes the 'replace-in-file' dependency.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes