### PR TITLE
Fix | Full width controller config correction

### DIFF
--- a/styleguide/Http/Controllers/FullWidthController.php
+++ b/styleguide/Http/Controllers/FullWidthController.php
@@ -74,7 +74,7 @@ class FullWidthController extends Controller
             'accordion-101' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-icons',
+                        'promo_item_id' => 'component_config_icons',
                         'title' => 'Icons row configuration',
                         'description' => '',
                         'tr1' => [
@@ -115,7 +115,7 @@ class FullWidthController extends Controller
             'accordion-201' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-catalog',
+                        'promo_item_id' => 'component_config_catalog',
                         'title' => 'Catalog with background configuration',
                         'description' => '',
                         'tr1' => [
@@ -178,7 +178,7 @@ class FullWidthController extends Controller
             'accordion-303' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-resources',
+                        'promo_item_id' => 'component_config_resources',
                         'title' => 'Resources area configuration',
                         'description' => '',
                         'tr1' => [
@@ -228,7 +228,7 @@ class FullWidthController extends Controller
             'accordion-401' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-news',
+                        'promo_item_id' => 'component_config_news',
                         'title' => 'News configuration',
                         'description' => '',
                         'tr1' => [
@@ -277,7 +277,7 @@ class FullWidthController extends Controller
             'accordion-503' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-events',
+                        'promo_item_id' => 'component_config_events',
                         'title' => 'Events area configuration',
                         'description' => '',
                         'tr1' => [
@@ -337,7 +337,7 @@ class FullWidthController extends Controller
             'accordion-602' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-facts',
+                        'promo_item_id' => 'component_config_facts',
                         'title' => 'Facts area configuration',
                         'description' => '',
                         'tr1' => [
@@ -400,7 +400,7 @@ class FullWidthController extends Controller
             'accordion-702' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-catalog-and-buttons',
+                        'promo_item_id' => 'component_config_catalog_and_buttons',
                         'title' => 'Single column catalog and buttons area configuration',
                         'description' => '',
                         'tr1' => [
@@ -446,7 +446,7 @@ class FullWidthController extends Controller
             'accordion-801' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-spotlight-row',
+                        'promo_item_id' => 'component_config_spotlight_row',
                         'title' => 'Spotlight row area configuration',
                         'description' => '',
                         'tr1' => [
@@ -483,7 +483,7 @@ class FullWidthController extends Controller
             'accordion-901' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-smaller-width',
+                        'promo_item_id' => 'component_config_smaller_width',
                         'title' => 'Smaller-width area configuration',
                         'description' => '',
                         'tr1' => [
@@ -522,7 +522,7 @@ class FullWidthController extends Controller
             'accordion-1001' => [
                 'data' => [
                     0 => [
-                        'promo_item_id' => 'component-config-button-row',
+                        'promo_item_id' => 'component_config_button_row',
                         'title' => 'Button row area configuration',
                         'description' => '',
                         'tr1' => [


### PR DESCRIPTION

Correct all of the values for `promo_item_id` within the full width controller to use underscores instead of dashes.

---

### Reason for Change

With the `promo_item_id` using dashes instead of underscores keeps the accordions from expanding. This change rectifies this issue.

---

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---

| Before | After |
|--------|--------|
|<img width="1624" height="987" alt="image" src="https://github.com/user-attachments/assets/ad9e2481-9374-4a4f-840a-bbcd615424f9" /><img width="1624" height="987" alt="Screenshot 2026-06-26 at 12 29 40 PM" src="https://github.com/user-attachments/assets/9a9512d6-1f2c-4a29-a87c-86921a22c546" />|<img width="1624" height="987" alt="Screenshot 2026-06-26 at 12 29 11 PM" src="https://github.com/user-attachments/assets/47be966c-a94c-40a6-a8ba-4e1484cc0860" /><img width="1624" height="987" alt="Screenshot 2026-06-26 at 12 29 33 PM" src="https://github.com/user-attachments/assets/85a67cbf-3b37-47f5-88f5-7ea4c1d6cb1e" />| 