### PR TITLE
Feature | Fix cross-site modular promo links

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -207,7 +207,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
                     }
 
                     if (!empty($promo['link'])) {
-                        $promo['link'] = $this->externalPromoLink($promo['link'], $promo['site']);
+                        $promo['link'] = $this->fullyQualifiedUrl($promo['link'], $promo['site']['url'] ?? '');
                     }
                 }
 
@@ -237,38 +237,41 @@ class ModularPageRepository implements ModularPageRepositoryContract
         return $promos;
     }
 
-    public function externalPromoLink(string $link, array $site): string
+    /**
+     * Fully qualify a local or bare-domain URL using the provided base URL when needed.
+     */
+    public function fullyQualifiedUrl(string $url, string $base_url = ''): string
     {
-        if (Str::startsWith($link, '#')) {
-            return $link;
+        if (Str::startsWith($url, '#')) {
+            return $url;
         }
 
-        if ($this->isAbsolutePromoLink($link)) {
-            return $link;
+        if ($this->isAbsoluteUrl($url)) {
+            return $url;
         }
 
-        if ($this->isPromoUrlWithoutScheme($link)) {
-            return $this->promoSiteUrl($link);
+        if ($this->isUrlWithoutScheme($url)) {
+            return $this->urlWithScheme($url);
         }
 
-        if (empty($site['url'])) {
-            return $link;
+        if (empty($base_url)) {
+            return $url;
         }
 
-        return rtrim($this->promoSiteUrl($site['url']), '/').'/'.ltrim($link, '/');
+        return rtrim($this->urlWithScheme($base_url), '/').'/'.ltrim($url, '/');
     }
 
-    protected function isAbsolutePromoLink(string $link): bool
+    protected function isAbsoluteUrl(string $url): bool
     {
-        return Str::startsWith($link, '//') || parse_url($link, PHP_URL_SCHEME) !== null;
+        return Str::startsWith($url, '//') || parse_url($url, PHP_URL_SCHEME) !== null;
     }
 
-    protected function isPromoUrlWithoutScheme(string $link): bool
+    protected function isUrlWithoutScheme(string $url): bool
     {
-        return preg_match('/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:[\/?#]|$)/', $link) === 1;
+        return preg_match('/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:[\/?#]|$)/', $url) === 1;
     }
 
-    protected function promoSiteUrl(string $url): string
+    protected function urlWithScheme(string $url): string
     {
         if (parse_url($url, PHP_URL_SCHEME) === null) {
             return 'https://'.$url;

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -243,37 +243,16 @@ class ModularPageRepository implements ModularPageRepositoryContract
             return $link;
         }
 
-        $site_url = $this->promoSiteUrl($site);
-
-        if (empty($site_url)) {
+        if (empty($site['url'])) {
             return $link;
         }
 
-        return rtrim($site_url, '/').'/'.ltrim($link, '/');
+        return rtrim($site['url'], '/').'/'.ltrim($link, '/');
     }
 
     protected function isAbsolutePromoLink(string $link): bool
     {
         return Str::startsWith($link, ['#', '//']) || parse_url($link, PHP_URL_SCHEME) !== null;
-    }
-
-    protected function promoSiteUrl(array $site): ?string
-    {
-        $site_url = $site['url'] ?? $site['domain'] ?? $site['hostname'] ?? $site['host'] ?? null;
-
-        if (empty($site_url)) {
-            return null;
-        }
-
-        if (Str::startsWith($site_url, '//')) {
-            return 'https:'.$site_url;
-        }
-
-        if (parse_url($site_url, PHP_URL_SCHEME) === null) {
-            return 'https://'.$site_url;
-        }
-
-        return $site_url;
     }
 
     /**

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -239,8 +239,16 @@ class ModularPageRepository implements ModularPageRepositoryContract
 
     public function externalPromoLink(string $link, array $site): string
     {
+        if (Str::startsWith($link, '#')) {
+            return $link;
+        }
+
         if ($this->isAbsolutePromoLink($link)) {
             return $link;
+        }
+
+        if ($this->isPromoUrlWithoutScheme($link)) {
+            return $this->promoSiteUrl($link);
         }
 
         if (empty($site['url'])) {
@@ -252,7 +260,12 @@ class ModularPageRepository implements ModularPageRepositoryContract
 
     protected function isAbsolutePromoLink(string $link): bool
     {
-        return Str::startsWith($link, ['#', '//']) || parse_url($link, PHP_URL_SCHEME) !== null;
+        return Str::startsWith($link, '//') || parse_url($link, PHP_URL_SCHEME) !== null;
+    }
+
+    protected function isPromoUrlWithoutScheme(string $link): bool
+    {
+        return preg_match('/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:[\/?#]|$)/', $link) === 1;
     }
 
     protected function promoSiteUrl(string $url): string

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -247,12 +247,21 @@ class ModularPageRepository implements ModularPageRepositoryContract
             return $link;
         }
 
-        return rtrim($site['url'], '/').'/'.ltrim($link, '/');
+        return rtrim($this->promoSiteUrl($site['url']), '/').'/'.ltrim($link, '/');
     }
 
     protected function isAbsolutePromoLink(string $link): bool
     {
         return Str::startsWith($link, ['#', '//']) || parse_url($link, PHP_URL_SCHEME) !== null;
+    }
+
+    protected function promoSiteUrl(string $url): string
+    {
+        if (parse_url($url, PHP_URL_SCHEME) === null) {
+            return 'https://'.$url;
+        }
+
+        return $url;
     }
 
     /**

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -194,21 +194,26 @@ class ModularPageRepository implements ModularPageRepositoryContract
             $promos['promotions'] = $this->filterExpiredItems($promos['promotions'], ['end_date', 'display_end_date']);
         }
 
-        // Use another site's promo items only from Base
-        if (!empty($site_id) && $site_id === 1561) {
-            $promos['promotions'] = collect($promos['promotions'])->map(function ($promo) {
-                if (!empty($promo['filename_url'])) {
-                    $promo['relative_url'] = $promo['filename_url'];
-                }
+        // Use another site's promo items
+        if (!empty($promos['promotions'])) {
+            $promos['promotions'] = collect($promos['promotions'])->map(function ($promo) use ($site_id) {
+                if (!empty($promo['site']) && !empty($promo['site']['site_id']) && $promo['site']['site_id'] != $site_id) {
+                    if (!empty($promo['filename_url'])) {
+                        $promo['relative_url'] = $promo['filename_url'];
+                    }
 
-                if (!empty($promo['secondary_filename_url'])) {
-                    $promo['secondary_relative_url'] = $promo['secondary_filename_url'];
+                    if (!empty($promo['secondary_filename_url'])) {
+                        $promo['secondary_relative_url'] = $promo['secondary_filename_url'];
+                    }
+
+                    if (!empty($promo['link'])) {
+                        $promo['link'] = $this->externalPromoLink($promo['link'], $promo['site']);
+                    }
                 }
 
                 return $promo;
             })->toArray();
         }
-
         $promos = $this->parsePromos->parse($promos, $components['group_reference'], $components['group_config']);
 
         foreach ($promos as $name => $data) {
@@ -230,6 +235,45 @@ class ModularPageRepository implements ModularPageRepositoryContract
         }
 
         return $promos;
+    }
+
+    public function externalPromoLink(string $link, array $site): string
+    {
+        if ($this->isAbsolutePromoLink($link)) {
+            return $link;
+        }
+
+        $site_url = $this->promoSiteUrl($site);
+
+        if (empty($site_url)) {
+            return $link;
+        }
+
+        return rtrim($site_url, '/').'/'.ltrim($link, '/');
+    }
+
+    protected function isAbsolutePromoLink(string $link): bool
+    {
+        return Str::startsWith($link, ['#', '//']) || parse_url($link, PHP_URL_SCHEME) !== null;
+    }
+
+    protected function promoSiteUrl(array $site): ?string
+    {
+        $site_url = $site['url'] ?? $site['domain'] ?? $site['hostname'] ?? $site['host'] ?? null;
+
+        if (empty($site_url)) {
+            return null;
+        }
+
+        if (Str::startsWith($site_url, '//')) {
+            return 'https:'.$site_url;
+        }
+
+        if (parse_url($site_url, PHP_URL_SCHEME) === null) {
+            return 'https://'.$site_url;
+        }
+
+        return $site_url;
     }
 
     /**

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -690,6 +690,8 @@ final class ModularPageRepositoryTest extends TestCase
     {
         $page_id = $this->faker->numberbetween(10, 50);
         $promo_group_id = $this->faker->numberbetween(1, 3);
+        $current_site_id = 1561;
+        $promo_site_id = 2;
 
         // Fake return
         $return['promotions'] = app(GenericPromo::class)->create(5, false, [
@@ -701,7 +703,7 @@ final class ModularPageRepositoryTest extends TestCase
             'promo_group_id' => $promo_group_id,
             'page_id' => $page_id,
             'site' => [
-                'site_id' => 9999,
+                'site_id' => $promo_site_id,
                 'url' => 'https://base.wayne.edu',
             ],
             'group' => [
@@ -712,7 +714,7 @@ final class ModularPageRepositoryTest extends TestCase
         // Create a fake data request
         $data = app(Page::class)->create(1, true, [
             'site' => [
-                'id' => 1561,
+                'id' => $current_site_id,
             ],
             'page' => [
                 'controller' => 'ChildpageController',

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -686,7 +686,7 @@ final class ModularPageRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function replace_modular_page_relative_url_with_filename_if_on_base(): void
+    public function replace_modular_page_relative_urls_and_local_links_for_promos_from_other_sites(): void
     {
         $page_id = $this->faker->numberbetween(10, 50);
         $promo_group_id = $this->faker->numberbetween(1, 3);
@@ -697,8 +697,13 @@ final class ModularPageRepositoryTest extends TestCase
             'filename_url' => 'https://base.wayne.edu/promo/image.jpg',
             'secondary_relative_url' => '/promo/image2.jpg',
             'secondary_filename_url' => 'https://base.wayne.edu/promo/image2.jpg',
+            'link' => '/apply',
             'promo_group_id' => $promo_group_id,
             'page_id' => $page_id,
+            'site' => [
+                'site_id' => 9999,
+                'url' => 'https://base.wayne.edu',
+            ],
             'group' => [
                 'promo_group_id' => $promo_group_id,
             ],
@@ -731,6 +736,7 @@ final class ModularPageRepositoryTest extends TestCase
 
         $this->assertTrue($component['relative_url'] === $component['filename_url']);
         $this->assertTrue($component['secondary_relative_url'] === $component['secondary_filename_url']);
+        $this->assertEquals('https://base.wayne.edu/apply', $component['link']);
     }
 
     #[Test]

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -842,4 +842,26 @@ final class ModularPageRepositoryTest extends TestCase
         $this->assertEmpty($components['news-and-events-2']['data']['events']);
         $this->assertArrayHasKey(0, $components['news-and-events-2']['data']);
     }
+
+    #[Test]
+    public function external_promo_link_does_not_change_absolute_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://wayne.edu/apply',
+            $repository->externalPromoLink('https://wayne.edu/apply', ['url' => 'https://base.wayne.edu'])
+        );
+    }
+
+    #[Test]
+    public function external_promo_link_does_not_change_local_links_without_site_url(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '/apply',
+            $repository->externalPromoLink('/apply', [])
+        );
+    }
 }

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -875,4 +875,15 @@ final class ModularPageRepositoryTest extends TestCase
             $repository->externalPromoLink('/apply', ['url' => 'wayne.edu'])
         );
     }
+
+    #[Test]
+    public function external_promo_link_adds_scheme_to_bare_domain_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://wayne.edu/summer/',
+            $repository->externalPromoLink('wayne.edu/summer/', ['url' => 'https://wayne.wayne.localhost'])
+        );
+    }
 }

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -844,46 +844,68 @@ final class ModularPageRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function external_promo_link_does_not_change_absolute_links(): void
+    public function fully_qualified_url_does_not_change_absolute_links(): void
     {
         $repository = app(ModularPageRepository::class);
 
         $this->assertEquals(
             'https://wayne.edu/apply',
-            $repository->externalPromoLink('https://wayne.edu/apply', ['url' => 'https://base.wayne.edu'])
+            $repository->fullyQualifiedUrl('https://wayne.edu/apply', 'https://base.wayne.edu')
         );
     }
 
     #[Test]
-    public function external_promo_link_does_not_change_local_links_without_site_url(): void
+    public function fully_qualified_url_does_not_change_protocol_relative_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '//wayne.edu/apply',
+            $repository->fullyQualifiedUrl('//wayne.edu/apply', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_anchor_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '#apply',
+            $repository->fullyQualifiedUrl('#apply', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_local_links_without_base_url(): void
     {
         $repository = app(ModularPageRepository::class);
 
         $this->assertEquals(
             '/apply',
-            $repository->externalPromoLink('/apply', [])
+            $repository->fullyQualifiedUrl('/apply')
         );
     }
 
     #[Test]
-    public function external_promo_link_adds_scheme_to_site_urls_without_prefix(): void
+    public function fully_qualified_url_adds_scheme_to_base_urls_without_prefix(): void
     {
         $repository = app(ModularPageRepository::class);
 
         $this->assertEquals(
             'https://wayne.edu/apply',
-            $repository->externalPromoLink('/apply', ['url' => 'wayne.edu'])
+            $repository->fullyQualifiedUrl('/apply', 'wayne.edu')
         );
     }
 
     #[Test]
-    public function external_promo_link_adds_scheme_to_bare_domain_links(): void
+    public function fully_qualified_url_adds_scheme_to_bare_domain_links(): void
     {
         $repository = app(ModularPageRepository::class);
 
         $this->assertEquals(
             'https://wayne.edu/summer/',
-            $repository->externalPromoLink('wayne.edu/summer/', ['url' => 'https://wayne.wayne.localhost'])
+            $repository->fullyQualifiedUrl('wayne.edu/summer/', 'https://wayne.wayne.localhost')
         );
     }
 }

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -864,4 +864,15 @@ final class ModularPageRepositoryTest extends TestCase
             $repository->externalPromoLink('/apply', [])
         );
     }
+
+    #[Test]
+    public function external_promo_link_adds_scheme_to_site_urls_without_prefix(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://wayne.edu/apply',
+            $repository->externalPromoLink('/apply', ['url' => 'wayne.edu'])
+        );
+    }
 }


### PR DESCRIPTION

Allows you to use promos from other sites and enables them to link correctly.

---

### Reason for Change

You're able to use the same promos on multiple sites. This helps redundancy in promo creation, especially for promo items that in theory are multi-use for multiple sites. I have also made changes to the test to reflect the changes.

---

[Basecamp Link](https://3.basecamp.com/5750155/buckets/37389969/card_tables/cards/9886756859)

### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---
<img width="1580" height="943" alt="Screenshot 2026-06-25 at 3 29 14 PM" src="https://github.com/user-attachments/assets/11d5c362-4d96-4a3b-a87f-138dbc256b50" />
<img width="1624" height="987" alt="Screenshot 2026-06-25 at 3 29 48 PM" src="https://github.com/user-attachments/assets/aa126d5f-35fc-42ef-9bed-f4565f9db7fc" />
<img width="1624" height="987" alt="Screenshot 2026-06-25 at 3 29 57 PM" src="https://github.com/user-attachments/assets/d2ac5497-0315-445b-9e30-b6c95024d63d" />
<img width="1624" height="987" alt="Screenshot 2026-06-25 at 3 30 45 PM" src="https://github.com/user-attachments/assets/c4e7b5ff-336e-4c10-b042-bc872d6ff83c" />
<img width="2032" height="1162" alt="Screenshot 2026-07-07 at 11 47 12 AM" src="https://github.com/user-attachments/assets/5c6d46bc-a20d-4f1a-8093-cc38b2d37768" />
<img width="2032" height="1162" alt="Screenshot 2026-07-07 at 11 50 03 AM" src="https://github.com/user-attachments/assets/339cdec1-b3e3-47d7-9cf7-3dd6280ca921" />


---