### PR TITLE
Feature | Components | Added 'visibility' option to show or hide modular components regardless if data is available

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -346,7 +346,22 @@ class ModularPageRepository implements ModularPageRepositoryContract
                 unset($modularComponents[$name]['component']['heading']);
             } else {
                 $modularComponents[$name]['data'] = $promos[$name]['data'] ?? [];
-                $modularComponents[$name]['component'] = $promos[$name]['component'] ?? [];
+                $modularComponents[$name]['component'] = $component;
+            }
+
+            // Post-process based on visibility option
+            $visibility = $component['visibility'] ?? 'data-only';
+            if ($visibility === 'hide') {
+                $modularComponents[$name]['data'] = [];
+            } elseif ($visibility === 'always') {
+                $hasData = !empty($modularComponents[$name]['data']);
+                if ($hasData && (isset($modularComponents[$name]['data']['news']) || isset($modularComponents[$name]['data']['events']))) {
+                    $hasData = !empty($modularComponents[$name]['data']['news']) || !empty($modularComponents[$name]['data']['events']);
+                }
+
+                if (!$hasData) {
+                    $modularComponents[$name]['data'][] = $component;
+                }
             }
         }
 

--- a/styleguide/Views/styleguide-component-guide.blade.php
+++ b/styleguide/Views/styleguide-component-guide.blade.php
@@ -12,7 +12,7 @@
         <h2>Configuring components</h2>
         <p>You will use a JSON array paired with your page field to configure each component. The specifics of each component can be found on the individual component page from the menu.</p>
         <h3 id="example-component-configurations">Example component configuration</h3>
-        <p>Adding this data set into your CMS page fields area will display your promo data as a catalog component.</p>  
+        <p>Adding this data set into your CMS page fields area will display your promo data as a catalog component.</p>
         <table class="mt-2">
             <thead>
                 <tr>
@@ -99,6 +99,13 @@ Add any number of classes to a component heading.
 Change default component heading level from h2 to h3 or h4.
                     </td>
                 </tr>
+                <tr>
+                    <td class="font-bold">visibility</td>
+                    <td>
+<code class="mt-1 mb-2">"visibility":"always"</code><br />
+Control when the component is displayed. Options: <code>data-only</code> (default, only show if there is data), <code>always</code> (always show component), and <code>hide</code> (temporarily hide component).
+                    </td>
+                </tr>
         </table>
 
         <h3>Page config</h3>
@@ -174,10 +181,10 @@ Define how many columns the component will display.<br />
 1 to 4 columns is recommended.
                     </td>
                     <td class="font-bold">
-                        Catalog<br /> 
-                        Button row<br /> 
-                        Icon row<br /> 
-                        Events row<br /> 
+                        Catalog<br />
+                        Button row<br />
+                        Icon row<br />
+                        Events row<br />
                         News row
                     </td>
                 </tr>
@@ -189,10 +196,10 @@ Creates a link to a detailed page of a single promo item, like a Spotlight.<br /
 True or false; false is default and will use the promotion's link field if it is set.
                     </td>
                     <td class="font-bold">
-                        Catalog<br /> 
-                        Spotlight<br /> 
-                        Promo row, column<br /> 
-                        Icon row, column<br /> 
+                        Catalog<br />
+                        Spotlight<br />
+                        Promo row, column<br />
+                        Icon row, column<br />
                     </td>
                 </tr>
                 <tr>
@@ -203,10 +210,10 @@ Show or hide the promo's title.<br />
 True or false; true is default.
                     </td>
                     <td class="font-bold">
-                        Catalog<br /> 
-                        Spotlight<br /> 
-                        Promo row, column<br /> 
-                        Icon row, column<br /> 
+                        Catalog<br />
+                        Spotlight<br />
+                        Promo row, column<br />
+                        Icon row, column<br />
                     </td>
                 </tr>
                 <tr>
@@ -217,10 +224,10 @@ Show or hide the promo's excerpt.<br />
 True or false; true is default.
                     </td>
                     <td class="font-bold">
-                        Catalog<br /> 
-                        Spotlight<br /> 
-                        Promo row, column<br /> 
-                        Icon row, column<br /> 
+                        Catalog<br />
+                        Spotlight<br />
+                        Promo row, column<br />
+                        Icon row, column<br />
                     </td>
                 </tr>
                 <tr>
@@ -232,10 +239,10 @@ True or false; true is default.<br />
 Commonly used in conjunction with "singlePromoView" where the description is hidden from the catalog but displayed on the detailed promo page.
                     </td>
                     <td class="font-bold">
-                        Catalog<br /> 
-                        Spotlight<br /> 
-                        Promo row, column<br /> 
-                        Icon row, column<br /> 
+                        Catalog<br />
+                        Spotlight<br />
+                        Promo row, column<br />
+                        Icon row, column<br />
                     </td>
                 </tr>
                 <tr>
@@ -309,7 +316,7 @@ Define how many columns the component will display.<br />
 1 to 4 columns is recommended.
                     </td>
                     <td class="font-bold">
-                        Events row<br /> 
+                        Events row<br />
                         News row
                     </td>
                 </tr>

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -6,6 +6,8 @@ use Factories\Article;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Test;
 use App\Repositories\ModularPageRepository;
+use Contracts\Repositories\ArticleRepositoryContract;
+use Contracts\Repositories\EventRepositoryContract;
 use Factories\Page;
 use Factories\GenericPromo;
 use Factories\PromoWithOptions;
@@ -729,5 +731,107 @@ final class ModularPageRepositoryTest extends TestCase
 
         $this->assertTrue($component['relative_url'] === $component['filename_url']);
         $this->assertTrue($component['secondary_relative_url'] === $component['secondary_filename_url']);
+    }
+
+    #[Test]
+    public function get_modular_page_components_with_visibility_options(): void
+    {
+        $promo_group_id_summon = 9876;
+        $promo_group_id_accordion_always = 5432;
+        $promo_group_id_accordion_hide = 1111;
+        $promo_group_id_accordion_default = 2222;
+
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+            ],
+            'data' => [
+                // 1. Custom component, no ID, visibility = always -> should display
+                'modular-weekly-hours-1' => '{"visibility": "always", "filename": "weekly-hours"}',
+
+                // 2. Promo component, ID, visibility = always, no promotions returned -> should display
+                'modular-summon-search-1' => '{"id": ' . $promo_group_id_summon . ', "visibility": "always", "filename": "summon-search"}',
+
+                // 3. Promo component, ID, visibility = always, no promotions returned -> should display
+                'modular-accordion-1' => '{"id": ' . $promo_group_id_accordion_always . ', "visibility": "always", "filename": "accordion"}',
+
+                // 4. Promo component, ID, visibility = hide, promotions returned -> should NOT display (empty)
+                'modular-accordion-2' => '{"id": ' . $promo_group_id_accordion_hide . ', "visibility": "hide", "filename": "accordion"}',
+
+                // 5. Promo component, ID, visibility = data-only (default), no promotions returned -> should NOT display (empty)
+                'modular-accordion-3' => '{"id": ' . $promo_group_id_accordion_default . ', "filename": "accordion"}',
+
+                // 6. News and Events component, ID, visibility = always, returns news/events -> should NOT append component, should have news/events
+                'modular-news-and-events-1' => '{"id": 1, "visibility": "always", "filename": "news-and-events"}',
+
+                // 7. News and Events component, ID, visibility = always, returns empty news/events -> should append component
+                'modular-news-and-events-2' => '{"id": 2, "visibility": "always", "filename": "news-and-events"}',
+            ],
+        ]);
+
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn([
+            'promotions' => [
+                [
+                    'promo_item_id' => 101,
+                    'promo_group_id' => $promo_group_id_accordion_hide,
+                    'title' => 'Active Promo',
+                ]
+            ]
+        ]);
+
+        $articleRepo = Mockery::mock(ArticleRepositoryContract::class);
+        $articleRepo->shouldReceive('listing')
+            ->with(1, Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn(['articles' => ['data' => [['title' => 'News 1']], 'meta' => []]]);
+        $articleRepo->shouldReceive('listing')
+            ->with(2, Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn(['articles' => ['data' => [], 'meta' => []]]);
+
+        $eventRepo = Mockery::mock(EventRepositoryContract::class);
+        $eventRepo->shouldReceive('getEvents')
+            ->with(1, Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn(['events' => [['title' => 'Event 1']]]);
+        $eventRepo->shouldReceive('getEvents')
+            ->with(2, Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn(['events' => []]);
+
+        $components = app(ModularPageRepository::class, [
+            'wsuApi' => $wsuApi,
+            'article' => $articleRepo,
+            'event' => $eventRepo,
+        ])->getModularComponents($data);
+
+        // 1. Weekly-hours (visibility: always) should be present and contain the component array in its data list
+        $this->assertArrayHasKey('weekly-hours-1', $components);
+        $this->assertNotEmpty($components['weekly-hours-1']['data']);
+
+        // 2. Summon-search (visibility: always) should be present and contain the component array in its data list
+        $this->assertArrayHasKey('summon-search-1', $components);
+        $this->assertNotEmpty($components['summon-search-1']['data']);
+
+        // 3. Accordion-1 (visibility: always) should be present and contain data even with 0 promos
+        $this->assertArrayHasKey('accordion-1', $components);
+        $this->assertNotEmpty($components['accordion-1']['data']);
+
+        // 4. Accordion-2 (visibility: hide) should be empty even though promos were returned
+        $this->assertArrayHasKey('accordion-2', $components);
+        $this->assertEmpty($components['accordion-2']['data']);
+
+        // 5. Accordion-3 (visibility: data-only / default) should be empty since no promos were returned
+        $this->assertArrayHasKey('accordion-3', $components);
+        $this->assertEmpty($components['accordion-3']['data']);
+
+        // 6. News-and-events-1 (visibility: always, with data) should contain news and events and NOT append the component array
+        $this->assertArrayHasKey('news-and-events-1', $components);
+        $this->assertNotEmpty($components['news-and-events-1']['data']['news']);
+        $this->assertNotEmpty($components['news-and-events-1']['data']['events']);
+        $this->assertArrayNotHasKey(0, $components['news-and-events-1']['data']);
+
+        // 7. News-and-events-2 (visibility: always, empty data) should append the component array to the data list
+        $this->assertArrayHasKey('news-and-events-2', $components);
+        $this->assertEmpty($components['news-and-events-2']['data']['news']);
+        $this->assertEmpty($components['news-and-events-2']['data']['events']);
+        $this->assertArrayHasKey(0, $components['news-and-events-2']['data']);
     }
 }


### PR DESCRIPTION
By default, custom page fields only show when they have data (from promotions, news, or events). This is a great standard practice, but there are times when we may want to disable a component for a short time or display a component that isn't connected to a datasource at all.

This change allows us to determine the visibility of a component based on the "visibility" config option. It is a new optional option available to all existing and future components.

It allows us to have a formal way of hiding a component instead of changing the custom page field or putting a "/" or somehow making the JSON invalid to force skipping over the component.

It allows us to introduce components that do not rely on promotion groups (JavaScript only, third-party sources, static HTML, etc).

## Default behavior

`visibility: data-only` - The default visibility is to only show a component if there is data. No need to list this, but added for completeness/documentation.

## Temporarily hide

`visibility: hide` - Allows the content owner to "hide" a component while keeping everything about its name, position and config intact.

## Show without data

`visibility: always` - Right now, the only way to show a component that isn't connected to a promotion is to add it to the code as an exception. Being able to show something all the time, reguarless if there is data, decouples the component from a collection.

## Demo / Context

| Config | Result |
|--------|------|
| <img width="935" height="190" alt="Screenshot 2026-07-10 at 1 24 45 PM" src="https://github.com/user-attachments/assets/62020c85-e94e-4544-aec4-346507143de6" /> | <img width="797" height="259" alt="Screenshot 2026-07-10 at 1 25 02 PM" src="https://github.com/user-attachments/assets/be516b91-26f2-4917-9a29-9d2c69fc0a43" /> |

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

## Testing Notes

Tests added to confirm each visibility option:

<img width="869" height="408" alt="Screenshot 2026-07-10 at 1 26 12 PM" src="https://github.com/user-attachments/assets/332dd514-1ecb-42b9-92e9-e6ad730482ed" />