### PR TITLE
Hotfix 8.14.7 | update php to be v8.2.20 for local environment compatibility

### DIFF
--- a/.phpbrewrc
+++ b/.phpbrewrc
@@ -1,1 +1,1 @@
-phpbrew use 8.2.7
+phpbrew use 8.2.20

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.6",
+  "version": "8.14.7",
   "description": "",
   "scripts": {
     "dev": "npm run development",


### PR DESCRIPTION
Update PHP from v8.2.7 to v8.2.20 for local environment compatibility across sites.