### PR TITLE
Feature | Deployment | Excluded the .yarn cache directory for deployment

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -232,7 +232,7 @@ fi
         echo "LocalSource Pack release...";
         [ -f {{ $localdeploy_tmp_dir }}/release_{{ $release_hash }}.tgz ] && rm -rf {{ $localdeploy_tmp_dir }}/release_{{ $release_hash }}.tgz;
         cd {{ $localdeploy_base }}/;
-        tar --exclude=storage --exclude=node_modules --exclude-vcs -czf {{ $localdeploy_tmp_dir }}/release_{{ $release_hash }}.tgz {{ $source_name }};
+        tar --exclude=storage --exclude=node_modules --exclude-vcs --exclude='.yarn' -czf {{ $localdeploy_tmp_dir }}/release_{{ $release_hash }}.tgz {{ $source_name }};
         echo "LocalSource Pack release Done.";
     fi
 @endtask


### PR DESCRIPTION
## Reduce deployment size

Removed the `.yarn` cache directory from the deployment process to reduce unused code on the server.

---

## Reason for Change

The `.yarn` directory is an artifact of the install and bulid of the frontend, it isn't used after `make build` and does not need to be on the server for the site to work.

This change removes it in the deployment process. Resulting in reduced tar filesize, faster transport, untaring and speeding up deployment.

---

## Demo / Context

```
ls -lh
total 171872
-rw-r--r--@ 1 ak8863  staff    28M Dec 12 06:27 release_after.tgz
-rw-r--r--@ 1 ak8863  staff    56M Dec 11 15:02 release_before.tgz
```

<img width="537" height="251" alt="Screenshot 2025-12-12 at 6 29 21 AM" src="https://github.com/user-attachments/assets/c09f03ab-7f79-4fbc-aeaf-01df5be387c7" />

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions