### PR TITLE
Feature | Accessibility | Anchor elements with multiple sub-elements now have accessible names

### DIFF
--- a/resources/views/components/events-featured-column.blade.php
+++ b/resources/views/components/events-featured-column.blade.php
@@ -2,11 +2,12 @@
     @if(!empty($data))
         @foreach($data as $item)
             <li class="mb-6">
-                <a href="{{$item['url']}}" class="flex w-full group">
+                @php $titleId = 'event-' . $item['event_id']; @endphp
+                <a href="{{$item['url']}}" class="flex w-full group" aria-labelledby="{{ $titleId }}">
                     <div class="w-1/3 shrink-0">
                         <img data-src="{{$item['display_image']['full_url']}}" alt="{{($item['display_image']['description']) ? $item['display_image']['description'] : ''}}" class="lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
                     </div>
-                    <div class="ml-4 pt-3 font-bold">
+                    <div class="ml-4 pt-3 font-bold" id="{{ $titleId }}">
                         @if(!empty($item['date']))
                             <div class="text-sm uppercase mb-1">{{ date('F j', strtotime($item['date'])) }}</div>
                         @endif

--- a/resources/views/components/events-featured-row.blade.php
+++ b/resources/views/components/events-featured-row.blade.php
@@ -1,12 +1,13 @@
-<ul class="grid gap-4 {{ !empty($component['columns']) && $component['columns'] % 2 == 0 ? (count($data) >= 4 ? ' sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-'.($component['columns']) : ' md:grid-cols-'.$component['columns']) : (count($data) >= 3 ? ' sm:grid-cols-1 md:grid-cols-3' : ' md:grid-cols-'.$component['columns']) }}"> 
+<ul class="grid gap-4 {{ !empty($component['columns']) && $component['columns'] % 2 == 0 ? (count($data) >= 4 ? ' sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-'.($component['columns']) : ' md:grid-cols-'.$component['columns']) : (count($data) >= 3 ? ' sm:grid-cols-1 md:grid-cols-3' : ' md:grid-cols-'.$component['columns']) }}">
     @if(!empty($data))
         @foreach($data as $item)
             <li>
-                <a href="{{$item['url']}}" class="block w-full group">
+                @php $titleId = 'event-' . $item['event_id']; @endphp
+                <a href="{{$item['url']}}" class="block w-full group" aria-labelledby="{{ $titleId }}">
                     <div class="w-full">
                         <img data-src="{{$item['display_image']['full_url']}}" alt="{{($item['display_image']['description']) ? $item['display_image']['description'] : ''}}" class="lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
                     </div>
-                    <div class="mt-2 font-bold">
+                    <div class="mt-2 font-bold" id="{{ $titleId }}">
                         @if(!empty($item['date']))
                             <div class="text-sm uppercase mb-1">{{ date('F j', strtotime($item['date'])) }}</div>
                         @endif

--- a/resources/views/components/icons-column.blade.php
+++ b/resources/views/components/icons-column.blade.php
@@ -4,14 +4,15 @@
 <ul class="grid grid-cols-1 items-start gap-6 lg:gap-8 mt-2 mb-8 lg:my-8">
     @foreach($data as $item)
         <li>
+            @php $titleId = 'promo-' . $item['promo_item_id']; @endphp
             @if (!empty($item['link']))
-                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group">
+                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group" aria-labelledby="{{ $titleId }}">
             @else
                 <div class="flex items-start gap-x-4">
             @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'grow-0 shrink-0 w-16')
                 <div>
-                    <div class="font-bold text-xl mt-0 mb-1 text-green no-underline group-hover:underline">{{ $item['title'] }}</div>
+                    <div id="{{ $titleId }}" class="font-bold text-xl mt-0 mb-1 text-green no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
                         @if (!empty($item['link']))

--- a/resources/views/components/icons-row.blade.php
+++ b/resources/views/components/icons-row.blade.php
@@ -4,14 +4,15 @@
 <ul class="grid items-start gap-6 lg:gap-8 mt-2 mb-8 lg:my-8 md:grid-cols-2 lg:grid-cols-{{ !empty($component['columns']) && $component['columns'] >= 3 ? '3' : '2' }} xl:grid-cols-{{ !empty($component['columns']) ? $component['columns'] : '2' }}">
     @foreach($data as $item)
         <li>
+            @php $titleId = 'promo-' . $item['promo_item_id']; @endphp
             @if (!empty($item['link']))
-                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group">
+                <a href="{{ $item['link'] }}" class="flex items-start gap-x-4 group" aria-labelledby="{{ $titleId }}">
             @else
                 <div class="flex items-start gap-x-4">
             @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'grow-0 shrink-0 w-16 '.(!empty($component['columns']) && $component['columns'] >= 3 ? ' xl:w-16' : ' xl:w-20'))
                 <div>
-                    <div class="font-bold text-xl xl:text-2xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
+                    <div id="{{ $titleId }}" class="font-bold text-xl xl:text-2xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm lg:text-base text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
                         @if (!empty($item['link']))

--- a/resources/views/components/icons-top-row.blade.php
+++ b/resources/views/components/icons-top-row.blade.php
@@ -4,14 +4,15 @@
 <ul class="grid items-start gap-6 gap-y-2 lg:gap-8 lg:gap-y-4 grid-cols-2 lg:grid-cols-{{ !empty($component['columns']) && count($data) % 2 == 0 ? '2' : '3' }} xl:grid-cols-{{ !empty($component['columns']) ? $component['columns'] : '2' }}">
     @foreach($data as $item)
         <li>
+            @php $titleId = 'promo-' . $item['promo_item_id']; @endphp
             @if (!empty($item['link']))
-                <a href="{{ $item['link'] }}" class="text-center group">
+                <a href="{{ $item['link'] }}" class="text-center group" aria-labelledby="{{ $titleId }}">
             @else
                 <div class="text-center">
             @endif
                 @image($item['relative_url'], $item['filename_alt_text'], 'block mx-auto grow-0 shrink-0 mb-2 w-16'.(!empty($component['columns']) && $component['columns'] >= 5 ? ' xl:w-16' : ' xl:w-20'))
                 <div>
-                    <div class="font-bold text-xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
+                    <div id="{{ $titleId }}" class="font-bold text-xl mt-0 mb-1 no-underline group-hover:underline">{{ $item['title'] }}</div>
                     @if(!empty($item['excerpt']))<div class="text-sm text-black">{{ $item['excerpt'] }}</div>@endif
                     @if(!empty($item['description']))
                         @if (!empty($item['link']))

--- a/resources/views/components/news-featured-column.blade.php
+++ b/resources/views/components/news-featured-column.blade.php
@@ -6,22 +6,23 @@
 @if(!empty($data))
     <ul>
         @foreach($data as $item)
+            @php $titleId = 'news-' . $item['id']; @endphp
             @if($loop->iteration === 1)
                 <li class="bg-green-800">
-                    <a href="{{ $item['link'] }}" class="relative block mb-6 group">
+                    <a href="{{ $item['link'] }}" class="relative block mb-6 group" aria-labelledby="{{ $titleId }}">
                         <img class="lazy w-full" data-src="{{ $item['featured']['url'] ?? 'https://wayne.edu/opengraph/wsu-social-share.png' }}" alt="{{ $item['featured']['alt_text'] ?? "Wayne State University" }}">
                         <div class="bg-gradient-darkest absolute inset-x-0 bottom-0">
-                            <div class="w-full text-white font-bold relative text-xl p-4 pt-8 group-hover:underline">{{ $item['title'] }}</div>
+                            <div id="{{ $titleId }}" class="w-full text-white font-bold relative text-xl p-4 pt-8 group-hover:underline">{{ $item['title'] }}</div>
                         </div>
                     </a>
                 </li>
             @else
                 <li>
-                    <a href="{{ $item['link'] }}" class="flex mb-6 group">
+                    <a href="{{ $item['link'] }}" class="flex mb-6 group" aria-labelledby="{{ $titleId }}">
                         <div class="shrink-0 w-1/2 pr-4">
                             <img class="lazy" data-src="{{ $item['featured']['url'] ?? 'https://wayne.edu/opengraph/wsu-social-share.png' }}" alt="{{ $item['featured']['alt_text'] ?? "Wayne State University" }}">
                         </div>
-                        <div class="font-bold group-hover:underline">{{ $item['title'] }}</div>
+                        <div id="{{ $titleId }}" class="font-bold group-hover:underline">{{ $item['title'] }}</div>
                     </a>
                 </li>
             @endif

--- a/resources/views/components/news-row.blade.php
+++ b/resources/views/components/news-row.blade.php
@@ -9,9 +9,10 @@
     <ul class="grid gap-x-6 gap-y-4 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-{{ !empty($component['limit']) ? $component['limit'] : '4' }}">
         @foreach($data as $item)
             <li class="group flex items-start md:block">
-                <a class="group-hover:no-underline flex items-start md:block" href="{{ $item['link'] }}">
+                @php $titleId = 'news-' . $item['id']; @endphp
+                <a class="group-hover:no-underline flex items-start md:block" href="{{ $item['link'] }}" aria-labelledby="{{ $titleId }}">
                     @image($item['featured']['url'] ?? 'https://wayne.edu/opengraph/wsu-social-share.png', $item['featured']['alt_text'] ?? 'Wayne State University', 'block lazy w-1/3 shrink-0 mr-2 mb-2 md:w-full md:mr-0 md:shrink')
-                    <p class="group-hover:underline leading-snug font-bold">{{ $item['title'] }}</p>
+                    <p id="{{ $titleId }}" class="group-hover:underline leading-snug font-bold">{{ $item['title'] }}</p>
                 </a>
             </li>
         @endforeach

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -1,11 +1,12 @@
 {{--
 $profile => array // ['First Name, Last Name, Title, link']
 --}}
-<a href="{{ $profile['link'] }}" class="group">
+@php $titleId = 'profile-' . $profile['data']['AccessID']; @endphp
+<a href="{{ $profile['link'] }}" class="group" aria-labelledby="{{ $titleId }}">
     <div class="aspect-portrait mb-1">
         @image(!empty($profile['data']['Picture']['url']) ? $profile['data']['Picture']['url'] : '/_resources/images/no-photo.svg', '', 'h-full w-full object-cover object-center')
     </div>
-    <div class="underline group-hover:no-underline group-focus:no-underline font-bold">{{ $profile['full_name'] }}</div>
+    <div id="{{ $titleId }}" class="underline group-hover:no-underline group-focus:no-underline font-bold">{{ $profile['full_name'] }}</div>
     @if(!empty($profile['data']['Title']))
         <div class="text-black text-sm">{!! strip_tags($profile['data']['Title'], '<br>') !!}</div>
     @endif

--- a/resources/views/components/promo/grid-item.blade.php
+++ b/resources/views/components/promo/grid-item.blade.php
@@ -3,8 +3,9 @@
     $item => array // ['title', 'link', 'description', 'excerpt', 'relative_url', 'option']
 --}}
 
+@php $titleId = isset($item['promo_item_id']) ? 'promo-' . $item['promo_item_id'] : null; @endphp
 @if (!empty($item['link']))
-    <a href="{{ $item['link'] }}" class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} group">
+    <a href="{{ $item['link'] }}" class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} group" @if($titleId) aria-labelledby="{{ $titleId }}" @endif>
 @else
     <div class="block {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'bg-green-800 relative overflow-hidden' : '' }} {{ $loop->last != true && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6 mb-8' : '' }}">
 @endif
@@ -26,11 +27,11 @@
         <div class="content {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'white-links text-white relative p-4 pt-20 drop-shadow-px' : '' }}">
             @if(! empty($item['title']))
                 @if(!empty($item['youtube_id']) || !empty($item['relative_url']))
-                    <div class="my-1 font-bold {{ !empty($component['columns']) ? ($component['columns'] < 4 ? 'text-lg' : 'text-base') : 'text-xl' }} group-hover:underline group-focus:underline leading-snug xl:leading-tight">
+                    <div @if($titleId) id="{{ $titleId }}" @endif class="my-1 font-bold {{ !empty($component['columns']) ? ($component['columns'] < 4 ? 'text-lg' : 'text-base') : 'text-xl' }} group-hover:underline group-focus:underline leading-snug xl:leading-tight">
                         {{ $item['title'] }}
                     </div>
                 @else
-                    @include('partials/heading', ['heading' => $item['title'], 'headingLevel' => $component['headingLevel'] ?? 'h3', 'headingClass' => (!empty($component['columns']) ? ($component['columns'] < 3 ? 'text-2xl' : 'text-xl') : 'text-2xl').' group-hover:underline group-focus:underline leading-snug xl:leading-tight '.($component['headingClass'] ?? '')])
+                    @include('partials/heading', ['heading' => $item['title'], 'headingLevel' => $component['headingLevel'] ?? 'h3', 'headingId' => $titleId, 'headingClass' => (!empty($component['columns']) ? ($component['columns'] < 3 ? 'text-2xl' : 'text-xl') : 'text-2xl').' group-hover:underline group-focus:underline leading-snug xl:leading-tight '.($component['headingClass'] ?? '')])
                 @endif
             @endif
             <div class="{{ !empty($component['columns']) ? ($component['columns'] < 4 ? ($component['columns'] < 3 ? 'text-base md:text-base' : 'text-base md:text-sm xl:text-base') : 'text-sm') : 'text-base' }} {{ !empty($component['gradientOverlay']) && $component['gradientOverlay'] === true ? 'xl:leading-tight' : 'text-black'}}">

--- a/resources/views/components/promo/list-item.blade.php
+++ b/resources/views/components/promo/list-item.blade.php
@@ -3,13 +3,14 @@
     $item => array // ['title', 'link', 'description', 'excerpt', 'relative_url', 'option']
 --}}
 
+@php $titleId = isset($item['promo_item_id']) ? 'promo-' . $item['promo_item_id'] : null; @endphp
 @if (!empty($item['link']))
-    <a href="{{ $item['link'] }}" class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 group {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}">
+    <a href="{{ $item['link'] }}" class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 group {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}" @if($titleId) aria-labelledby="{{ $titleId }}" @endif>
 @else
     <div class="block {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'flex items-start' : 'md:flex xl:items-center' }} gap-x-3 lg:gap-x-6 {{ $loop->iteration > 1 && !empty($component['filename']) && $component['filename'] != 'catalog' ? 'mt-6' : '' }}">
 @endif
     @if(!empty($item['youtube_id']) || !empty($item['relative_url']))
-        <div class="shrink-0 grow-0 {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'w-1/4' : 'md:w-2/5' }}  
+        <div class="shrink-0 grow-0 {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? 'w-1/4' : 'md:w-2/5' }}
             @if(!empty($component['imagePosition']) && ($component['imagePosition'] === 'right' || ($component['imagePosition'] === 'alternate' && $loop->even))) md:order-2 @endif">
             @if(!empty($item['youtube_id']))
                 <div class="play-video-button">
@@ -28,15 +29,15 @@
     <div class="content w-full">
         @if(! empty($item['title']))
             @if(!empty($item['youtube_id']) || !empty($item['relative_url']))
-                <div class="mb-1 font-bold group-hover:underline group-focus:underline leading-tight text-lg lg:text-xl {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? '' : 'mt-2 lg:mt-0' }}">{{ $item['title'] }}</div>
+                <div @if($titleId) id="{{ $titleId }}" @endif class="mb-1 font-bold group-hover:underline group-focus:underline leading-tight text-lg lg:text-xl {{ !empty($component['imageSize']) && $component['imageSize'] === 'small' ? '' : 'mt-2 lg:mt-0' }}">{{ $item['title'] }}</div>
             @else
-                @include('partials/heading', ['heading' => $item['title'], 'headingLevel' => $component['headingLevel'] ?? 'h3', 'headingClass' => (!empty($component['columns']) ? ($component['columns'] < 3 ? 'text-2xl' : 'text-xl') : 'text-2xl').' group-hover:underline group-focus:underline leading-snug xl:leading-tight '.($component['headingClass'] ?? '')])
+                @include('partials/heading', ['heading' => $item['title'], 'headingLevel' => $component['headingLevel'] ?? 'h3', 'headingId' => $titleId, 'headingClass' => (!empty($component['columns']) ? ($component['columns'] < 3 ? 'text-2xl' : 'text-xl') : 'text-2xl').' group-hover:underline group-focus:underline leading-snug xl:leading-tight '.($component['headingClass'] ?? '')])
             @endif
         @endif
         <div class="text-black">
             @if(!empty($item['excerpt']))
                 <p class="my-1">{!! strip_tags($item['excerpt'], ['em', 'strong', 'br', '&ldquo;', '&rdquo;']) !!}</p>
-            @endif 
+            @endif
             @if(!empty($item['description']))
                 @if (!empty($item['link']))
                     <div>{!! preg_replace(['"<a href(.*?)>"', '"</a>"'], '', $item['description']) !!}</div>

--- a/resources/views/components/spotlight-column.blade.php
+++ b/resources/views/components/spotlight-column.blade.php
@@ -2,8 +2,9 @@
     $data => array // ['title', 'excerpt', 'description', 'relative_url', 'filename_alt_text', 'link']
 --}}
 @foreach($data as $item)
+    @php $titleId = 'promo-' . $item['promo_item_id']; @endphp
     @if (!empty($item['link']))
-        <a href="{{ $item['link'] }}" class="group">
+        <a href="{{ $item['link'] }}" class="group" aria-labelledby="{{ $titleId }}">
     @else
         <div>
     @endif
@@ -29,7 +30,7 @@
                         </div>
                     </div>
                     <cite class="not-italic">
-                        <span class="block font-bold mb-0 text-lg {{ !empty($item['link']) ? 'group-hover:underline' : '' }}">{{ $item['title'] }}</span>
+                        <span id="{{ $titleId }}" class="block font-bold mb-0 text-lg {{ !empty($item['link']) ? 'group-hover:underline' : '' }}">{{ $item['title'] }}</span>
                         @if(!empty($item['description']) && !empty($item['excerpt']) && !empty($component['showDescription']) && $component['showDescription'] === true)
                             <span class="block text-black">{!! strip_tags($item['excerpt'], ['em', 'strong', 'br', '&ldquo;', '&rdquo;']) !!}</span>
                         @endif

--- a/resources/views/components/spotlight-row.blade.php
+++ b/resources/views/components/spotlight-row.blade.php
@@ -2,8 +2,9 @@
     $data => array // ['title', 'excerpt', 'description', 'relative_url', 'filename_alt_text', 'link']
 --}}
 @foreach($data as $item)
+    @php $titleId = 'promo-' . $item['promo_item_id']; @endphp
     @if (!empty($item['link']))
-        <a href="{{ $item['link'] }}" class="group">
+        <a href="{{ $item['link'] }}" class="group" aria-labelledby="{{ $titleId }}">
     @else
         <div>
     @endif
@@ -30,7 +31,7 @@
                         </div>
                     </div>
                     <cite class="not-italic">
-                        <span class="block font-bold mb-0 text-lg xl:text-xl group-hover:underline">{{ $item['title'] }}</span>
+                        <span id="{{ $titleId }}" class="block font-bold mb-0 text-lg xl:text-xl group-hover:underline">{{ $item['title'] }}</span>
                         @if(!empty($item['description']) && !empty($item['excerpt']) && !empty($component['showDescription']) && $component['showDescription'] === true)
                             <span class="block text-black 2xl:text-lg">{!! strip_tags($item['excerpt'], ['em', 'strong', 'br', '&ldquo;', '&rdquo;']) !!}</span>
                         @endif

--- a/resources/views/partials/heading.blade.php
+++ b/resources/views/partials/heading.blade.php
@@ -1,14 +1,16 @@
 {{--
     "heading":"Heading text",
     "headingLevel":["h2", "h3", "h4"],
-    "headingClass":"text-green divider-gold"
+    "headingClass":"text-green divider-gold",
+    "headingId":"optional-id-override"
 --}}
+@php $headingId = $headingId ?? Str::slug($heading); @endphp
 @if (!empty($headingLevel) && strtolower($headingLevel) != 'h1')
-    <{{ $headingLevel }} id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
+    <{{ $headingLevel }} id="{{ $headingId }}" class="{{ $headingClass ?? '' }}">
         {!! strip_tags($heading, ['em', 'strong']) !!}
     </{{ $headingLevel }}>
 @else
-    <h2 id="{{ Str::slug($heading) }}" class="{{ $headingClass ?? '' }}">
+    <h2 id="{{ $headingId }}" class="{{ $headingClass ?? '' }}">
         {!! strip_tags($heading, ['em', 'strong']) !!}
     </h2>
 @endif

--- a/tests/Feature/AccessibleLinkNamesTest.php
+++ b/tests/Feature/AccessibleLinkNamesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AccessibleLinkNamesTest extends TestCase
+{
+    #[Test]
+    public function promo_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/component/singlepromo');
+        $content = $response->content();
+
+        // GenericPromo factory produces promo_item_id starting at 0
+        $this->assertStringContainsString('id="promo-0"', $content);
+        $this->assertStringContainsString('aria-labelledby="promo-0"', $content);
+    }
+
+    #[Test]
+    public function icon_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/component/icons');
+        $content = $response->content();
+
+        // Icon factory produces promo_item_id starting at 1
+        $this->assertStringContainsString('id="promo-1"', $content);
+        $this->assertStringContainsString('aria-labelledby="promo-1"', $content);
+    }
+
+    #[Test]
+    public function news_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/component/articlelisting');
+        $content = $response->content();
+
+        // ArticleComponent factory produces id starting at 1
+        $this->assertStringContainsString('id="news-1"', $content);
+        $this->assertStringContainsString('aria-labelledby="news-1"', $content);
+    }
+
+    #[Test]
+    public function event_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/component/eventlisting');
+        $content = $response->content();
+
+        // EventFullListing factory produces event_id starting at 1
+        $this->assertStringContainsString('id="event-1"', $content);
+        $this->assertStringContainsString('aria-labelledby="event-1"', $content);
+    }
+
+    #[Test]
+    public function spotlight_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/component/spotlight');
+        $content = $response->content();
+
+        // GenericPromo (used for the linked spotlight) produces promo_item_id starting at 0
+        $this->assertStringContainsString('id="promo-0"', $content);
+        $this->assertStringContainsString('aria-labelledby="promo-0"', $content);
+    }
+
+    #[Test]
+    public function profile_links_have_aria_labelledby_pointing_to_title_id(): void
+    {
+        $response = $this->call('GET', '/styleguide/profiles');
+        $content = $response->content();
+
+        // Profile AccessID is two letters + four digits (e.g. ab1234)
+        $this->assertMatchesRegularExpression('/id="profile-[a-z]{2}\d{4}"/', $content);
+        $this->assertMatchesRegularExpression('/aria-labelledby="profile-[a-z]{2}\d{4}"/', $content);
+    }
+}


### PR DESCRIPTION
## Reason for change

Sites using anchor elements with multiple child elements (headings, images, descriptions) cause run-on sentences for screenreader users as it reads the entire contents of the anchor.

There are CSS techniques to work around this, but in the meantime, let's correct this for all sites using the standard components.

---

Each anchor wrapping card content (image + title + excerpt/description) now has aria-labelledby pointing to the id on the title element inside it, so screen readers announce the link using only the visible title text rather than the full card content.

### ID strategy

- `promo-{promo_item_id}` - spotlights, icons, single/catalog promos
- `news-{id}`- news row and featured news column
- `event-{event_id}` - featured event components
- `profile-{AccessID}` - profile grid

The heading partial accepts an optional `headingId` override so the ID can be passed through to title elements rendered via that partial.

---

## Catalog (current left vs updated right)

<img width="2212" height="756" alt="Screenshot 2026-03-25 at 6 12 17 AM" src="https://github.com/user-attachments/assets/adafbc9e-735e-40cd-b05b-b50b42c3f51d" />

## Events

<img width="2224" height="706" alt="Screenshot 2026-03-25 at 6 12 06 AM" src="https://github.com/user-attachments/assets/4daee0d4-77ec-4de5-9efc-3c98a14646a4" />

## Icons

<img width="1926" height="704" alt="Screenshot 2026-03-25 at 6 12 27 AM" src="https://github.com/user-attachments/assets/c205baf5-3003-46dd-bbe5-7d7d14372149" />

## Featured news

<img width="2040" height="758" alt="Screenshot 2026-03-25 at 6 12 38 AM" src="https://github.com/user-attachments/assets/5c0f4679-50d1-4c9e-8cb1-08a4aafab00c" />

## Spotlight

<img width="1928" height="650" alt="Screenshot 2026-03-25 at 6 12 47 AM" src="https://github.com/user-attachments/assets/bf510534-da6d-40c5-9474-39738b72514d" />

## Profiles

<img width="2024" height="696" alt="Screenshot 2026-03-25 at 6 12 56 AM" src="https://github.com/user-attachments/assets/1b702128-9535-4f3b-aa9d-cf6bcb40b492" />


---

## Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

---

## Testing

- [x] Mac, Safari & VoiceOver
- [ ] Windows, Edge & NVDA