### PR TITLE
update:  global hero override test assumption fix

### DIFF
--- a/tests/Unit/Repositories/PromoRepositoryTest.php
+++ b/tests/Unit/Repositories/PromoRepositoryTest.php
@@ -517,7 +517,7 @@ final class PromoRepositoryTest extends TestCase
         $promos = app(PromoRepository::class, ['wsuApi' => $wsuApi])->getRequestData($data);
 
         // Assert that the (empty) modular hero component replaces the global hero
-        $this->assertTrue($promos['hero'] == []);
+        $this->assertEmpty($promos['hero'] ?? []);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for Change
@chrispelzer spotted the test failing when he created a new site off of base.  We found that the issue was that if the site is based off of Base but has an override to remove the hero promo it fails a test that should be irrelevant if it has no default config hero promo.  The fix is to apply nullish coalescing to ensure that we are searching over a broader spectrum of possible empty values that should pass this test.

I also switched the assertion to `assertEmpty()` instead of an `assertTrue()` where the argument was returning true for an empty value.

---

## Demo / Context

| Before | After |
|--------|--------|
| <img width="1145" height="444" alt="before" src="https://github.com/user-attachments/assets/12226a7e-9e30-4234-b04f-0ec0e3418e95" /> | <img width="469" height="202" alt="after" src="https://github.com/user-attachments/assets/53d0c524-2e07-4389-930c-3a43a6981bac" /> | 

---



### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions