### PR TITLE
Feature | Component ordering within CMS custom fields

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -38,12 +38,13 @@ class ModularPageRepository implements ModularPageRepositoryContract
      *
      */
     public function __construct(
-        Connector $wsuApi,
-        ParsePromos $parsePromos,
-        Repository $cache,
+        Connector                 $wsuApi,
+        ParsePromos               $parsePromos,
+        Repository                $cache,
         ArticleRepositoryContract $article,
-        EventRepositoryContract $event
-    ) {
+        EventRepositoryContract   $event
+    )
+    {
         $this->wsuApi = $wsuApi;
         $this->parsePromos = $parsePromos;
         $this->cache = $cache;
@@ -129,7 +130,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
                         foreach ($promo_config as $key => $config_item) {
                             // Inject page_id
                             if (Str::startsWith($config_item, 'page_id')) {
-                                $promo_config[$key] = 'page_id:'.$data['page']['id'];
+                                $promo_config[$key] = 'page_id:' . $data['page']['id'];
                             }
                             // Component loop expects the return being a multi-dimensional array
                             if (Str::startsWith($config_item, 'first')) {
@@ -335,7 +336,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
     public function adjustPromoData($data, $component)
     {
         if (isset($component['singlePromoView']) && $component['singlePromoView'] === true) {
-            $data['link'] = 'view/'.Str::slug($data['title']).'-'.$data['promo_item_id'];
+            $data['link'] = 'view/' . Str::slug($data['title']) . '-' . $data['promo_item_id'];
         }
 
         if (isset($component['showExcerpt']) && $component['showExcerpt'] === false) {
@@ -359,8 +360,8 @@ class ModularPageRepository implements ModularPageRepositoryContract
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function organizePromoItemsByOption(array $data)
     {
         $options_exist = collect($data)->filter(function ($item) {
@@ -397,7 +398,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
             if (!empty($component['component']['filename']) && $component['component']['filename'] != 'hero') {
                 if (!empty($component['component']['columnSpan'])) {
                     // Inject the column span class
-                    array_push($components[$componentName]['component']['containerClass'], 'px-4', 'mt:colspan-'.$component['component']['columnSpan']);
+                    array_push($components[$componentName]['component']['containerClass'], 'px-4', 'mt:colspan-' . $component['component']['columnSpan']);
                 } elseif (!empty($component['component']['filename']) && strpos($component['component']['filename'], 'column') !== false) {
                     // Inject the column span class
                     array_push($components[$componentName]['component']['containerClass'], 'px-4', 'mt:colspan-6');
@@ -408,7 +409,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
             }
 
             // Collect all legacy class names
-            $classes = trim(($component['component']['sectionClass'] ?? '').' '.($component['component']['componentClass'] ?? '').' '.($component['component']['classes'] ?? ''));
+            $classes = trim(($component['component']['sectionClass'] ?? '') . ' ' . ($component['component']['componentClass'] ?? '') . ' ' . ($component['component']['classes'] ?? ''));
 
             // Group the classes based on the container they will be applied to
             // Set backgroundClass, containerClass, componentClass
@@ -419,7 +420,15 @@ class ModularPageRepository implements ModularPageRepositoryContract
                     if (strpos($class, 'bg-') !== false) {
                         // backgroundClass
                         $components[$componentName]['component']['backgroundClass'][] = $class;
-                    } elseif (strpos($class, 'my-') !== false | strpos($class, 'mt-') !== false | strpos($class, 'mb-') !== false | strpos($class, 'end') !== false | strpos($class, 'left') !== false | strpos($class, 'right') !== false) {
+                    } elseif (
+                        strpos($class, 'my-') !== false |
+                        strpos($class, 'mt-') !== false |
+                        strpos($class, 'mb-') !== false |
+                        strpos($class, 'end') !== false |
+                        strpos($class, 'left') !== false |
+                        strpos($class, 'right') !== false |
+                        strpos($class, 'order-') !== false
+                    ) {
                         // containerClass
                         $components[$componentName]['component']['containerClass'][] = $class;
                     } else {
@@ -462,7 +471,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
         foreach ($components as $componentName => $component) {
             if (!empty($component['component']['backgroundImageUrl'])) {
                 //$component['component']['backgroundImageUrl'] = "background-image:url('".$component['component']['backgroundImageUrl']."');";
-                $components[$componentName]['component']['backgroundImageUrl'] = "style=\"background-image:url('".$component['component']['backgroundImageUrl']."');\"";
+                $components[$componentName]['component']['backgroundImageUrl'] = "style=\"background-image:url('" . $component['component']['backgroundImageUrl'] . "');\"";
             }
 
             // Forcing a space delimeter

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -43,8 +43,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
         Repository                $cache,
         ArticleRepositoryContract $article,
         EventRepositoryContract   $event
-    )
-    {
+    ) {
         $this->wsuApi = $wsuApi;
         $this->parsePromos = $parsePromos;
         $this->cache = $cache;

--- a/composer.lock
+++ b/composer.lock
@@ -9553,5 +9553,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
Adds the ability to control the display order of components in the CMS using Tailwind order classes (e.g., order-1, order-2).

## Changes
- Enabled support for Tailwind order utilities in component layouts

---

### Reason for Change

- Allows editors/devs to adjust component order without modifying template structure
- Ensures responsive variants can be applied (sm:, md:, etc.) where needed

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---

| Before | After |
|--------|--------|
| <img width="1024" height="595" alt="Screenshot 2026-04-27 at 1 06 51 PM" src="https://github.com/user-attachments/assets/bb4e2879-7766-486d-93ce-f46a8895dbd0" /> | <img width="1024" height="595" alt="Screenshot 2026-04-27 at 1 05 40 PM" src="https://github.com/user-attachments/assets/04697c44-29cf-486c-9341-333718ac5c81" /> | 
|<img width="942" height="494" alt="Screenshot 2026-04-27 at 1 05 00 PM" src="https://github.com/user-attachments/assets/bb2c1030-fb9e-42ce-988d-a84d63a9c2f4" /> | <img width="942" height="494" alt="Screenshot 2026-04-27 at 1 01 13 PM" src="https://github.com/user-attachments/assets/b2f68dcb-7804-4cee-b62a-c14686bea752" /> |

