### PR TITLE
Fix | Artisan | base:module generation now creates a usable accordion to display config

### DIFF
--- a/stubs/component-controller.stub
+++ b/stubs/component-controller.stub
@@ -30,7 +30,7 @@ class ComponentDummyComponentController extends Controller
                 'data' => [
                     0 => [
                         'title' => 'Component configuration',
-                        'promo_item_id' => 'component-config',
+                        'promo_item_id' => 'component_config',
                         'description' => '',
                         'tr1' => [
                             'Page field' => 'modular-dummy-component-1',
@@ -43,7 +43,7 @@ class ComponentDummyComponentController extends Controller
                     ],
                     1 => [
                         'title' => 'Promotion group details',
-                        'promo_item_id' => 'promo-details',
+                        'promo_item_id' => 'promo_details',
                         'description' => '',
                         'table' => [
                             'Title' => 'Bold text.',


### PR DESCRIPTION
When generating a new modular component, the styleguide config and promotion group accordions do not expand by default.

The stub file was using a different array key than expected and the content was not visible.

This change updates the `promo_item_id` from dashes to underscores to match the expectations of the template.

---

## Demo / Context

| Before | After |
|--------|------|
| <img  alt="accordion-broken" src="https://github.com/user-attachments/assets/b0931f90-1ba7-438b-97d8-df7d8d2559eb" /> | <img  alt="accordion-fixed" src="https://github.com/user-attachments/assets/b3f189d8-4399-448a-be12-3c757da022b7" /> |

---

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions