### PR TITLE
FEATURE | Config - Sites | Allow sub-site surtitle override

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -276,6 +276,8 @@ $global_config = [
             //     ],
             //     'callbacks' => [],
             //     'surtitle_disabled' => null,
+            //     'surtitle' => null,
+            //     'surtitle_url' => null,
             // ],
         ],
     ],

--- a/contracts/Repositories/MenuRepositoryContract.php
+++ b/contracts/Repositories/MenuRepositoryContract.php
@@ -93,4 +93,12 @@ interface MenuRepositoryContract
      * @return array
      */
     public function menuDisplayToggles($menus, $data);
+
+    /**
+     * Get the surtitle.
+     *
+     * @param  array  $site
+     * @return array
+     */
+    public function getSurtitle(array $site);
 }

--- a/resources/views/components/menu-top.blade.php
+++ b/resources/views/components/menu-top.blade.php
@@ -1,23 +1,17 @@
 {{--
     $site => array // ['short-title', 'title', 'subsite-folder']
     $top_menu_output => string // '<ul></ul>'
+    $surtitle => string // 'Lenore & Vollrad Von Berg'
+    $surtitle_url => string // '/natural-histroy'
+    $hasSurtitle => boolean // true
 --}}
-
-@php
-    $hasSurtitle = (
-        (config('base.surtitle') !== null &&
-        ($site['parent']['id'] === null && config('base.surtitle_main_site_enabled') === true) ||
-        ($site['parent']['id'] !== null && config('base.surtitle') !== null)) &&
-        !config('base.global.sites.' . $site['id'] . '.surtitle_disabled')
-    );
-@endphp
 
 <div class="menu-top-container bg-green-600 print:bg-transparent">
     <div class="row flex justify-between">
         <div class="grow-0 mx-4 {{ $hasSurtitle ? 'py-[5px]' : 'py-2' }}" data-short-title="{{ $site['short-title'] }}">
             @if($hasSurtitle)
                 <div class="text-base mb-0 font-normal leading-tight">
-                    <a href="{{ config('base.surtitle_url') }}" class="text-white print:text-black inline-block py-[3px]">{{ config('base.surtitle') }}</a>
+                    <a href="{{ $surtitle_url }}" class="text-white print:text-black inline-block py-[3px]">{{ $surtitle }}</a>
                 </div>
 
                 <div class="font-normal mb-1 text-2xl leading-none">

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    
+
     @if(!empty($base['page']['canonical']))<link rel="canonical" href="{{ $base['page']['canonical'] }}">@endif
 
     @include('components.gtm-head')
@@ -27,7 +27,13 @@
     @include('components.header')
 
     @if(!empty($base['site']))
-        @include('components.menu-top', ['site' => $base['site'], 'top_menu_output' => $base['top_menu_output']])
+        @include('components.menu-top', [
+            'site' => $base['site'],
+            'top_menu_output' => $base['top_menu_output'],
+            'surtitle' => $base['surtitle'],
+            'surtitle_url' => $base['surtitle_url'],
+            'hasSurtitle' => $base['hasSurtitle'],
+        ])
     @endif
 
     @if(!empty($base['flag']))
@@ -37,7 +43,7 @@
 
 <div id="panel" @class(['site-theme', $base['layout_config']['page_class'] ?? ''])>
     @yield('top')
-    
+
     @if(!empty($base['hero']) && (empty($base['hero']['component']['option']) || $base['hero']['component']['option'] != 'Banner contained'))
         @include('components.hero', ['hero' => $base['hero']])
 


### PR DESCRIPTION
## Reason for Change

Currently, there is no means of displaying a custom surtitle on just a single child/sub-site.  For a surtitle to be configured, it must also be shown on the parent/main site at a minimum.

This feature allows for a custom child/sub-site override for the surtitle in the site config.

_Additionally, there is a bit of clean-up for leftover logic inside the `menu-top.blade.php` file that should have gone in the `MenuRepository.php`_

---

## Demo / Context

### Links
- TP3: [https://waynedotedu.tpondemand.com/restui/board.aspx?#page=request/197972](https://waynedotedu.tpondemand.com/restui/board.aspx?#page=request/197972)
- Front-end:
  - [Child site](https://www-dev.museums.wayne.edu/natural-history)
  - [Parent site](https://www-dev.museums.wayne.edu/)

### Demo

| Before | After |
|--------|--------|
| <img width="3801" height="833" alt="before" src="https://github.com/user-attachments/assets/5a9e75b7-d474-47a3-bc32-853ab489a054" /> | <img width="3816" height="1440" alt="after" src="https://github.com/user-attachments/assets/fa2952a1-4850-4528-b765-16228135a374" /> |


---



## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions
