### PR TITLE
UPDATE | Hero - Modular & Carousel | Support hero types in carousel layout, only carousel if limit and items for carousel

### DIFF
--- a/app/Repositories/HeroRepository.php
+++ b/app/Repositories/HeroRepository.php
@@ -67,9 +67,35 @@ class HeroRepository implements HeroRepositoryContract
             return $promos;
         }
 
+        // Initialize the hero component if not set
+        $hero['component'] = $hero['component'] ?? [];
+        $hero['component']['heroLayout'] = '';
+
+        // Layout is carousel if the limit is more than 1 and there is more than one hero promo item
         $heroCount = count($hero['data']);
         $heroLimit = (int) ($hero['component']['limit'] ?? 1);
-        $isCarousel = $heroCount > 1 || $heroLimit > 1;
+
+        // If it's a global hero (no component limit set), it should be a carousel if there's more than 1 item
+        if (!isset($hero['component']['limit']) && $heroCount > 1) {
+            $heroLimit = $heroCount;
+        }
+
+        $isCarousel = ($heroCount > 1 && $heroLimit > 1);
+
+        // Check if any promo or component option explicitly sets the carousel
+        if (!$isCarousel) {
+            foreach ($hero['data'] as $hero_data) {
+                $option = strtolower(($hero_data['option'] ?? '') . ' ' . ($hero['component']['option'] ?? ''));
+                if (str_contains($option, 'carousel')) {
+                    $isCarousel = true;
+                    break;
+                }
+            }
+        }
+
+        if ($isCarousel) {
+            $hero['component']['heroLayout'] = 'carousel';
+        }
 
         foreach ($hero['data'] as $hero_key => $hero_data) {
             $promoOption = strtolower($hero_data['option'] ?? '');
@@ -77,39 +103,26 @@ class HeroRepository implements HeroRepositoryContract
             $option = trim($promoOption . ' ' . $componentOption);
             $hero_data['hero_options'] = explode(' ', $option);
 
-            // Determine carousel type from option if not already set by count or limit
-            if (!$isCarousel && str_contains($option, 'carousel')) {
-                $isCarousel = true;
+            // Determine Type
+            $type = $this->mapType($promoOption, $componentOption);
+            if ($type) {
+                $hero['component']['heroType'] = $type;
+                $hero_data['hero_classes'] = 'hero--' . $type;
+            } else {
+                $type = $hero['component']['heroType'] ?? config('base.hero_type') ?? 'large';
+                $hero['component']['heroType'] = $type;
+                $hero_data['hero_classes'] = $type === 'large' ? '' : 'hero--' . $type;
             }
 
+            // If carousel, add the class to the item as well
             if ($isCarousel) {
-                $hero['component']['heroType'] = 'carousel';
-                $hero['component']['heroPlacement'] = 'full-width';
+                $hero_data['hero_classes'] .= ' hero--carousel';
+            }
 
-                // Determine Placement for carousel
-                $placement = $this->mapPlacement($promoOption, $componentOption);
-                if ($placement) {
-                    $hero['component']['heroPlacement'] = $placement;
-                }
-
-                $hero_data['hero_classes'] = '';
-            } else {
-                // Determine Type
-                $type = $this->mapType($promoOption, $componentOption);
-                if ($type) {
-                    $hero['component']['heroType'] = $type;
-                    $hero_data['hero_classes'] = 'hero--' . $type;
-                } else {
-                    $type = $hero['component']['heroType'] ?? config('base.hero_type') ?? 'large';
-                    $hero['component']['heroType'] = $type;
-                    $hero_data['hero_classes'] = $type === 'large' ? '' : 'hero--' . $type;
-                }
-
-                // Determine Placement
-                $placement = $this->mapPlacement($promoOption, $componentOption);
-                if ($placement) {
-                    $hero['component']['heroPlacement'] = $placement;
-                }
+            // Determine Placement
+            $placement = $this->mapPlacement($promoOption, $componentOption);
+            if ($placement) {
+                $hero['component']['heroPlacement'] = $placement;
             }
 
             $hero['data'][$hero_key] = $hero_data;

--- a/resources/scss/components/_hero.scss
+++ b/resources/scss/components/_hero.scss
@@ -190,11 +190,6 @@
 
     &--carousel {
 
-        #{$c}__content,
-        #{$c}__secondary-image {
-            @apply hidden;
-        }
-
         #{$c}__carousel-item {
             @apply max-h-hero;
         }

--- a/resources/views/components/hero-carousel.blade.php
+++ b/resources/views/components/hero-carousel.blade.php
@@ -8,7 +8,7 @@
         @foreach($hero['data'] as $item)
             @if(count($hero['data']) > 1)<div class="hero__carousel-item">@endif
 
-                <div class="hero__type hero--{{ $item['hero_type'] ?? 'banner' }}">
+                <div class="hero__type hero--{{ $item['hero_type'] ?? 'banner' }} {{ $item['hero_classes'] ?? '' }}">
 
                     <img class="hero__primary-image {{ $hero['component']['backgroundClass'] ?? ''}}{{ $loop->first ? '' : ' lazy'}}"
                          @if($loop->first) src="{{ $item['relative_url'] }}" @else data-src="{{ $item['relative_url'] }}"@endif

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -45,7 +45,7 @@
     @yield('top')
 
     @if(!empty($base['hero']) && (!empty($base['hero']['component']['heroPlacement']) && $base['hero']['component']['heroPlacement'] != 'contained'))
-        @if(($base['hero']['component']['heroType'] ?? '') === 'carousel')
+        @if(($base['hero']['component']['heroLayout'] ?? '') === 'carousel')
             @include('components.hero-carousel', ['hero' => $base['hero'], 'class' => 'hero--full-width'])
         @else
             @include('components.hero', ['hero' => $base['hero'], 'class' => 'hero--full-width'])
@@ -60,7 +60,7 @@
         <main class="content-area mx-auto w-full {{ $base['show_site_menu'] === true ? 'max-w-[900px]' : 'max-w-[75rem]' }} {{ (in_array($base['page']['controller'], config('base.full_width_controllers'))) ? ' max-w-full' : '' }}" tabindex="-1">
 
             @if(!empty($base['hero']) && (!empty($base['hero']['component']['heroPlacement']) && $base['hero']['component']['heroPlacement'] === 'contained'))
-                @if(($base['hero']['component']['heroType'] ?? '') === 'carousel')
+                @if(($base['hero']['component']['heroLayout'] ?? '') === 'carousel')
                     @include('components.hero-carousel', ['hero' => $base['hero'], 'class' => 'hero--contained'])
                 @else
                     @include('components.hero', ['hero' => $base['hero'], 'class' => 'hero--contained'])

--- a/styleguide/Http/Controllers/ComponentHeroController.php
+++ b/styleguide/Http/Controllers/ComponentHeroController.php
@@ -85,6 +85,7 @@ class ComponentHeroController extends Controller
         $title = $data['page']['title'] ?? '';
 
         $hero_type = $data['base']['hero']['component']['heroType'] ?? '';
+        $hero_layout = $data['base']['hero']['component']['heroLayout'] ?? '';
         $hero_placement = $data['base']['hero']['component']['heroPlacement'] ?? '';
 
         // If page data is missing, check hero data (common on styleguide pages)
@@ -105,7 +106,7 @@ class ComponentHeroController extends Controller
             'large' => ['option' => 'large'],
             'slim' => ['option' => 'small'],
             'split' => ['option' => 'half'],
-            'carousel' => ['limit' => 3],
+            'buttons' => ['option' => 'buttons'],
         ];
 
         if (isset($type_map[$hero_type])) {
@@ -113,11 +114,15 @@ class ComponentHeroController extends Controller
             $limit = $type_map[$hero_type]['limit'] ?? $limit;
         }
 
