### PR TITLE
Feature | Remove no console from eslint to allow ease of development use

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,6 @@ module.exports = [
         },
         rules: {
             ...js.configs.recommended.rules,
-            'no-console': 'error',
             'no-undef': 'off'
         }
     },


### PR DESCRIPTION
### Remove no console from eslint to allow ease of development use

Removed the no-console configuration from eslint, which was causing eslint errors being thrown when using locally while developing. We can remove these manually but eventually the strategy with using vitejs will allow it to be done on build.

---

### Reason for Change

Issues while developing locally and compiling the js will throw eslint errors even when we want to use the console within the code locally.

---

### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---

_Thanks for your contribution! 🎉_