### PR TITLE
Hotfix | Left menu displaying again when top menu is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.15.0",
+  "version": "8.15.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/resources/views/partials/nav-left.blade.php
+++ b/resources/views/partials/nav-left.blade.php
@@ -1,14 +1,20 @@
 <nav id="menu" class="px-container-lg mt:w-80 {{ $base['show_site_menu'] === false ? ' mt:hidden' : '' }}" aria-label="Page menu" tabindex="-1">
     @if(!empty($base['top_menu_output']) && $base['site_menu'] !== $base['top_menu'] && config('base.top_menu_enabled'))
-        <div class="slideout-main-menu mt:hidden">
-            <ul class="main-menu mb-2">
-                <li>
-                    <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">{{ config('base.top_menu_label') }}</a>
-                    {!! $base['top_menu_output'] !!}
-                </li>
-            </ul>
-        </div>
-    @else
+        @if(!empty($base['top_menu_output']))
+            <div class="slideout-main-menu mt:hidden">
+                <ul class="main-menu mb-2">
+                    <li>
+                        <a role="button" class="main-menu-toggle pt-2 pb-2 pl-3 pr-3 block" tabindex="0" aria-expanded="false">{{ config('base.top_menu_label') }}</a>
+                        {!! $base['top_menu_output'] !!}
+                    </li>
+                </ul>
+            </div>
+        @else
+            {!! $base['top_menu_output'] !!}
+        @endif
+    @endif
+
+    @if(!empty($base['site_menu_output']))
         {!! $base['site_menu_output'] !!}
     @endif
 


### PR DESCRIPTION
### Restored left menu conditional

I moved the left menu into a partial to clean up the main layout file. I appear to have removed a very important conditional that made sure the menu displayed when the top menu was enabled. I believe at the time I thought it was duplicating an existing check. Clearly not! Since Base doesn't have top menu enabled by default, I did not catch this until it was deployed. 

I am looking for ideas on testing menu display changes to avoid this in the future. 

---

### Demo / Context

- [Basecamp](https://3.basecamp.com/5750155/buckets/37389969/todos/9231190810)

| Before | After |
|----|----|
|<img width="1300" height="800" alt="image" src="https://github.com/user-attachments/assets/24554ac7-77d7-4472-9d59-d82d6b9fca08" />|<img width="1300" height="1069" alt="image" src="https://github.com/user-attachments/assets/de8d19ee-7d8d-490b-92b4-655f5af47c47" />|
|<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/3c88b66a-d4d0-453b-a9fe-aa337273c664" />|<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/d7648f22-1e6b-4854-bb11-42373de893ce" />|

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions