### PR TITLE
FIX | Middleware - Data | Config layout fallback

### DIFF
--- a/app/Http/Middleware/Data.php
+++ b/app/Http/Middleware/Data.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -65,7 +66,8 @@ class Data
         $request->data = merge($data, $page);
 
         // Get the site layout and merge
-        $layout['layout'] = config('base.layout');
+        $layoutName = config('base.layout', 'main');
+        $layout['layout'] = View::exists('layouts.' . $layoutName) ? $layoutName : 'main';
         $request->data = merge($request->data, $layout);
 
         // Determine whether the global header should be shown based on the request

--- a/tests/Unit/Http/Middleware/DataTest.php
+++ b/tests/Unit/Http/Middleware/DataTest.php
@@ -349,6 +349,18 @@ final class DataTest extends TestCase
     }
 
     #[Test]
+    public function layout_falls_back_to_main_when_configured_layout_does_not_exist(): void
+    {
+        config(['base.layout' => 'contained-hero']);
+
+        $request = Request::create('styleguide');
+
+        app(Data::class)->handle($request, function ($request) {
+            $this->assertEquals('main', $request->data['base']['layout']);
+        });
+    }
+
+    #[Test]
     public function show_header_is_true_when_exclude_cookie_is_absent(): void
     {
         $request = Request::create('styleguide');


### PR DESCRIPTION
## Reason for Change
The fallback for the config.layout was added with a recent update for the hero component, but we needed to account for edge cases where the config of a site did not already have the `layout` defined.

---

## Demo / Context

### Screenshots
| Before | After |
|--------|--------|
| <img width="1512" height="904" alt="before" src="https://github.com/user-attachments/assets/0707e5bd-47ed-43eb-a73c-47aead1b6a66" /> | <img width="1512" height="904" alt="after" src="https://github.com/user-attachments/assets/84f1ca23-b2ed-4e81-9d60-6a4c9eb994bd" /> | 


---



### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions