### PR TITLE
Feature | Formy legend styling now consistent for required fields

### DIFF
--- a/resources/scss/components/_formy.scss
+++ b/resources/scss/components/_formy.scss
@@ -176,7 +176,8 @@
     }
 
     /* Required */
-    label em {
+    label em,
+    legend em {
         @apply text-red-600;
     }
 }


### PR DESCRIPTION
### Title

Fields requiring user input within `.formy legend em` will now display the same accessible red required-field indicator styling as `.formy label em.`

---

### Reason for Change

The required indicators did not follow the same color coding under `.formy legend em`.

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---

| Before | After |
|--------|--------|
|<img width="1624" height="987" alt="Screenshot 2026-06-16 at 2 32 07 PM" src="https://github.com/user-attachments/assets/519a635b-7033-439d-adc0-dfb0c8b95af0" /> <img width="899" height="280" alt="image" src="https://github.com/user-attachments/assets/fb430130-ad3a-4ddd-8812-5a8eef8d0df5" />| <img width="1580" height="943" alt="Screenshot 2026-06-16 at 2 31 58 PM" src="https://github.com/user-attachments/assets/9043cc65-0f29-4500-8afb-ada20de71dc8" /><img width="899" height="280" alt="image" src="https://github.com/user-attachments/assets/b986e062-3370-4677-991f-b69e3b95db82" />| 
