### PR TITLE
FIX | Nav Left - Mobile | Menu Top Toggle Presence Condition

### DIFF
--- a/resources/views/partials/nav-left.blade.php
+++ b/resources/views/partials/nav-left.blade.php
@@ -1,6 +1,6 @@
 <nav id="menu" class="px-container-lg mt:w-80 {{ $base['show_site_menu'] === false ? ' mt:hidden' : '' }}" aria-label="Page menu" tabindex="-1">
     @if(!empty($base['top_menu_output']) && $base['site_menu'] !== $base['top_menu'] && config('base.top_menu_enabled'))
-        @if(!empty($base['top_menu_output']))
+        @if(! empty($base['site_menu_output']))
             <div class="slideout-main-menu mt:hidden">
                 <ul class="main-menu mb-2">
                     <li>


### PR DESCRIPTION
## Reason for Change

The _top menu_ content is hidden and a toggle is present on all pages where a _top menu_ is enable, regardless of whether there is a need to hide its content due to available space or navigation context.

The condition that was in place was checking for a case that would always be true, targeting the presence of the _top menu_ to determine whether to show the _top menu_ toggle, instead of checking if there is a need to truncate the top menu on mobile devices.  By checking for the presence of _site menu_ we can assume more accurately whether there is a need to truncate the _top menu_ and split the two for more clear separation.

---

## Demo / Context

### Links
- Basecamp: [https://3.basecamp.com/5750155/buckets/37389969/todos/9171167316](https://3.basecamp.com/5750155/buckets/37389969/todos/9171167316)
- Front end example (not remediated): [https://train.med.wayne.edu/training-benefits](https://train.med.wayne.edu/training-benefits)

### Screenshots

| Before | After |
|--------|--------|
| <img width="351" height="839" alt="before" src="https://github.com/user-attachments/assets/0fcaeab5-cd33-4c68-a0ae-28848943c786" /> | <img width="412" height="923" alt="Screenshot 2026-02-12 at 7 58 35 AM" src="https://github.com/user-attachments/assets/e961ae9a-4914-4189-9027-514932aa7ada" />
| | <img width="419" height="924" alt="Screenshot 2026-02-12 at 7 58 20 AM" src="https://github.com/user-attachments/assets/07286068-f921-4e22-83b5-65bf6696ab99" /> | 

---



## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- I have added or updated relevant documentation
  - _N/A_
- I have added tests (if applicable)
  - _N/A_
- I have communicated with the team about necessary post-deploy actions
  - _N/A_

---

## Testing Notes

- Go to a **base** site that has a top menu enabled
  - [ ] Confirm that the _top menu_ is present
- Go to a page that has an active site menu
  - [ ] Confirm that the _top menu_ toggle is visible
  - [ ] Confirm that the _top menu_ is present inside the dialog opened by the toggle
- Go to a page that does **NOT** have an active site menu
  - [ ] Confirm that the _top menu_ toggle is **NOT** present
  - [ ] Confirm that the _top menu_ is visible and is **NOT** nested inside of the menu toggle