### PR TITLE
Fix | Profiles | Legacy support for the base.profile_back_url restored

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -370,7 +370,7 @@ class ProfileRepository implements ProfileRepositoryContract
             || $referer == $scheme.'://'.$host.$uri
             || strpos($referer, $host) === false
         ) {
-            return config('profile.default_back_url');
+            return config('base.profile_back_url', config('profile.default_back_url'));
         }
 
         return $referer;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.10",
+  "version": "8.14.11",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -101,6 +101,12 @@ final class ProfileRepositoryTest extends TestCase
         $parsed = parse_url($referer);
         $url = app(ProfileRepository::class)->getBackToProfileListUrl($referer, $parsed['scheme'], $parsed['host'], $this->faker->word());
         $this->assertEquals($referer, $url);
+
+        // Legacy support for the base.profile_back_url
+        $legacy_back_url = 'some/other/url';
+        Config::set('base.profile_back_url', $legacy_back_url);
+        $url = app(ProfileRepository::class)->getBackToProfileListUrl();
+        $this->assertEquals($legacy_back_url, $url);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for change

With the update to use the `profile. config` for all profile listing configuration and `profile-config` JSON array to override in custom page fields, the previous `base.profile_back_url` custom page field stopped working.

Because this functionality exists on many sites, this change restores the ability to use `base.profile_back_url` without affecting forward progress on the configurations.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes

## Demo

| Base Config | Frontend |
|--------|------|
| <img width="359" height="148" alt="Screenshot 2025-08-22 at 7 11 17 AM" src="https://github.com/user-attachments/assets/d9e32e25-4739-4f66-a9b8-f027aa1f2412" /> | <img width="486" height="125" alt="Screenshot 2025-08-22 at 7 17 02 AM" src="https://github.com/user-attachments/assets/4e4cc082-0b73-4aca-9db6-51ce31794b35" /> |
