### PR TITLE
Fix | Accessibility | Breadcrumb container removed if no breadcrumbs available

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,6 +1,7 @@
 {{--
     $breadcrumbs => array // ['display_name', 'relative_url']
 --}}
+@if (!empty($breadcrumbs))
 <nav id="breadcrumbs-menu" class="breadcrumbs mt-6 mb-2 print:mt-0 max-w-screen-3xl px-4 mx-auto" aria-label="Breadcrumbs">
     <ul class="text-sm @if(!empty($base['flag']))mt:w-4/5 @endif">
         @foreach($breadcrumbs as $key=>$crumb)
@@ -20,3 +21,4 @@
         @endforeach
     </ul>
 </nav>
+@endif


### PR DESCRIPTION
## Clear up WCAG 2.2 A error

All Base sites have an WCAG 2.2 A error "Container element is empty" when a page doesn't have breadcrumbs visible. 

<img width="1380" height="823" alt="Screenshot 2025-12-10 at 6 01 08 AM" src="https://github.com/user-attachments/assets/cda1fc61-e429-4952-8c0f-85d5277a4ba9" />

---

## Change

This updated code wraps the whole partial in a conditional to ensure the container and DOM elements are only displayed if there are breadcumbs.

---

## Demo / Context

| Before | After |
|--------|------|
| <img width="1007" height="847" alt="Screenshot 2025-12-10 at 5 57 28 AM" src="https://github.com/user-attachments/assets/2fded642-1542-4d98-b92d-81d36e7d5c85" /> | <img width="1009" height="849" alt="Screenshot 2025-12-10 at 6 00 06 AM" src="https://github.com/user-attachments/assets/7c8bfd13-2405-4156-a077-6a459d0cb4d1" /> |

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions