### PR TITLE
Refactor | Modular component Tabs | Accessibility - Add ARIA roles and arrow key navigation

### DIFF
--- a/resources/js/modules/tabs.js
+++ b/resources/js/modules/tabs.js
@@ -4,15 +4,30 @@
     const tabAreas = document.querySelectorAll('.js-tabArea');
     if (tabAreas.length === 0) return;
 
-    // Activates a tab based on the clicked link
-    function activateTab(linkElement) {
+    // 'setFocus' flag to manage visual focus.
+    function activateTab(linkElement, setFocus = true) {
         const container = linkElement.closest('.js-tabArea');
 
+        // Reset ARIA and tabindex for all tabs.
+        const nav = container.querySelector('.js-tabNav');
+        nav.querySelectorAll('a[role="tab"]').forEach(el => {
+            el.parentElement.classList.remove('active');
+            el.setAttribute('aria-selected', 'false');
+            el.setAttribute('tabindex', '-1');
+        });
+
         // Deactivate all active items
-        container.querySelectorAll('.active').forEach(el => el.classList.remove('active'));
+        container.querySelectorAll('.tabs__pane-content').forEach(el => el.classList.remove('active'));
 
         // Activate the clicked Tab li
         linkElement.parentElement.classList.add('active');
+
+        // ARIA, tabindex, and apply focus.
+        linkElement.setAttribute('aria-selected', 'true');
+        linkElement.setAttribute('tabindex', '0');
+        if (setFocus) {
+            linkElement.focus();
+        }
 
         // Activate the Content Panel using data-target
         const targetSelector = linkElement.dataset.target;
@@ -24,10 +39,11 @@
 
     // Click Handler
     function onTabClick(event) {
-        event.preventDefault();
-        const link = event.target.closest('a');
+        // Target elements with role="tab".
+        const link = event.target.closest('a[role="tab"]');
         if (!link) return;
 
+        event.preventDefault();
         activateTab(link);
 
         // Sets hash to #definition-123
@@ -38,22 +54,59 @@
         }
     }
 
+    // Accessible keyboard navigation (arrows, home, end).
+    function onTabKeydown(event) {
+        const link = event.target.closest('a[role="tab"]');
+        if (!link) return;
+
+        const nav = link.closest('.js-tabNav');
+        const tabs = Array.from(nav.querySelectorAll('a[role="tab"]'));
+        const index = tabs.indexOf(link);
+        let nextIndex = null;
+
+        switch (event.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+                nextIndex = (index === tabs.length - 1) ? 0 : index + 1;
+                event.preventDefault();
+                break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                nextIndex = (index === 0) ? tabs.length - 1 : index - 1;
+                event.preventDefault();
+                break;
+            case 'Home':
+                nextIndex = 0;
+                event.preventDefault();
+                break;
+            case 'End':
+                nextIndex = tabs.length - 1;
+                event.preventDefault();
+                break;
+        }
+
+        if (nextIndex !== null) {
+            const nextTab = tabs[nextIndex];
+            activateTab(nextTab, true);
+        }
+    }
+
     // Listen for clicks
     tabAreas.forEach(function(area) {
-        const navElement = area.querySelector(' .js-tabNav');
+        const navElement = area.querySelector('.js-tabNav');
         if (navElement) {
             navElement.addEventListener('click', onTabClick, false);
+            navElement.addEventListener('keydown', onTabKeydown, false);
         }
     });
 
     // Check if URL Hash matches a tab
     if (window.location.hash) {
-        // We look for a link where href="#definition-..." and matches the current hash
         const matchingLink = document.querySelector(`.js-tabNav a[href="${window.location.hash}"]`);
 
         if (matchingLink) {
-            activateTab(matchingLink);
-            // Smooth scroll to tabs if deep linked
+            // Prevent focus stealing on initial load.
+            activateTab(matchingLink, false);
             matchingLink.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }

--- a/resources/scss/components/_tabs.scss
+++ b/resources/scss/components/_tabs.scss
@@ -36,7 +36,7 @@
     }
 
     &__nav-link {
-        @apply w-full h-full text-white bg-green text-sm leading-tight hover:underline p-4 pt-3 border-t-8 border-green-700 box-border;
+        @apply w-full h-full text-white bg-green text-sm leading-tight hover:underline p-4 pt-3 border-t-8 border-green-700 box-border focus-visible:outline-2 focus-visible:outline-green;
     }
 
     &__pane {

--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -5,14 +5,20 @@
     @include('components.accordion', ['data' => $data])
 
     <div class="tabs__area js-tabArea">
-        <ul class="tabs__nav js-tabNav">
+        <ul class="tabs__nav js-tabNav" role="tablist" aria-label="Promo Tabs">
             @foreach($data as $item)
                 <li @class([
                         'tabs__nav-item',
                         'lg:w-1/' . $loop->count,
                         'active' => $loop->first
-                    ])>
+                    ]) role="presentation">
+
                     <a class="tabs__nav-link"
+                       id="tab-link-{{ $item['promo_item_id'] }}"
+                       role="tab"
+                       aria-selected="{{ $loop->first ? 'true' : 'false' }}"
+                       aria-controls="tab-{{ $item['promo_item_id'] }}"
+                       tabindex="{{ $loop->first ? '0' : '-1' }}"
                        href="#definition-{{ $item['promo_item_id'] }}"
                        data-target="#tab-{{ $item['promo_item_id'] }}">
                         {{ $item['title'] }}
@@ -23,7 +29,12 @@
 
         <div class="tabs__pane">
             @foreach($data as $item)
-                <div @class(['tabs__pane-content', 'active' => $loop->first]) id="tab-{{ $item['promo_item_id'] }}">
+                <div @class(['tabs__pane-content', 'active' => $loop->first])
+                     id="tab-{{ $item['promo_item_id'] }}"
+                     role="tabpanel"
+                     aria-labelledby="tab-link-{{ $item['promo_item_id'] }}"
+                     tabindex="0">
+
                     <div @class([
                          'content',
                          'tabs__pane-description',

--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -5,7 +5,7 @@
     @include('components.accordion', ['data' => $data])
 
     <div class="tabs__area js-tabArea">
-        <ul class="tabs__nav js-tabNav" role="tablist" aria-label="Promo Tabs">
+        <ul class="tabs__nav js-tabNav" role="tablist">
             @foreach($data as $item)
                 <li @class([
                         'tabs__nav-item',


### PR DESCRIPTION
Accesibility Review goals

Add in ARIA for tabs: currently there is no designated role for tabs (role="tablist", role="tab", role="tabpanel"). Without this, each tab just reads out like a link and there is not context given to screen reader users for the changing content.

Each tab section should be navigable using the horizontal arrow keys: right now you have to use the tab key to get through the full list of tab options.

### Relevant links
- https://dequeuniversity.com/library/aria/tabpanel
- https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#keyboardinteraction

### Final Checklist
- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

### Screen Recording of use of arrow key navigation
https://www.loom.com/share/5f4a174405514db39ae435d7e661f22f