### PR TITLE
UPDATE | config/base.php | Hero contained defaults and tests

### DIFF
--- a/config/base.php
+++ b/config/base.php
@@ -55,7 +55,7 @@ $global_config = [
     | ];
     |
     */
-    'hero_placement' => 'full-width',
+    'hero_placement' => 'contained',
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Unit/Repositories/HeroRepositoryTest.php
+++ b/tests/Unit/Repositories/HeroRepositoryTest.php
@@ -521,7 +521,7 @@ final class HeroRepositoryTest extends TestCase
 
         $result = $this->heroRepository->setHero($promos, []);
         $this->assertEquals('carousel', $result['hero']['component']['heroLayout']);
-        $this->assertEquals('full-width', $result['hero']['component']['heroPlacement']);
+        $this->assertEquals('contained', $result['hero']['component']['heroPlacement']);
     }
 
     #[Test]


### PR DESCRIPTION
## Reason for Change

I made an assumption (#919) based on incoming support requests that `full-width` and `banner` hero is the expected default.  After further discussion with @nickdenardis I believe that this was premature.

### "Banner" type
The "Slim" type hero is a new feature, so it was correct to set the "banner" type hero; we'll be keeping that as the default

### "Contained" placement
The "Contained" placement is our default, and we'll update individual sites that expect a full-width hero as they are reported.  The problem with enforcing "full width" onto sites that currently assume "contained" is that their hero images may be sized incorrectly causing fuzzy/low resolution images to be present.

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions