### PR TITLE
FEATURE | Sub-site - Meta Image | Allow sub-sites to set sub-site specific default meta image

### DIFF
--- a/app/Http/Middleware/Data.php
+++ b/app/Http/Middleware/Data.php
@@ -43,8 +43,12 @@ class Data
         }
 
         // Overrides for meta information
-        $data['meta']['image'] = ! empty($page['data']['meta_image']) ? $page['data']['meta_image'] : '';
-        $data['meta']['image_alt'] = ! empty($page['data']['meta_image_alt']) ? $page['data']['meta_image_alt'] : '';
+        $data['meta']['image'] = ! empty($page['data']['meta_image']) ?
+            $page['data']['meta_image'] :
+            (config('base.global.sites.'.$page['site']['id'].'.meta_image') ?? '');
+        $data['meta']['image_alt'] = ! empty($page['data']['meta_image_alt']) ?
+            $page['data']['meta_image_alt'] :
+            (config('base.global.sites.'.$page['site']['id'].'.meta_image_alt') ?? '');
         $page['page']['description'] = ! empty($page['data']['page_description']) ? $page['data']['page_description'] : $page['page']['description'];
         $page['page']['title'] = ! empty($page['data']['page_title']) ? $page['data']['page_title'] : $page['page']['title'];
 

--- a/config/base.php
+++ b/config/base.php
@@ -278,6 +278,8 @@ $global_config = [
             //     'surtitle_disabled' => null,
             //     'surtitle' => null,
             //     'surtitle_url' => null,
+            //     'meta_image' => 'https://site.wayne.edu/opengraph/site-social-share.png',
+            //     'meta_image_alt' => 'Alt text for subsite social share image',
             // ],
         ],
     ],


### PR DESCRIPTION
## Reason for Change

Some sub-sites have different meta images than their parent site, but right now the only way to change this is to set a meta image on every single page.  We needed a way to allow sub-sites to set a default fallback meta image (and corresponding alt text) different from their parent site but that itself could be overwritten by page.

---

## Context

### Links
- Basecamp: [https://3.basecamp.com/5750155/buckets/37389969/todos/9547303577](https://3.basecamp.com/5750155/buckets/37389969/todos/9547303577)

---



### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation