### PR TITLE
Fix | Profiles | Profile group dropdown is now always visible if a group is selected

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -163,7 +163,7 @@ class ProfileRepository implements ProfileRepositoryContract
         }
 
         // Hide filtering if all profiles belong to the same group
-        if (!$options['hide_filtering'] && !empty($profiles['profiles'])) {
+        if (empty($selected_group) && !$options['hide_filtering'] && !empty($profiles['profiles'])) {
             $unique_groups = $this->getUniqueGroupsFromProfiles($profiles['profiles']);
             if (count($unique_groups) <= 1) {
                 $options['hide_filtering'] = true;


### PR DESCRIPTION
## Reason for Change

The previous code didn't take into account the selected state for a group of profiles.

The updated code now only hides the dropdown in these two cases:
- All profiles on a page are in a single group
- There is a `forced_profile_group_id` from the site or page config

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

---

## Demo

| Before | After |
|--------|------|
| ![before](https://github.com/user-attachments/assets/e233ab3d-c8df-4027-b8ff-a04152b24153) | ![after](https://github.com/user-attachments/assets/d7b5f231-da0c-4fc1-9113-74562e2cf9cf) |