### PR TITLE
Fix | base:feature | New feature stub now mirrors the updated childpage view

### DIFF
--- a/resources/views/childpage.blade.php
+++ b/resources/views/childpage.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.' . (!empty($base['layout']) ? $base['layout'] : 'main'))
-    
+
 @section('content')
     @include('partials.page-title', ['title' => $base['page']['title']])
     @include('components.page-content')

--- a/stubs/view.stub
+++ b/stubs/view.stub
@@ -1,13 +1,8 @@
 @extends('layouts.' . (!empty($base['layout']) ? $base['layout'] : 'main'))
-    
-@section('content')
-    @include('components.page-title', ['title' => $base['page']['title']])
 
-    @if(empty($base['components']['page-content-row']) && empty($base['components']['page-content-column']))
-        <div class="content">
-            {!! $base['page']['content']['main'] !!}
-        </div>
-    @endif
+@section('content')
+    @include('partials.page-title', ['title' => $base['page']['title']])
+    @include('components.page-content')
 
     @if(!empty($dummyitems))
         <ul class="list-disc">
@@ -16,6 +11,4 @@
             @endforeach
         </ul>
     @endif
-
-    @include('partials.component-loop')
 @endsection


### PR DESCRIPTION
### Fixes php artisan base:feature initial state

Ensures the file generated after creating a new feature mirror the rest of the site structure.

---

### Reason for Change

After generating a new feature, the previous stub file didn't match the current childpage structure, causing failed tests.

<img width="1316" height="958" alt="Screenshot 2025-12-01 at 11 22 37 AM" src="https://github.com/user-attachments/assets/67792b08-caa9-4958-a826-5dca12c9a4e0" />

It was also causing a duplicate inclusion of the `component-loop`.

---

### Demo / Context

This updates the view to match the latest childpage.blade.php file to ensure it functions like the rest of the pages.

<img width="1428" height="782" alt="Screenshot 2025-12-01 at 11 28 02 AM" src="https://github.com/user-attachments/assets/65973a13-483a-4009-bb59-e7ca8772a033" />

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

---

### Testing Notes

After creating a feature, test with the `make runtests` command to ensure everything is functional.

<img width="582" height="191" alt="Screenshot 2025-12-01 at 4 32 19 PM" src="https://github.com/user-attachments/assets/083c0e7a-498c-44c9-a0c7-606710dc98bd" />

---