+        if ($hero_layout === 'carousel') {
+            $limit = 3;
+        }
+
         if ($hero_placement === 'contained') {
             $option .= ($option !== '' ? ' ' : '').'contained';
         }
 
-        if ($hero_type === 'carousel' && $hero_placement !== 'contained') {
+        if ($hero_layout === 'carousel' && $hero_placement !== 'contained') {
             $option .= ($option !== '' ? ' ' : '').'full';
         }
 

--- a/tests/Unit/Repositories/HeroRepositoryTest.php
+++ b/tests/Unit/Repositories/HeroRepositoryTest.php
@@ -26,6 +26,7 @@ final class HeroRepositoryTest extends TestCase
     #[Test]
     public function carousel_hero_with_multiple_promos(): void
     {
+        config(['base.hero_placement' => 'full-width']);
         $promos = [
             'hero' => [
                 ['title' => 'Hero 1', 'option' => ''],
@@ -33,9 +34,10 @@ final class HeroRepositoryTest extends TestCase
             ]
         ];
         $result = $this->heroRepository->setHero($promos, []);
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('slim', $result['hero']['component']['heroType']);
         $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
-        $this->assertEquals('', $result['hero']['data'][0]['hero_classes']);
+        $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
+        $this->assertEquals('hero--slim hero--carousel', $result['hero']['data'][0]['hero_classes']);
         $this->assertArrayHasKey('hero_options', $result['hero']['data'][0]);
     }
 
@@ -49,8 +51,9 @@ final class HeroRepositoryTest extends TestCase
             ]
         ];
         $result = $this->heroRepository->setHero($promos, []);
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('slim', $result['hero']['component']['heroType']);
         $this->assertEquals('contained', $result['hero']['component']['heroPlacement']);
+        $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
     }
 
     #[Test]
