### PR TITLE
Update | Form errors |  Changed error color for accessibility

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -48,8 +48,8 @@
         @apply w-full m-0 mb-4;
     }
 
-    [type='checkbox'] + label[for],
-    [type='radio'] + label[for] {
+    [type='checkbox']+label[for],
+    [type='radio']+label[for] {
         cursor: pointer;
     }
 
@@ -82,7 +82,7 @@
     /* Errors */
     .error {
         p {
-            @apply text-red-500 mx-auto mt-1 mb-4 text-sm;
+            @apply text-red-600 mx-auto mt-1 mb-4 text-sm;
         }
 
         input,
@@ -177,6 +177,6 @@
 
     /* Required */
     label em {
-        @apply text-red-500;
+        @apply text-red-600;
     }
 }


### PR DESCRIPTION

### Reason for Change

The error red did not meet accessibility contrast guidelines. 
---

https://3.basecamp.com/5750155/buckets/37389969/card_tables/cards/9608928570


### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---

| Before | After |
|--------|--------|
| <img width="685" height="414" alt="Screenshot 2026-02-25 at 11 17 30 AM" src="https://github.com/user-attachments/assets/ec9aeefe-9908-43ba-afbf-44317d5385dc" /> | <img width="659" height="365" alt="Screenshot 2026-02-25 at 11 36 31 AM" src="https://github.com/user-attachments/assets/c700fc1e-3f98-4919-afce-a2cf55c30273" /> | 

