### PR TITLE
FIX | Pre-commit | Ensure PHPStan only runs on base repository

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -134,22 +134,32 @@ else
     printf "phpunit tests have passed.\n"
 fi
 
-# PHPStan/Larastan analysis
-if [ "${docker_test}" = "true" ]; then
-    printf "Running PHPStan/Larastan analysis...\n"
-    phpstan="$(make phpstandry)"
-else
-    printf "Running PHPStan/Larastan analysis...\n"
-    phpstan="$(faketty docker exec -it wsu-${site_folder} bash -i -c "make phpstandry")"
+# PHPStan/Larastan analysis — only for the base-site repository
+repo_url=$(git config --get remote.origin.url 2>/dev/null || true)
+repo_name=""
+if [ -n "$repo_url" ]; then
+    repo_name=$(basename -s .git "$repo_url" | tr '[:upper:]' '[:lower:]')
 fi
 
-# Check if the last command (PHPStan) didn't exit with a 0 success
-if  (( $? != 0 )); then
-    printf "PHPStan/Larastan analysis failed. Please fix the issues before committing.\n"
-    printf ">> run: make phpstan\n"
-    exit 1
+if [ "$repo_name" = "base-site" ]; then
+    if [ "${docker_test}" = "true" ]; then
+        printf "Running PHPStan/Larastan analysis...\n"
+        phpstan="$(make phpstandry)"
+    else
+        printf "Running PHPStan/Larastan analysis...\n"
+        phpstan="$(faketty docker exec -it wsu-${site_folder} bash -i -c "make phpstandry")"
+    fi
+
+    # Check if the last command (PHPStan) didn't exit with a 0 success
+    if  (( $? != 0 )); then
+        printf "PHPStan/Larastan analysis failed. Please fix the issues before committing.\n"
+        printf ">> run: make phpstan\n"
+        exit 1
+    else
+        printf "PHPStan/Larastan analysis has passed.\n"
+    fi
 else
-    printf "PHPStan/Larastan analysis has passed.\n"
+    printf "Skipping PHPStan/Larastan (repo detected: %s).\n" "${repo_name:-unknown}"
 fi
 
 exit 0;


### PR DESCRIPTION
## Reason for change
 
- The pre-commit hook was attaching itself to all repositories that use **base**, triggering a bunch of errors on individual sites.  This goes against the intention of adding PHPStan/Larastan where we really only want it to run on **base** and then we resolve all issues there before releases.
- This update adds a conditional check to confirm which should only allow sites with the repository name `base-site` to run `make phpstandry` on pre-commit.
 
## Relevant links
 
- _*This change was brought up in a conversation with @Fw7424 and there is no Basecamp or TP3 issue_
 
## Reminders
 
- Update package version number
- Frontend accessibility check
- Styleguide example in place
- New functionality covered by tests
- Screenshots of multiple screen sizes