### PR TITLE
Hotfix | Test coverage back to 100%, news-and-events-row docs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.8",
+  "version": "8.14.9",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/styleguide/Http/Controllers/ComponentNewsAndEventsController.php
+++ b/styleguide/Http/Controllers/ComponentNewsAndEventsController.php
@@ -44,11 +44,11 @@ class ComponentNewsAndEventsController extends Controller
 <p>HeadingClass and headingLevel are available.
                         ',
                         'tr1' => [
-                            'Page field' => 'modular-news-and-events-1',
+                            'Page field' => 'modular-news-and-events-row-1',
                             'Data' => '{}',
                         ],
                         'tr2' => [
-                            'Page field' => 'modular-news-and-events-1',
+                            'Page field' => 'modular-news-and-events-row-1',
                             'Data' => '{
 "news_id":0,
 "events_id":0000,

--- a/tests/Unit/Http/Controllers/DirectoryControllerTest.php
+++ b/tests/Unit/Http/Controllers/DirectoryControllerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use PHPUnit\Framework\Attributes\Test;
+use App\Http\Controllers\DirectoryController;
+use App\Repositories\ProfileRepository;
+use Tests\TestCase;
+use Mockery as Mockery;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Factories\Page;
+use Factories\Profile;
+
+final class DirectoryControllerTest extends TestCase
+{
+    #[Test]
+    public function directory_index_should_order_profiles_by_accessid_when_configured(): void
+    {
+        // Create mock profiles data
+        $profile_listing = app(Profile::class)->create(5);
+
+        // Get AccessIDs and create a custom order
+        $access_ids = collect($profile_listing)->pluck('data.AccessID')->toArray();
+        $profiles_by_accessid = implode('|', array_reverse($access_ids));
+
+        // Create profiles grouped by department
+        $grouped_profiles = [
+            'profiles' => [
+                'Department A' => array_slice($profile_listing, 0, 3),
+                'Department B' => array_slice($profile_listing, 3, 2),
+            ],
+            'anchors' => [
+                'Department A' => 'department-a',
+                'Department B' => 'department-b',
+            ],
+        ];
+
+        // Create request data with profile configuration
+        $base_data = app(Page::class)->create(1, true, [
+            'data' => [
+                'profile-config' => json_encode([
+                    'profiles_by_accessid' => $profiles_by_accessid,
+                ]),
+            ],
+        ]);
+
+        $request = new Request();
+        $request->data = ['base' => $base_data];
+
+        // Mock the ProfileRepository
+        $profileRepository = Mockery::mock(ProfileRepository::class);
+
+        // Mock parseProfileConfig to set the config
+        $profileRepository->shouldReceive('parseProfileConfig')
+            ->once()
+            ->with($base_data)
+            ->andReturnUsing(function ($data) use ($profiles_by_accessid) {
+                Config::set('profile.profiles_by_accessid', $profiles_by_accessid);
+            });
+
+        // Mock getSiteID
+        $profileRepository->shouldReceive('getSiteID')
+            ->once()
+            ->with($base_data)
+            ->andReturn($base_data['site']['id']);
+
+        // Mock getProfilesByGroup (since group_id is not set)
+        $profileRepository->shouldReceive('getProfilesByGroup')
+            ->once()
+            ->with($base_data['site']['id'], $base_data['site']['subsite-folder'])
+            ->andReturn($grouped_profiles);
+
+        // Mock orderProfilesById for each department
+        $profileRepository->shouldReceive('orderProfilesById')
+            ->twice()
+            ->with(Mockery::type('array'), $profiles_by_accessid)
+            ->andReturnUsing(function ($department_profiles, $profiles_by_accessid) {
+                // Simulate the ordering logic
+                $accessids = explode('|', $profiles_by_accessid);
+                $ordered = collect($accessids)->map(function ($accessid) use ($department_profiles) {
+                    return collect($department_profiles)->firstWhere('data.AccessID', trim($accessid));
+                })->filter()->values()->toArray();
+
+                $remaining = collect($department_profiles)->reject(function ($profile) use ($accessids) {
+                    return in_array($profile['data']['AccessID'], $accessids);
+                })->values()->toArray();
+
+                return array_merge($ordered, $remaining);
+            });
+
+        // Create controller instance
+        $controller = new DirectoryController($profileRepository);
+
+        // Call the index method
+        $view = $controller->index($request);
+
+        // Verify the view was returned
+        $this->assertEquals('directory', $view->getName());
+    }
+
+    #[Test]
+    public function directory_index_should_use_group_order_when_group_id_configured(): void
+    {
+        // Create mock profiles data
+        $profile_listing = app(Profile::class)->create(3);
+        $group_id = '1|2|3';
+
+        // Create profiles grouped by department
+        $grouped_profiles = [
+            'profiles' => [
+                'Department A' => $profile_listing,
+            ],
+            'anchors' => [
+                'Department A' => 'department-a',
+            ],
+        ];
+
+        // Create request data
+        $base_data = app(Page::class)->create(1, true, [
+            'data' => [
+                'profile-config' => json_encode([
+                    'group_id' => $group_id,
+                ]),
+            ],
+        ]);
+
+        $request = new Request();
+        $request->data = ['base' => $base_data];
+
+        // Mock the ProfileRepository
+        $profileRepository = Mockery::mock(ProfileRepository::class);
+
+        // Mock parseProfileConfig to set the config
+        $profileRepository->shouldReceive('parseProfileConfig')
+            ->once()
+            ->with($base_data)
+            ->andReturnUsing(function ($data) use ($group_id) {
+                Config::set('profile.group_id', $group_id);
+            });
+
+        // Mock getSiteID
+        $profileRepository->shouldReceive('getSiteID')
+            ->once()
+            ->with($base_data)
+            ->andReturn($base_data['site']['id']);
+
+        // Mock getProfilesByGroupOrder (since group_id is set)
+        $profileRepository->shouldReceive('getProfilesByGroupOrder')
+            ->once()
+            ->with($base_data['site']['id'], $group_id, $base_data['site']['subsite-folder'])
+            ->andReturn($grouped_profiles);
+
+        // Create controller instance
+        $controller = new DirectoryController($profileRepository);
+
+        // Call the index method
+        $view = $controller->index($request);
+
+        // Verify the view was returned
+        $this->assertEquals('directory', $view->getName());
+    }
+}

--- a/tests/Unit/Repositories/HeroRepositoryTest.php
+++ b/tests/Unit/Repositories/HeroRepositoryTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Tests\Unit\Repositories;
+
+use PHPUnit\Framework\Attributes\Test;
+use App\Repositories\HeroRepository;
+use Tests\TestCase;
+use Mockery as Mockery;
+use Waynestate\Api\Connector;
+use Illuminate\Cache\Repository;
+
+final class HeroRepositoryTest extends TestCase
+{
+    private HeroRepository $heroRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $wsuApi = Mockery::mock(Connector::class);
+        $cache = Mockery::mock(Repository::class);
+
+        $this->heroRepository = new HeroRepository($wsuApi, $cache);
+    }
+
+    #[Test]
+    public function set_hero_with_banner_contained_option(): void
+    {
+        // Test Banner contained option is set
+        $promos = [
+            'hero' => [
+                [
+                    'option' => 'Banner contained',
+                    'title' => 'Test Hero'
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        $this->assertEquals('Banner contained', $result['hero']['component']['option']);
+    }
+
+    #[Test]
+    public function set_hero_with_contained_hero_layout_and_no_option(): void
+    {
+        // Test Layout is 'contained-hero' and no option is set
+        config(['base.layout' => 'contained-hero']);
+
+        $promos = [
+            'hero' => [
+                [
+                    'title' => 'Test Hero'
+                    // No 'option' key set
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        $this->assertEquals('Banner contained', $result['hero']['component']['option']);
+    }
+
+    #[Test]
+    public function set_hero_overrides_from_components(): void
+    {
+        // Test Hero component override functionality
+        $promos = [
+            'components' => [
+                'modular-hero-1' => [
+                    'data' => [
+                        [
+                            'title' => 'Component Hero',
+                            'description' => 'This is from a component'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        // The hero should be set from the component
+        $this->assertArrayHasKey('hero', $result);
+        $this->assertEquals('Component Hero', $result['hero']['data'][0]['title']);
+
+        // The component should be removed from components array
+        $this->assertArrayNotHasKey('modular-hero-1', $result['components']);
+
+        // Config should be set for hero_full_controllers
+        $this->assertContains('TestController', config('base.hero_full_controllers'));
+    }
+
+    #[Test]
+    public function set_hero_replaces_buttons_option_with_text_overlay(): void
+    {
+        // Test Buttons option is replaced with Text Overlay
+        $promos = [
+            'hero' => [
+                [
+                    'option' => 'Buttons',
+                    'title' => 'Test Hero with Buttons'
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        $this->assertArrayHasKey('hero', $result);
+        $this->assertArrayHasKey('data', $result['hero']);
+        $this->assertArrayHasKey(0, $result['hero']['data']);
+        $this->assertEquals('Text Overlay', $result['hero']['data'][0]['option']);
+    }
+
+    #[Test]
+    public function set_hero_handles_hero_buttons_component(): void
+    {
+        // Test hero buttons functionality
+        $promos = [
+            'components' => [
+                'hero-buttons-1' => [
+                    'data' => [
+                        [
+                            'title' => 'Button 1',
+                            'url' => 'http://example.com'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        // Hero buttons should be moved to hero_buttons key
+        $this->assertArrayHasKey('hero_buttons', $result);
+        $this->assertEquals('Button 1', $result['hero_buttons']['data'][0]['title']);
+
+        // Component should be removed
+        $this->assertArrayNotHasKey('hero-buttons-1', $result['components']);
+    }
+
+    #[Test]
+    public function set_hero_with_multiple_hero_data_items_does_not_set_component_option(): void
+    {
+        // When there are multiple hero items, component option should not be set
+        $promos = [
+            'hero' => [
+                [
+                    'option' => 'Banner contained',
+                    'title' => 'Hero 1'
+                ],
+                [
+                    'option' => 'Banner small',
+                    'title' => 'Hero 2'
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        // Component option should not be set when there are multiple hero items
+        // but the component key should still exist as an empty array
+        $this->assertArrayHasKey('component', $result['hero']);
+        $this->assertEmpty($result['hero']['component']);
+    }
+
+    #[Test]
+    public function set_hero_preserves_existing_hero_data_structure(): void
+    {
+        // Test that hero data is preserved when forcing into component structure
+        $promos = [
+            'hero' => [
+                [
+                    'title' => 'Test Hero',
+                    'description' => 'Test Description'
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        // Hero data should be moved to data key
+        $this->assertArrayHasKey('data', $result['hero']);
+        $this->assertEquals('Test Hero', $result['hero']['data'][0]['title']);
+        $this->assertEquals('Test Description', $result['hero']['data'][0]['description']);
+    }
+
+    #[Test]
+    public function set_hero_with_empty_promos_returns_unchanged(): void
+    {
+        // Test that empty promos are returned unchanged
+        $promos = [
+            'components' => []
+        ];
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        $this->assertEquals($promos, $result);
+    }
+
+    #[Test]
+    public function set_hero_with_no_option_and_different_layout_sets_banner_small(): void
+    {
+        // Test the final elseif condition for Banner small
+        config(['base.layout' => 'full-width']); // Not 'contained-hero'
+
+        $promos = [
+            'hero' => [
+                [
+                    'title' => 'Test Hero'
+                    // No 'option' key set
+                ]
+            ],
+            'components' => []
+        ];
+
+        $data = [
+            'page' => [
+                'controller' => 'TestController'
+            ]
+        ];
+
+        $result = $this->heroRepository->setHero($promos, $data);
+
+        $this->assertEquals('Banner small', $result['hero']['component']['option']);
+    }
+}

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -372,6 +372,7 @@ final class ModularPageRepositoryTest extends TestCase
                     'singlePromoView' => true,
                     'showExcerpt' => true,
                     'showDescription' => true,
+                    'option' => 'Component Override Option',
                 ]),
             ],
         ]);
@@ -393,6 +394,8 @@ final class ModularPageRepositoryTest extends TestCase
         $this->assertEquals($component['link'], 'view/'.Str::slug($component['title']).'-'.$component['promo_item_id']);
         $this->assertArrayHasKey('excerpt', $component);
         $this->assertArrayHasKey('description', $component);
+        // Test that component option overrides promo item option
+        $this->assertEquals('Component Override Option', $component['option']);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for change

While testing the news-and-events modular component row, noticed the styleguide docs didn't reflect the full custom page field name. This now corrects the styleguide.

Additionally, with the end of the 8.14 release, this restores the 100% code coverage to the repository.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

<img width="1002" height="275" alt="Screenshot 2025-08-12 at 1 49 15 PM" src="https://github.com/user-attachments/assets/7d9e21f9-c95c-46f9-933c-6f3aebc4f7cc" />