### PR TITLE
UPDATE |  Formy middleware | Parse descriptions

### DIFF
--- a/app/Http/Middleware/Formy.php
+++ b/app/Http/Middleware/Formy.php
@@ -27,7 +27,9 @@ class Formy
         if (!empty($request->data['base']['page']['content'])) {
             $request->data['base']['page']['content'] = collect($request->data['base']['page']['content'])
                 ->map(function ($content) {
-                    return $this->parser->parse(stripslashes($content));
+                    $content = is_string($content) ? stripslashes($content) : $content;
+
+                    return is_string($content) && str_contains($content, '[') ? $this->parser->parse($content) : $content;
                 })
                 ->toArray();
         }
@@ -48,7 +50,8 @@ class Formy
             if (is_array($value)) {
                 $data[$key] = $this->parseDescriptions($value);
             } elseif ($key === 'description' && is_string($value)) {
-                $data[$key] = $this->parser->parse(stripslashes($value));
+                $value = stripslashes($value);
+                $data[$key] = str_contains($value, '[') ? $this->parser->parse($value) : $value;
             }
         }
 

--- a/app/Http/Middleware/Formy.php
+++ b/app/Http/Middleware/Formy.php
@@ -24,12 +24,34 @@ class Formy
      */
     public function handle(Request $request, Closure $next): ?Response
     {
-        $request->data['base']['page']['content'] = collect($request->data['base']['page']['content'])
-            ->map(function ($content) {
-                return $this->parser->parse(stripslashes($content));
-            })
-            ->toArray();
+        if (!empty($request->data['base']['page']['content'])) {
+            $request->data['base']['page']['content'] = collect($request->data['base']['page']['content'])
+                ->map(function ($content) {
+                    return $this->parser->parse(stripslashes($content));
+                })
+                ->toArray();
+        }
+
+        if (!empty($request->data['base'])) {
+            $request->data['base'] = $this->parseDescriptions($request->data['base']);
+        }
 
         return $next($request);
+    }
+
+    /**
+     * Recursively parse the description fields.
+     */
+    public function parseDescriptions(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = $this->parseDescriptions($value);
+            } elseif ($key === 'description' && is_string($value)) {
+                $data[$key] = $this->parser->parse(stripslashes($value));
+            }
+        }
+
+        return $data;
     }
 }

--- a/tests/Unit/Http/Middleware/FormyTest.php
+++ b/tests/Unit/Http/Middleware/FormyTest.php
@@ -14,7 +14,8 @@ final class FormyTest extends TestCase
     #[Test]
     public function formy_embed_should_show_form_in_page_content(): void
     {
-        $content = $this->faker->sentence();
+        $content = "[\'formy-shortcode\']";
+        $strippedContent = "['formy-shortcode']";
         $parsed = $this->faker->sentence();
 
         // Fake request
@@ -30,9 +31,9 @@ final class FormyTest extends TestCase
         ];
 
         // Mock the parser
