### PR TITLE
Fix | Top Bar | Cleaned up remaining .menu-top-container references

### DIFF
--- a/resources/js/modules/anchor.js
+++ b/resources/js/modules/anchor.js
@@ -13,8 +13,7 @@
         var hash = window.location.hash.substring(1);
 
         if(hash !== '' && document.getElementById(hash)) {
-            let y = offset((document.getElementById(hash))).top - document.querySelector('.menu-top-container').offsetHeight;
-
+            let y = offset((document.getElementById(hash))).top - document.querySelector('.nav-top').offsetHeight;
             window.scroll(0, y);
         }
     }

--- a/resources/scss/components/_print.scss
+++ b/resources/scss/components/_print.scss
@@ -18,12 +18,12 @@
         content: '';
     }
 
-    .menu-top-container {
+    .nav-top {
         &.fixed {
             @apply relative;
         }
 
-        h1 > a[href]::after {
+        a[href]::after {
             content: '';
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,11 +2790,11 @@ __metadata:
   linkType: soft
 
 "baseline-browser-mapping@npm:^2.9.0":
-  version: 2.10.0
-  resolution: "baseline-browser-mapping@npm:2.10.0"
+  version: 2.10.17
+  resolution: "baseline-browser-mapping@npm:2.10.17"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/da9c3ec0fcd7f325226a47d2142794d41706b6e0a405718a2c15410bbdb72aacadd65738bedef558c6f1b106ed19458cb25b06f63b66df2c284799905dbbd003
+  checksum: 10c0/e792a92a6b206521681e3ab3a72770023f74a3274450bfe11ba55a075ba26f5820d5d2d02d92e25224b8d01e327b78fbf3e116bdc6ac74b3d9c52f5e3f4a048a
   languageName: node
   linkType: hard
 
@@ -3241,24 +3241,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001726":
-  version: 1.0.30001726
-  resolution: "caniuse-lite@npm:1.0.30001726"
-  checksum: 10c0/2c5f91da7fd9ebf8c6b432818b1498ea28aca8de22b30dafabe2a2a6da1e014f10e67e14f8e68e872a0867b6b4cd6001558dde04e3ab9770c9252ca5c8849d0e
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001774
-  resolution: "caniuse-lite@npm:1.0.30001774"
-  checksum: 10c0/cc6a340a5421b9a67d8fa80889065ee27b2839ad62993571dded5296e18f02bbf685ce7094e93fe908cddc9fefdfad35d6c010b724cc3d22a6479b0d0b679f8c
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001774":
-  version: 1.0.30001777
-  resolution: "caniuse-lite@npm:1.0.30001777"
-  checksum: 10c0/e35443fa7c470edc06e315297cca706790840e96983fff12dfe502a4b123d6e4a64b9b4e8e35fb2f5bb60c31b24fbda93d76b2f700ce183df474671236fa7a4a
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001726, caniuse-lite@npm:^1.0.30001759, caniuse-lite@npm:^1.0.30001774":
+  version: 1.0.30001787
+  resolution: "caniuse-lite@npm:1.0.30001787"
+  checksum: 10c0/93a6975afbf07f49c9077b348948bbc25b6a82596ccd07b4b6503e48f6f968e1a1e057cc25004db8a2d1d4f35f0c792739e33634edfcefc88ff184c9a2f7a036
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Reason for Change

Looks like this was adjusted in 8.16.3:
https://github.com/waynestate/base-site/pull/875

There were two lingering references to `.menu-top-container` causing these issues:

- Anchors to be hidden behind the top bar
- Top bar to be overlapping in print view

This change addresses both of those issues.

---

## Anchors

| Before | After |
|--------|------|
| <img width="836" height="333" alt="Screenshot 2026-04-09 at 1 42 22 PM" src="https://github.com/user-attachments/assets/5205475c-c34e-49ae-b69a-704ec36f2809" /> | <img width="838" height="323" alt="Screenshot 2026-04-09 at 1 41 47 PM" src="https://github.com/user-attachments/assets/c2bf7bf5-2737-4f71-a27b-b9a512bdc8ec" /> |


## Print

| Before | After |
|--------|------|
| <img width="519" height="256" alt="Screenshot 2026-04-09 at 1 43 51 PM" src="https://github.com/user-attachments/assets/fd9c10df-6aaa-43f9-a2b6-3b8cc355d5c2" /> |<img width="596" height="274" alt="Screenshot 2026-04-09 at 2 03 18 PM" src="https://github.com/user-attachments/assets/e58ff2b3-405e-4465-81b2-c3e0c534266c" /> |

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions