### PR TITLE
Fix | Skip links | Restored the top menu skip link functionality

### DIFF
--- a/resources/views/components/skip.blade.php
+++ b/resources/views/components/skip.blade.php
@@ -1,7 +1,7 @@
 <nav aria-label="Skip navigation" class="skip">
     <ul>
         @if(config('base.top_menu_enabled') === true)
-            <li class="skip-site-menu"><a href="#top-menu">Skip to site menu</a></li>
+            <li class="skip-site-menu"><a href="#site-menu">Skip to site menu</a></li>
         @endif
         @if(!empty($base['site_menu_output']))
             <li class="skip-page-menu"><a href="#menu">Skip to page menu</a></li>


### PR DESCRIPTION
It looks like the top menu ID changed within the last release or two, which is causing a broken link in the skip menu.

The skip menu anchor should reference the `site-menu` ID now.

## Context

<img width="1097" height="856" alt="Screenshot 2026-05-13 at 7 15 10 AM" src="https://github.com/user-attachments/assets/014f0255-2a9d-4134-9400-ac528765a2c5" />

## Demo

| Before | After |
|--------|------|
| <img width="1254" height="779" alt="Screenshot 2026-05-14 at 6 28 56 AM" src="https://github.com/user-attachments/assets/ed8a15b4-b3a4-4ed6-90c9-39037e2cbbae" /> | <img width="1251" height="742" alt="Screenshot 2026-05-14 at 6 28 08 AM" src="https://github.com/user-attachments/assets/d00c1ab7-c06f-49c4-beb2-3cc77d2bd3f0" /> | 

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions