### PR TITLE
Fix | Profiles | Cleanup of base profile configs and correction to base.profile_default_back_url

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -197,7 +197,7 @@ class ProfileRepository implements ProfileRepositoryContract
         // Filter down the groups based on the parent group from the config
         $profile_groups['results'] = collect($profile_groups['results'])
             ->filter(function ($item) {
-                return (int) $item['parent_id'] === config('profile.parent_group_id');
+                return (int) $item['parent_id'] === config('base.profile_parent_group_id', config('profile.parent_group_id'));
             })
             ->toArray();
 
@@ -370,7 +370,7 @@ class ProfileRepository implements ProfileRepositoryContract
             || $referer == $scheme.'://'.$host.$uri
             || strpos($referer, $host) === false
         ) {
-            return config('base.profile_back_url', config('profile.default_back_url'));
+            return config('base.profile_default_back_url', config('profile.default_back_url'));
         }
 
         return $referer;

--- a/config/base.php
+++ b/config/base.php
@@ -136,29 +136,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Profile View Back Url
-    |--------------------------------------------------------------------------
-    |
-    | Back URL to use when viewing a Individual Profile view in place for the
-    | "Return to Listing" link.
-    |
-    */
-    'profile_default_back_url' => '/profiles',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Profile Parent Group
-    |--------------------------------------------------------------------------
-    |
-    | This will limit the groups displayed to only the children groups under
-    | this ID. Typically the group is called "Departments". If all desired
-    | groups are added to the root then leave this value as 0.
-    |
-    */
-    'profile_parent_group_id' => 0,
-
-    /*
-    |--------------------------------------------------------------------------
     | Default Meta Image
     |--------------------------------------------------------------------------
     |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.11",
+  "version": "8.14.12",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -102,9 +102,9 @@ final class ProfileRepositoryTest extends TestCase
         $url = app(ProfileRepository::class)->getBackToProfileListUrl($referer, $parsed['scheme'], $parsed['host'], $this->faker->word());
         $this->assertEquals($referer, $url);
 
-        // Legacy support for the base.profile_back_url
+        // Legacy support for the base.profile_default_back_url
         $legacy_back_url = 'some/other/url';
-        Config::set('base.profile_back_url', $legacy_back_url);
+        Config::set('base.profile_default_back_url', $legacy_back_url);
         $url = app(ProfileRepository::class)->getBackToProfileListUrl();
         $this->assertEquals($legacy_back_url, $url);
     }


### PR DESCRIPTION
## Reason for change

Fixing an issue introduced in https://github.com/waynestate/base-site/pull/822 with the `base.profile_default_back_url` key being wrong.

There were duplicate keys for the default_back_url and the parent_group_id in the base and profile configs. This now cleans them up, so there is only one reference moving forward.

## Reminders

- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes
