### PR TITLE
Hotfix 8.17.1 | Fix dependency issue with Laravel Mix to lock to webpackbar v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,13 @@
   "overrides": {
     "slideout": {
       "emitter": "https://github.com/Mango/emitter.git#0.0.7"
+    },
+    "laravel-mix": {
+      "webpackbar": "^7.0.0"
     }
+  },
+  "resolutions": {
+    "webpackbar": "^7.0.0"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base",
   "private": true,
-  "version": "8.17.0",
+  "version": "8.17.1",
   "description": "",
   "scripts": {
     "dev": "npm run development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansis@npm:^3.2.0":
+  version: 3.17.0
+  resolution: "ansis@npm:3.17.0"
+  checksum: 10c0/d8fa94ca7bb91e7e5f8a7d323756aa075facce07c5d02ca883673e128b2873d16f93e0dec782f98f1eeb1f2b3b4b7b60dcf0ad98fb442e75054fe857988cc5cb
+  languageName: node
+  linkType: hard
+
 "any-promise@npm:^1.0.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
@@ -3112,7 +3119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -3368,10 +3375,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"consola@npm:^2.15.3":
-  version: 2.15.3
-  resolution: "consola@npm:2.15.3"
-  checksum: 10c0/34a337e6b4a1349ee4d7b4c568484344418da8fdb829d7d71bfefcd724f608f273987633b6eef465e8de510929907a092e13cb7a28a5d3acb3be446fcc79fd5e
+"consola@npm:^3.2.3":
+  version: 3.4.2
+  resolution: "consola@npm:3.4.2"
+  checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
   languageName: node
   linkType: hard
 
@@ -8345,7 +8352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.0.1":
+"std-env@npm:^3.7.0":
   version: 3.10.0
   resolution: "std-env@npm:3.10.0"
   checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
@@ -9342,17 +9349,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpackbar@npm:^5.0.0-3":
-  version: 5.0.2
-  resolution: "webpackbar@npm:5.0.2"
+"webpackbar@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webpackbar@npm:7.0.0"
   dependencies:
-    chalk: "npm:^4.1.0"
-    consola: "npm:^2.15.3"
+    ansis: "npm:^3.2.0"
+    consola: "npm:^3.2.3"
     pretty-time: "npm:^1.1.0"
-    std-env: "npm:^3.0.1"
+    std-env: "npm:^3.7.0"
   peerDependencies:
+    "@rspack/core": "*"
     webpack: 3 || 4 || 5
-  checksum: 10c0/336568a6ed1c1ad743c8d20a5cab5875a7ebe1e96181f49ae0a1a897f1a59d1661d837574a25d8ba9dfa4f2f705bd46ca0cd037ff60286ff70fb8d9db2b0c123
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10c0/03ed85edca12af824319dfcd0fe5c3a90b9e3c86400a604a55589abe0a66a682033e7de027e89aae03652b6fb8ca7fd2831d86829179304ea3121f807808f7c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Hotfix 8.17.1 | Fix dependency issue with Laravel Mix to lock to webpackbar v7.0.0

webpackbar package upgraded to later version but laravel mix is pulling in a later incompatible version

---

### Reason for Change

Need to lock down the version to be the last compatible version v7.0.0 for webpackbar

---

### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---


_Thanks for your contribution! 🎉_