### PR TITLE
Fix | Profiles | Legacy support for profiles_by_accessid custom page field restored

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -408,19 +408,24 @@ class ProfileRepository implements ProfileRepositoryContract
             }
         }
 
-        // legacy support for profile_group_id
+        // Legacy support for profile_group_id
         if (!empty($data['data']['profile_group_id']) && empty($profile_config['group_id'])) {
             Config::set('profile.group_id', $data['data']['profile_group_id']);
         }
 
-        // legacy support for profile_site_id
+        // Legacy support for profile_site_id
         if (!empty($data['data']['profile_site_id']) && empty($profile_config['site_id'])) {
             Config::set('profile.site_id', $data['data']['profile_site_id']);
         }
 
-        // legacy support for table_of_contents
+        // Legacy support for table_of_contents
         if (!empty($data['data']['table_of_contents']) && empty($profile_config['table_of_contents'])) {
             Config::set('profile.table_of_contents', $data['data']['table_of_contents']);
+        }
+
+        // Legacy support for profiles_by_accessid
+        if (!empty($data['data']['profiles_by_accessid'])) {
+            Config::set('profile.profiles_by_accessid', $data['data']['profiles_by_accessid']);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.9",
+  "version": "8.14.10",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/styleguide/Pages/Profiles.php
+++ b/styleguide/Pages/Profiles.php
@@ -36,7 +36,8 @@ class Profiles extends Page
 "group_id":"1234|5678",
 "parent_group_id":"1234",
 "table_of_contents":"hide",
-"default_back_url":"/profiles/",
+"default_back_url":"/profiles",
+"profiles_by_accessid":"aa0000|aa0001"
 }
 </pre>
                                 </td>

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -472,4 +472,24 @@ final class ProfileRepositoryTest extends TestCase
         $this->assertEquals(collect($ordered_profiles)->pluck('data.AccessID')->toArray(), explode('|', $profiles_by_accessid));
     }
 
+    #[Test]
+    public function order_profiles_by_accessid_can_be_set_in_custom_field(): void
+    {
+        // Create mock profiles data
+        $profile_listing = app(Profile::class)->create(5);
+
+        // Get AccessIDs and create a custom order
+        $access_ids = collect($profile_listing)->pluck('data.AccessID')->toArray();
+        $profiles_by_accessid = implode('|', array_reverse($access_ids));
+
+        // Page field override
+        $data['data']['profiles_by_accessid'] = $profiles_by_accessid;
+
+        // Parse the profile config for the page
+        $profileRepository = app(ProfileRepository::class);
+        $profileRepository->parseProfileConfig($data);
+
+        // Ensure the config value is set
+        $this->assertEquals($profiles_by_accessid, config('profile.profiles_by_accessid'));
+    }
 }


### PR DESCRIPTION
## Reason for change

With the update to use the `profile.` config for all profile listing configuration and `profile_config` JSON array to override in custom page fields, the previous `profiles_by_accessid` custom page field stopped working.

This change restores that ability for all sites currently using it until we can convert them to use the `profile_config` JSON format and ensures backwards compatibility. 

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes