### PR TITLE
Feature/ Modular component | Page title allow for visually-hidden

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -304,7 +304,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
                         $modularComponents[$name]['component']['heading'] = '';
                     }
                 }
-            } elseif (Str::startsWith($name, 'page-content') || Str::startsWith($name, 'heading')) {
+            } elseif (Str::startsWith($name, 'page-content') || Str::startsWith($name, 'heading') || Str::contains($name, 'layout')) {
                 // If there's JSON but no news, events or promo data, assign the component array as data
                 // Page-content and heading components
                 $modularComponents[$name]['data'][] = $components['components'][$name] ?? [];

--- a/resources/views/components/page-title.blade.php
+++ b/resources/views/components/page-title.blade.php
@@ -1,1 +1,3 @@
-<h1 class="mt-4{{ !empty($class) ? ' '.$class : '' }}">{{ $title }}</h1>
+<h1 class="mt-4{{ !empty($class) ? ' '.$class : '' }} {{ ($base['components']['layout-config']['component']['showTitle'] ?? true) ? '' : 'visually-hidden' }}">
+    {{ $title }}
+</h1>

--- a/styleguide/Http/Controllers/LayoutPageTitleController.php
+++ b/styleguide/Http/Controllers/LayoutPageTitleController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Styleguide\Http\Controllers;
+
+use Illuminate\View\View;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Faker\Factory;
+
+class LayoutPageTitleController extends Controller
+{
+    /**
+     * Construct the controller.
+     */
+    public function __construct(Factory $faker)
+    {
+        $this->faker = $faker->create();
+    }
+
+    /**
+     * Display the double header view with a custom short title
+     */
+    public function index(Request $request): View
+    {
+        $request->data['base']['page']['content']['main'] = '
+<p>In the <code>modular-layout-config</code>, set whether a page title should be displayed.</p>
+<ul>
+<li><code>true</code> (Default option) shows the page title normally with margin top classes.</li>
+<li><code>false</code> hides the page title (applies a <code>visually-hidden</code> class for accessibility).</li>
+</ul>
+<p>If <code>showTitle</code> is omitted, the default is visible.</p>
+';
+
+        return view('styleguide-childpage', merge($request->data));
+    }
+}

--- a/styleguide/Pages/LayoutPageTitle.php
+++ b/styleguide/Pages/LayoutPageTitle.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Styleguide\Pages;
+
+use Factories\Page as PageFactory;
+
+class LayoutPageTitle extends Page
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPageData()
+    {
+        return app(PageFactory::class)->create(1, true, [
+            'page' => [
+                'controller' => 'LayoutPageTitleController',
+                'title' => 'Page title',
+                'id' => 105100100,
+            ],
+        ]);
+    }
+}

--- a/styleguide/menu.json
+++ b/styleguide/menu.json
@@ -689,6 +689,27 @@
                     }
                 }
             },
+            "105100": {
+                "menu_item_id": 105100,
+                "is_active": 1,
+                "page_id": 105100,
+                "target": "",
+                "display_name": "Page title",
+                "class_name": "",
+                "relative_url": "/styleguide/layout/page/title",
+                "submenu": {
+                    "105100100": {
+                        "menu_item_id": 105100100,
+                        "is_active": 1,
+                        "page_id": 105100100,
+                        "target": "",
+                        "display_name": "Page title",
+                        "class_name": "",
+                        "relative_url": "/styleguide/layout/page/title",
+                        "submenu": []
+                    }
+                }
+            },
             "103100": {
                 "menu_item_id": 103100,
                 "is_active": 1,


### PR DESCRIPTION
**Reason for the Change**
This change will allow for the page title to be visually-hidden on pages where the design calls for it. This will allow for more flexibility in sites that can utilize the base design.