### PR TITLE
FIX | Adding bottom margin to content area

### DIFF
--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -44,7 +44,7 @@
         @yield('under-hero')
     @endif
 
-    <div class="layout {{ (in_array($base['page']['controller'], config('base.full_width_controllers'))) ? 'layout--full-width' : 'layout--left-menu  max-w-[75em] mx-auto mt:flex' }}">
+    <div class="layout mb-8 {{ (in_array($base['page']['controller'], config('base.full_width_controllers'))) ? 'layout--full-width' : 'layout--left-menu  max-w-[75em] mx-auto mt:flex' }}">
         @include('partials.nav-left')
 
         <main class="content-area mx-auto w-full {{ $base['show_site_menu'] === true ? 'max-w-[900px]' : 'max-w-[75rem]' }}{{ (in_array($base['page']['controller'], config('base.full_width_controllers'))) ? ' max-w-full' : '' }}" tabindex="-1">


### PR DESCRIPTION
### Reason for Change

The modular repository adds a margin at the bottom of each component to maintain consistent spacing. However, there is no margin at the bottom of the content area when not using components.

This change adds a margin to the bottom of the `<div class="layout>"` element to ensure there is always space between the content and the footer. 

The caveat, there will be whitespace when you have a full width component that needs to butt up against the social footer. Future updates can address whether or not we will use logic to apply the margin or require a negative margin in the instance of a full width component that needs to butt up against the footer. Example: https://wayne.edu/about


### Demo

|Before|After|
|----|----|
|<img width="1300" height="1313" alt="image" src="https://github.com/user-attachments/assets/74da1e1b-a929-4dcc-97cb-71c4e1b2f10d" />|<img width="1300" height="1353" alt="image" src="https://github.com/user-attachments/assets/7739f322-d25f-4973-9f69-b6ee5ff9bc37" />|


### References

- [Basecamp](https://3.basecamp.com/5750155/buckets/37389969/todos/9350351866)



### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [n/a] I have added or updated relevant documentation
- [n/a] I have added tests (if applicable)
- [n/a] I have communicated with the team about necessary post-deploy actions