### PR TITLE
Fix | Add check to 404 on the ArticleController when we are on a page greater than 0 and there are no articles coming back from the News API. 

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -52,6 +52,14 @@ class ArticleController extends Controller
 
         $articles = $this->article->listing($request->data['base']['site']['news']['application_id'], 25, $request->query('page'), ! empty($selected_topic['topic_id']) ? $selected_topic['topic_id'] : null);
 
+        // 404 if no articles are found and we are trying to page which doesn't exist
+        if (
+            $request->query('page') > 0 &&
+            empty($articles['articles']['data'])
+        ) {
+            abort(404);
+        }
+
         if (! empty($articles['articles']['meta'])) {
             $articles['articles']['meta'] = $this->article->setPaging($articles['articles']['meta'], $request->query('page'));
         }

--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -149,7 +149,7 @@ class ArticleRepository implements ArticleRepositoryContract
     {
         if (empty($page)) {
             $meta['next_page_url'] = null;
-            $meta['prev_page_url'] = ($meta['total'] < $meta['per_page']) ? null : url()->current().'?page=2';
+            $meta['prev_page_url'] = ($meta['total'] <= $meta['per_page']) ? null : url()->current().'?page=2';
         } elseif ($page == $meta['last_page']) {
             $meta['next_page_url'] = url()->current().'?page='.($page - 1);
             $meta['prev_page_url'] = null;

--- a/tests/Unit/Http/Controllers/ArticleControllerTest.php
+++ b/tests/Unit/Http/Controllers/ArticleControllerTest.php
@@ -225,4 +225,36 @@ final class ArticleControllerTest extends TestCase
         // Call the news listing
         $view = $ArticleController->index($request);
     }
+
+    #[Test]
+    public function news_listing_with_page_and_no_articles_should_404(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $newsApi = Mockery::mock(News::class);
+        $articleRepository = app(ArticleRepository::class, ['newsApi' => $newsApi]);
+
+        $newsApi = Mockery::mock(News::class);
+        $newsApi->shouldReceive('request')->once()->andReturn(app(Topic::class)->create(3));
+        $topicRepository = app(TopicRepository::class, ['newsApi' => $newsApi]);
+
+        // Construct the news controller
+        $ArticleController = app(ArticleController::class, ['article' => $articleRepository, 'topic' => $topicRepository]);
+
+        $request = new Request(['page' => 2]);
+        $request->path = '/'.config('base.news_listing_route').'/';
+        $request->data = [
+            'base' => [
+                'site' => [
+                    'news' => [
+                        'application_id' => 1,
+                    ],
+                    'subsite-folder' => null,
+                ],
+            ],
+        ];
+
+        // Call the news listing
+        $view = $ArticleController->index($request);
+    }
 }

--- a/tests/Unit/Repositories/ArticleRepositoryTest.php
+++ b/tests/Unit/Repositories/ArticleRepositoryTest.php
@@ -94,10 +94,12 @@ final class ArticleRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function articles_paging_no_page(): void
+    public function articles_paging_no_page_with_more_than_limit(): void
     {
+        $total_articles = 10;
+        $per_page = 5;
         // Fake return
-        $return = app(Article::class)->create(5);
+        $return = app(Article::class)->create($total_articles);
 
         // Mock the connector and set the return
         $newsApi = Mockery::mock(News::class);
@@ -105,9 +107,12 @@ final class ArticleRepositoryTest extends TestCase
 
         $page = null;
 
-        $articles = app(ArticleRepository::class, ['newsApi' => $newsApi])->listing(1, 5, $page);
+        $articles = app(ArticleRepository::class, ['newsApi' => $newsApi])->listing(1, $per_page, $page);
 
-        $articles['articles']['meta'] = app(ArticleRepository::class, ['newsApi' => $newsApi])->setPaging($articles['articles']['meta'], $page);
+        $articles['articles']['meta']['total'] = $total_articles;
+        $articles['articles']['meta']['per_page'] = $per_page;
+        $articles['articles']['meta'] = app(ArticleRepository::class, ['newsApi' => $newsApi])
+            ->setPaging($articles['articles']['meta'], $page);
 
         $next = parse_url($articles['articles']['meta']['next_page_url']);
         $this->assertTrue(empty($next['page']));
@@ -115,6 +120,34 @@ final class ArticleRepositoryTest extends TestCase
         $prev = parse_url($articles['articles']['meta']['prev_page_url']);
         parse_str($prev['query'], $prev);
         $this->assertEquals(2, $prev['page']);
+    }
+
+    #[Test]
+    public function articles_paging_no_page_with_same_or_less_than_limit(): void
+    {
+        $total_articles = 5;
+        $per_page = 5;
+        // Fake return
+        $return = app(Article::class)->create($total_articles);
+
+        // Mock the connector and set the return
+        $newsApi = Mockery::mock(News::class);
+        $newsApi->shouldReceive('request')->andReturn($return);
+
+        $page = null;
+
+        $articles = app(ArticleRepository::class, ['newsApi' => $newsApi])->listing(1, $per_page, $page);
+
+        $articles['articles']['meta']['total'] = $total_articles;
+        $articles['articles']['meta']['per_page'] = $per_page;
+        $articles['articles']['meta'] = app(ArticleRepository::class, ['newsApi' => $newsApi])
+            ->setPaging($articles['articles']['meta'], $page);
+
+        $next = parse_url($articles['articles']['meta']['next_page_url']);
+        $this->assertTrue(empty($next['page']));
+
+        $prev = parse_url($articles['articles']['meta']['prev_page_url']);
+        $this->assertTrue(empty($prev['page']));
     }
 
     #[Test]


### PR DESCRIPTION
### Add check to 404 on the ArticleController when we are on a page greater than 0 and there are no articles coming back from the News API. 

This only happens if you specifically update the ?page= in the URL, the prev/next don't show if it's the last page

---

### Reason for Change

Bots will crawl by updating the ?page= which would show a blank listing, but still register as a valid page even though the ?page= is greater than it should be.

---

### Demo / Context

Before (?page=5 with only 2 pages) :
<img width="1798" height="1017" alt="SCR-20260410-ojpf" src="https://github.com/user-attachments/assets/0078c7e5-4011-4be2-a9be-3b6b482a27ce" />

After (?page=5 with only 2 pages):
<img width="1800" height="1013" alt="SCR-20260410-ojmi" src="https://github.com/user-attachments/assets/b1da0fac-17e3-4847-8746-ecc1b1195e1b" />

---



### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---

_Thanks for your contribution! 🎉_