### PR TITLE
Fix | Tests | Config override tests no longer rely on specific initial config values

### DIFF
--- a/tests/Unit/Support/BaseConfigTest.php
+++ b/tests/Unit/Support/BaseConfigTest.php
@@ -30,34 +30,49 @@ final class BaseConfigTest extends TestCase
     #[Test]
     public function config_returns_global_config_when_no_override_is_set(): void
     {
-        // Ensure CONFIG_OVERRIDE is not set
         config(['app.env' => 'testing']);
+
+        // Parse the config as-is
+        $config_original = include config_path('base.php');
+
+        // If CONFIG_OVERRIDE is defined with no value
         putenv('CONFIG_OVERRIDE=');
 
-        $config = include config_path('base.php');
+        // Re-parse the base config
+        $config_updated = include config_path('base.php');
 
-        $this->assertIsArray($config);
-        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
-        $this->assertEquals('contained-hero', $config['layout']);
-        $this->assertFalse($config['top_menu_enabled']);
+        // Ensure the app config was not modified
+        $this->assertIsArray($config_updated);
+        $this->assertEquals($config_original['gtm_code'], $config_updated['gtm_code']);
+        $this->assertEquals($config_original['layout'], $config_updated['layout']);
+        $this->assertEquals($config_original['top_menu_enabled'], $config_updated['top_menu_enabled']);
     }
 
     #[Test]
     public function config_returns_global_config_when_override_file_does_not_exist(): void
     {
+        // Parse the config as-is
+        $config_original = include config_path('base.php');
+
         // Set CONFIG_OVERRIDE to non-existent file
         putenv('CONFIG_OVERRIDE=non-existent-file.php');
 
-        $config = include config_path('base.php');
+        // Re-parse the base config
+        $config_updated = include config_path('base.php');
 
-        $this->assertIsArray($config);
-        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
-        $this->assertEquals('contained-hero', $config['layout']);
+        // Ensure the app config was not modified
+        $this->assertIsArray($config_updated);
+        $this->assertEquals($config_original['gtm_code'], $config_updated['gtm_code']);
+        $this->assertEquals($config_original['layout'], $config_updated['layout']);
+        $this->assertEquals($config_original['top_menu_enabled'], $config_updated['top_menu_enabled']);
     }
 
     #[Test]
     public function config_merges_override_file_when_it_exists(): void
     {
+        // Parse the config as-is
+        $config_original = include config_path('base.php');
+
         // Create a test override file
         $overrideContent = '<?php
 return [
@@ -81,7 +96,7 @@ return [
         $this->assertEquals('test_value', $config['new_config_key']);
 
         // Ensure non-overridden values remain
-        $this->assertEquals('@waynestate', $config['twitter_handle']);
+        $this->assertEquals($config_original['twitter_handle'], $config['twitter_handle']);
     }
 
     #[Test]
@@ -139,6 +154,9 @@ return [
     #[Test]
     public function config_handles_empty_override_file(): void
     {
+        // Parse the config as-is
+        $config_original = include config_path('base.php');
+
         // Create empty override file
         $overrideContent = '<?php
 return [];';
@@ -150,8 +168,8 @@ return [];';
 
         // Should return the global config unchanged
         $this->assertIsArray($config);
-        $this->assertEquals('GTM-NCBVKQ2', $config['gtm_code']);
-        $this->assertEquals('contained-hero', $config['layout']);
+        $this->assertEquals($config['gtm_code'], $config['gtm_code']);
+        $this->assertEquals($config['layout'], $config['layout']);
     }
 
     #[Test]


### PR DESCRIPTION
## Correcting assumptions made in test values

Tests now use what ever values are set in the local repository to compare against instead of the original Base config values.

---

## Reason for Change

Hardcoding the config values in tests works until they are overwritten for a specific site. 

When overwritten for a site, tests start to fail.

This corrects that issue and reads the original config, for the specific site first before testing the overrides and compares against what ever values are in the local codebase.

---

## Demo / Context

| Before | After |
|--------|------|
| <img width="920" height="1156" alt="Screenshot 2025-12-10 at 6 46 40 AM" src="https://github.com/user-attachments/assets/57c7f6dc-4bdc-4c41-b65d-ce4784690ba7" /> | <img width="960" height="1147" alt="Screenshot 2025-12-10 at 7 03 15 AM" src="https://github.com/user-attachments/assets/b985e229-c881-483c-8c1e-55c2a32ea386" /> |

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

---

## Testing Notes

Run tests normally with `make runtests`