@@ -69,8 +72,9 @@ final class HeroRepositoryTest extends TestCase
             ]
         ];
         $result = $this->heroRepository->setHero($promos, []);
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('slim', $result['hero']['component']['heroType']);
         $this->assertEquals('contained', $result['hero']['component']['heroPlacement']);
+        $this->assertEquals('', $result['hero']['component']['heroLayout']);
     }
 
     #[Test]
@@ -472,7 +476,7 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
 
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
         $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
         $this->assertCount(2, $result['hero']['data']);
     }
@@ -495,8 +499,7 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
 
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
-        $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
+        $this->assertEquals('buttons', $result['hero']['component']['heroType']);
         $this->assertCount(1, $result['hero']['data']);
     }
 
@@ -518,8 +521,8 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
 
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
-        $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
+        $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
+        $this->assertEquals('contained', $result['hero']['component']['heroPlacement']);
     }
 
     #[Test]
@@ -534,7 +537,7 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
 
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('slim', $result['hero']['component']['heroType']);
         $this->assertEquals('/logo.svg', $result['hero']['data'][0]['secondary_relative_url']);
     }
 
@@ -561,9 +564,10 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
 
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('slim', $result['hero']['component']['heroType']);
         $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
-        $this->assertEquals('', $result['hero']['data'][0]['hero_classes']);
+        $this->assertEquals('', $result['hero']['component']['heroLayout']);
+        $this->assertEquals('hero--slim', $result['hero']['data'][0]['hero_classes']);
     }
 
     #[Test]
@@ -575,7 +579,7 @@ final class HeroRepositoryTest extends TestCase
             ]
         ];
         $result = $this->heroRepository->setHero($promos, []);
-        $this->assertEquals('carousel', $result['hero']['component']['heroType']);
+        $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
     }
 
     #[Test]
@@ -600,7 +604,7 @@ final class HeroRepositoryTest extends TestCase
         $promos = $this->heroRepository->setHero($promos, []);
 
         $this->assertCount(4, $promos['hero']['data']);
-        $this->assertEquals('carousel', $promos['hero']['component']['heroType']);
+        $this->assertEquals('slim', $promos['hero']['component']['heroType']);
         $this->assertEquals('full-width', $promos['hero']['component']['heroPlacement']);
     }
 
@@ -630,7 +634,7 @@ final class HeroRepositoryTest extends TestCase
         $promos = $this->heroRepository->setHero($promos, []);
 
         // It should be a carousel
-        $this->assertEquals('carousel', $promos['hero']['component']['heroType']);
+        $this->assertEquals('slim', $promos['hero']['component']['heroType']);
 
         // Check the count of data items. If HeroRepository doesn't slice, it will be 4.
         // The user says there's only 1 item, but they EXPECT 3.
@@ -657,7 +661,7 @@ final class HeroRepositoryTest extends TestCase
         $promos = $this->heroRepository->setHero($promos, []);
 
         $this->assertCount(4, $promos['hero']['data']);
-        $this->assertEquals('carousel', $promos['hero']['component']['heroType']);
+        $this->assertEquals('slim', $promos['hero']['component']['heroType']);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for Change
[The hero refactor that I had previously done](https://github.com/waynestate/base-site/pull/882), did not account for cases where `limit > 1` had been set but there was only a single hero promotion item, or support for all of the custom hero types in carousels (both full and contained).  I've accounted for these cases with these updates.

---

## Demo / Context

### Relevant Links
- https://3.basecamp.com/5750155/buckets/37389969/card_tables/cards/9675227239#__recording_9679491348

| Before | After |
|--------|--------|
| <img width="3085" height="1183" alt="before - limit higher than number items" src="https://github.com/user-attachments/assets/8434e6a3-ad40-489a-a70f-0d16a8f0d4c5" />  <img width="3148" height="909" alt="before - no type support" src="https://github.com/user-attachments/assets/4f8bbe51-c048-4944-8a2d-0e8c0d24a89e" /> | <img width="3169" height="1272" alt="after - carousel limt only 1 item contained support types" src="https://github.com/user-attachments/assets/454a6b35-9b36-4f9e-bdbc-5154466a6e64" /> <img width="3577" height="1264" alt="after - carousel limit only 1 item" src="https://github.com/user-attachments/assets/baf6c033-8fec-48b2-8a61-687ac0b63757" /> <img width="3584" height="1381" alt="after - carousel support types" src="https://github.com/user-attachments/assets/5613d840-21e7-476e-984f-81beff6966d1" /> <img width="2987" height="1158" alt="after - carousel contained supporttypes" src="https://github.com/user-attachments/assets/408c9a32-72fd-434c-80c0-be73f4ba4d08" /> <img width="637" height="614" alt="after - tests HeroRepositoryTest" src="https://github.com/user-attachments/assets/556d7031-57e5-45a7-a4c6-37bff7f33e6c" /> <img width="345" height="61" alt="after - tests all" src="https://github.com/user-attachments/assets/24b188f8-0be0-4261-bb38-b2924141c61e" /> | 

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

