### PR TITLE
Fix | Correct the canonical url when on the PromoController::show to include the slug and promo id to match the current URL structure of the page

### DIFF
--- a/app/Http/Controllers/PromoController.php
+++ b/app/Http/Controllers/PromoController.php
@@ -11,6 +11,7 @@ namespace App\Http\Controllers;
 use Contracts\Repositories\PromoRepositoryContract;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -55,6 +56,12 @@ class PromoController extends Controller
 
         if (! empty($promo['promo']['title'])) {
             $request->data['base']['page']['title'] = $promo['promo']['title'];
+        }
+
+        // Update to append the slug and promo id to match the current URL structure
+        if (!empty($request->data['base']['page']['canonical'])) {
+            $request->data['base']['page']['canonical'] .= '/' . Str::slug($promo['promo']['title']) . '-' .
+                $promo['promo']['promo_item_id'];
         }
 
         // Set the back URL

--- a/tests/Unit/Http/Controllers/PromoControllerTest.php
+++ b/tests/Unit/Http/Controllers/PromoControllerTest.php
@@ -3,7 +3,11 @@
 namespace Tests\Unit\Http\Controllers;
 
 use App\Http\Controllers\PromoController;
+use Contracts\Repositories\PromoRepositoryContract;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -17,5 +21,37 @@ final class PromoControllerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals(config('app.url'), $response->getTargetUrl());
         $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function promo_show_appends_slug_and_id_to_canonical_url(): void
+    {
+        $promo_item_id = 42;
+        $title = 'Test Slug Promo';
+
+        $promoRepository = Mockery::mock(PromoRepositoryContract::class);
+        $promoRepository->shouldReceive('getPromoView')->once()->andReturn([
+            'promo' => [
+                'title' => $title,
+                'promo_item_id' => $promo_item_id,
+            ],
+        ]);
+        $promoRepository->shouldReceive('getBackToPromoPage')->once()->andReturn('');
+
+        $controller = app(PromoController::class, ['promo' => $promoRepository]);
+
+        $request = new Request();
+        $request->data = [
+            'base' => [
+                'page' => [
+                    'canonical' => config('app.url') . '/promos',
+                ],
+            ],
+        ];
+
+        $view = $controller->show($request);
+
+        $expected = config('app.url') . '/promos/' . Str::slug($title) . '-' . $promo_item_id;
+        $this->assertEquals($expected, $view->getData()['base']['page']['canonical']);
     }
 }


### PR DESCRIPTION
### Correct the canonical url when on the PromoController::show to include the slug and promo id to match the current URL structure of the page

Correct the canonical url when on the PromoController::show to include the slug and promo id to match the current URL structure of the page.

---

### Reason for Change

It was just showing the page without the slug-id which is what the page actually was loading as

---

### Demo / Context

Before:
<img width="941" height="373" alt="SCR-20260410-ovwf" src="https://github.com/user-attachments/assets/c963b624-9e1a-424f-ae17-f75288d1c2d2" />

After:
<img width="857" height="204" alt="SCR-20260410-ovrg" src="https://github.com/user-attachments/assets/2b942faf-879a-4787-a961-d870f2311854" />

---



### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---

_Thanks for your contribution! 🎉_