-        $this->app->bind(Parser::class, function () use ($content, $parsed) {
+        $this->app->bind(Parser::class, function () use ($strippedContent, $parsed) {
             $mock = Mockery::mock(Parser::class);
-            $mock->shouldReceive('parse')->with($content)->once()->andReturn($parsed);
+            $mock->shouldReceive('parse')->with($strippedContent)->once()->andReturn($parsed);
 
             return $mock;
         });
@@ -46,9 +47,11 @@ final class FormyTest extends TestCase
     #[Test]
     public function description_fields_should_be_parsed(): void
     {
-        $description = $this->faker->sentence();
+        $description = "[\'description\']";
+        $strippedDescription = "['description']";
         $parsedDescription = $this->faker->sentence();
-        $nestedDescription = $this->faker->sentence();
+        $nestedDescription = "[\'nested\']";
+        $strippedNestedDescription = "['nested']";
         $parsedNestedDescription = $this->faker->sentence();
 
         // Fake request
@@ -63,10 +66,10 @@ final class FormyTest extends TestCase
         ];
 
         // Mock the parser
-        $this->app->bind(Parser::class, function () use ($description, $parsedDescription, $nestedDescription, $parsedNestedDescription) {
+        $this->app->bind(Parser::class, function () use ($strippedDescription, $parsedDescription, $strippedNestedDescription, $parsedNestedDescription) {
             $mock = Mockery::mock(Parser::class);
-            $mock->shouldReceive('parse')->with($description)->once()->andReturn($parsedDescription);
-            $mock->shouldReceive('parse')->with($nestedDescription)->once()->andReturn($parsedNestedDescription);
+            $mock->shouldReceive('parse')->with($strippedDescription)->once()->andReturn($parsedDescription);
+            $mock->shouldReceive('parse')->with($strippedNestedDescription)->once()->andReturn($parsedNestedDescription);
 
             return $mock;
         });
@@ -75,6 +78,42 @@ final class FormyTest extends TestCase
         app(Formy::class)->handle($request, function ($request) use ($parsedDescription, $parsedNestedDescription) {
             $this->assertEquals($parsedDescription, $request->data['base']['description']);
             $this->assertEquals($parsedNestedDescription, $request->data['base']['nested']['description']);
+        });
+    }
+
+    #[Test]
+    public function it_should_not_parse_if_no_shortcode_is_present_but_still_strip_slashes(): void
+    {
+        $content = "No shortcode here, but has \'slashes\'";
+        $expectedContent = "No shortcode here, but has 'slashes'";
+        $description = "Another one without shortcode, but has \'slashes\'";
+        $expectedDescription = "Another one without shortcode, but has 'slashes'";
+
+        // Fake request
+        $request = new Request();
+        $request->data = [
+            'base' => [
+                'page' => [
+                    'content' => [
+                        'main' => $content,
+                    ],
+                ],
+                'description' => $description,
+            ],
+        ];
+
+        // Mock the parser - should NOT receive any calls
+        $this->app->bind(Parser::class, function () {
+            $mock = Mockery::mock(Parser::class);
+            $mock->shouldNotReceive('parse');
+
+            return $mock;
+        });
+
+        // Call the middleware
+        app(Formy::class)->handle($request, function ($request) use ($expectedContent, $expectedDescription) {
+            $this->assertEquals($expectedContent, $request->data['base']['page']['content']['main']);
+            $this->assertEquals($expectedDescription, $request->data['base']['description']);
         });
     }
 }

--- a/tests/Unit/Http/Middleware/FormyTest.php
+++ b/tests/Unit/Http/Middleware/FormyTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Http\Middleware;
 use PHPUnit\Framework\Attributes\Test;
 use App\Http\Middleware\Formy;
 use Tests\TestCase;
-use Mockery as Mockery;
+use Mockery;
 use Illuminate\Http\Request;
 use Waynestate\FormyParser\Parser;
 
@@ -14,30 +14,67 @@ final class FormyTest extends TestCase
     #[Test]
     public function formy_embed_should_show_form_in_page_content(): void
     {
+        $content = $this->faker->sentence();
+        $parsed = $this->faker->sentence();
+
         // Fake request
         $request = new Request();
         $request->data = [
             'base' => [
                 'page' => [
                     'content' => [
-                        'main' => 'original-form-main',
+                        'main' => $content,
                     ],
                 ],
             ],
         ];
 
-        // Fake return
-        $return = [
-            'main' => 'replaced-form-main',
+        // Mock the parser
+        $this->app->bind(Parser::class, function () use ($content, $parsed) {
+            $mock = Mockery::mock(Parser::class);
+            $mock->shouldReceive('parse')->with($content)->once()->andReturn($parsed);
+
+            return $mock;
+        });
+
+        // Call the middleware
+        app(Formy::class)->handle($request, function ($request) use ($parsed) {
+            $this->assertEquals($parsed, $request->data['base']['page']['content']['main']);
+        });
+    }
+
+    #[Test]
+    public function description_fields_should_be_parsed(): void
+    {
+        $description = $this->faker->sentence();
+        $parsedDescription = $this->faker->sentence();
+        $nestedDescription = $this->faker->sentence();
+        $parsedNestedDescription = $this->faker->sentence();
+
+        // Fake request
+        $request = new Request();
+        $request->data = [
+            'base' => [
+                'description' => $description,
+                'nested' => [
+                    'description' => $nestedDescription,
+                ],
+            ],
         ];
 
         // Mock the parser
-        $parser = Mockery::mock(Parser::class);
-        $parser->shouldReceive('parse')->once()->andReturn($return);
+        $this->app->bind(Parser::class, function () use ($description, $parsedDescription, $nestedDescription, $parsedNestedDescription) {
+            $mock = Mockery::mock(Parser::class);
+            $mock->shouldReceive('parse')->with($description)->once()->andReturn($parsedDescription);
+            $mock->shouldReceive('parse')->with($nestedDescription)->once()->andReturn($parsedNestedDescription);
+
+            return $mock;
+        });
 
         // Call the middleware
-        app(Formy::class, ['parser' => $parser])->handle($request, function ($response) use ($return) {
-            $this->assertEquals($return, $response->data['base']['page']['content']['main']);
+        app(Formy::class)->handle($request, function ($request) use ($parsedDescription, $parsedNestedDescription) {
+            $this->assertEquals($parsedDescription, $request->data['base']['description']);
+            $this->assertEquals($parsedNestedDescription, $request->data['base']['nested']['description']);
         });
     }
 }


### PR DESCRIPTION
## Reason for Change
The Formy middleware was not parsing deep enough into the fields in a promo to be able to pick up on the Formy shortcodes nested in the description.

---

## Demo / Context

| Before | After |
|--------|--------|
| <img width="1686" height="1260" alt="before" src="https://github.com/user-attachments/assets/49615466-e196-4d65-832c-594951222c8e" /> | <img width="1714" height="1395" alt="after" src="https://github.com/user-attachments/assets/35169290-8490-4fb2-aa97-613e7dd8a3ae" /> <img width="608" height="87" alt="after - test" src="https://github.com/user-attachments/assets/a046070c-b648-461b-8cac-389a5336cb69" /> | 

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions