### PR TITLE
Hotfix 8.14.3 | Fix yarn updating package.json on CI

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ deployproduction: install buildproduction runtests envoyproduction
 yarn: $(YARNFILE)
 	@if ! grep -q ".yarn" .gitignore > /dev/null 2>&1; then echo ".yarn/" >> .gitignore; fi
 	corepack enable yarn
-	yarn set version --only-if-needed stable
+	yarn set version self
 	yarn config set --home nodeLinker node-modules
 	yarn config set --home enableImmutableInstalls false
 	yarn config set --home enableTelemetry 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.2",
+  "version": "8.14.3",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Due to yarn on CI having the possibility to get updated, we could potentially have an error due to the package.json having a later yarn version than what was initially committed causing a git pull error. This will allow yarn to using the same version as in the package.json packageManager and allowing us to update as needed