### PR TITLE
Hotfix 8.14.15 | Hero component | Resolving hero randomly MIA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.14.14",
+  "version": "8.14.15",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -15,7 +15,7 @@
             <div class="hero__preserve-flickity">
                 @if(isset($base['hero']['component']['option']))
                     @includeIf('components.hero.'.Str::slug($base['hero']['component']['option']), ['item' => $item, 'loop' => $loop ?? ''])
-                @elseif(isset($item['option']))
+                @elseif(!empty($item['option']))
                     @includeIf('components.hero.'.Str::slug($item['option']), ['item' => $item, 'loop' => $loop ?? ''])
                 @else
                     @include('components.hero.banner-large', ['item' => $item, 'loop' => $loop ?? ''])


### PR DESCRIPTION
## Reason for change
- Reported issue where a previously set Hero image would only appear intermittently. 
- Nick identified the issue present within `hero.blade.php` where `!isset()` was insufficient, using `!empty()` resolves the issue.


## Notes
- Coveralls status page reporting intermittent issues.
- Added two tasks to create tests for the missing coverages.