### PR TITLE
FEATURE | Caching | Fallback cache fallback for failing API response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ NEWS_API_CACHE=../storage/app/newsapi/
 NEWS_API_ENDPOINT=https://news.wayne.edu/api/v1/
 
 TTL=0
+CACHE_STALE_TTL=604800
 
 CONFIG_OVERRIDE=
 

--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -5,9 +5,12 @@ namespace App\Repositories;
 use Contracts\Repositories\ArticleRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\News;
+use App\Traits\StaleCache;
 
 class ArticleRepository implements ArticleRepositoryContract
 {
+    use StaleCache;
+
     /** @var News */
     protected $newsApi;
 
@@ -45,7 +48,7 @@ class ArticleRepository implements ArticleRepositoryContract
             $params['topics'] = $topics;
         }
 
-        $articles['articles'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $articles['articles'] = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             try {
                 return $this->newsApi->request($params['method'], $params);
             } catch (\Exception $e) {
@@ -67,7 +70,7 @@ class ArticleRepository implements ArticleRepositoryContract
             'preview' => $preview,
         ];
 
-        $article['article'] = $this->cache->remember($params['method'].md5(serialize($params)), $preview ? 0 : config('cache.ttl'), function () use ($params) {
+        $article['article'] = $this->rememberWithFallback($params['method'].md5(serialize($params)), $preview ? 0 : config('cache.ttl'), function () use ($params) {
             return $this->newsApi->request($params['method'], $params);
         });
 

--- a/app/Repositories/EventRepository.php
+++ b/app/Repositories/EventRepository.php
@@ -6,9 +6,14 @@ use Contracts\Repositories\EventRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\Connector;
 use Waynestate\Promotions\ParsePromos;
+use App\Traits\StaleCache;
+use App\Traits\FiltersExpiredItems;
 
 class EventRepository implements EventRepositoryContract
 {
+    use StaleCache;
+    use FiltersExpiredItems;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -40,19 +45,19 @@ class EventRepository implements EventRepositoryContract
             'end_date' => date('Y-m-d', strtotime('+6 month')),
         ];
 
-        $events['events'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        // Cache the raw list only — grouping and expiry filtering must run on every
+        // call (fresh or stale), not just when the API is actually reached.
+        $events_listing = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
-            $events_listing = $this->wsuApi->sendRequest($params['method'], $params);
+            $response = $this->wsuApi->sendRequest($params['method'], $params);
 
-            if (!empty($events_listing['events'])) {
-                $events_listing = collect($events_listing['events'])->groupBy('date')->toArray();
-            } else {
-                $events_listing = [];
-            }
-
-            return $events_listing;
+            return !empty($response['events']) ? $response['events'] : [];
         });
+
+        $events['events'] = collect($this->filterExpiredItems($events_listing, ['date']))
+            ->groupBy('date')
+            ->toArray();
 
         return $events;
     }
@@ -69,29 +74,30 @@ class EventRepository implements EventRepositoryContract
             'end_date' => date('Y-m-d', strtotime('+6 month')),
         ];
 
-        $events['events'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params, $limit) {
+        // Cache the raw list only — the image-fallback map, expiry filter, and
+        // limit must run on every call (fresh or stale), not just when the API
+        // is actually reached.
+        $events_listing = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
-            $events_listing = $this->wsuApi->sendRequest($params['method'], $params);
+            $response = $this->wsuApi->sendRequest($params['method'], $params);
 
-            if (!empty($events_listing['events'])) {
-                $events = collect($events_listing['events'])
-                    ->map(function ($event) {
-                        if (!empty($event['images'])) {
-                            $event['display_image'] = collect($event['images'])->first();
-                        } else {
-                            $event['display_image']['full_url'] = 'https://wayne.edu/opengraph/wsu-social-share-square.jpg';
-                            $event['display_image']['description'] = 'Event on wayne.edu';
-                        }
-
-                        return $event;
-                    })
-                    ->take($limit)
-                    ->toArray();
-            }
-
-            return $events ?? [];
+            return !empty($response['events']) ? $response['events'] : [];
         });
+
+        $events['events'] = collect($this->filterExpiredItems($events_listing, ['end_date', 'repeat_end_date'], false))
+            ->map(function ($event) {
+                if (!empty($event['images'])) {
+                    $event['display_image'] = collect($event['images'])->first();
+                } else {
+                    $event['display_image']['full_url'] = 'https://wayne.edu/opengraph/wsu-social-share-square.jpg';
+                    $event['display_image']['description'] = 'Event on wayne.edu';
+                }
+
+                return $event;
+            })
+            ->take($limit)
+            ->toArray();
 
         return $events;
     }

--- a/app/Repositories/HomepageRepository.php
+++ b/app/Repositories/HomepageRepository.php
@@ -7,9 +7,14 @@ use Contracts\Repositories\ModularPageRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\Connector;
 use Waynestate\Promotions\ParsePromos;
+use App\Traits\StaleCache;
+use App\Traits\FiltersExpiredItems;
 
 class HomepageRepository implements HomepageRepositoryContract
 {
+    use StaleCache;
+    use FiltersExpiredItems;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -57,9 +62,13 @@ class HomepageRepository implements HomepageRepositoryContract
             'is_active' => '1',
         ];
 
-        $promos = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $promos = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
+
+        if (!empty($promos['promotions'])) {
+            $promos['promotions'] = $this->filterExpiredItems($promos['promotions'], ['end_date', 'display_end_date']);
+        }
 
         return $this->parsePromos->parse($promos, $group_reference, $group_config);
     }

--- a/app/Repositories/MenuRepository.php
+++ b/app/Repositories/MenuRepository.php
@@ -11,9 +11,12 @@ use Waynestate\Api\Connector;
 use Waynestate\Menuitems\ParseMenu;
 use Waynestate\Menu\DisplayMenu;
 use Illuminate\Cache\Repository;
+use App\Traits\StaleCache;
 
 class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryContract
 {
+    use StaleCache;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -161,7 +164,7 @@ class MenuRepository implements RequestDataRepositoryContract, MenuRepositoryCon
             'include_subsites' => true,
         ];
 
-        $menus = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $menus = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
 

--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -9,9 +9,14 @@ use Illuminate\Cache\Repository;
 use Illuminate\Support\Str;
 use Waynestate\Api\Connector;
 use Waynestate\Promotions\ParsePromos;
+use App\Traits\StaleCache;
+use App\Traits\FiltersExpiredItems;
 
 class ModularPageRepository implements ModularPageRepositoryContract
 {
+    use StaleCache;
+    use FiltersExpiredItems;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -181,9 +186,13 @@ class ModularPageRepository implements ModularPageRepositoryContract
             'is_active' => '1',
         ];
 
-        $promos = $this->cache->remember($params['method'] . md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $promos = $this->rememberWithFallback($params['method'] . md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
+
+        if (!empty($promos['promotions'])) {
+            $promos['promotions'] = $this->filterExpiredItems($promos['promotions'], ['end_date', 'display_end_date']);
+        }
 
         // Use another site's promo items only from Base
         if (!empty($site_id) && $site_id === 1561) {

--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -11,9 +11,12 @@ use Waynestate\Api\News;
 use Waynestate\Promotions\ParsePromos;
 use Contracts\Repositories\ProfileRepositoryContract;
 use Illuminate\Support\Facades\Config;
+use App\Traits\StaleCache;
 
 class ProfileRepository implements ProfileRepositoryContract
 {
+    use StaleCache;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -48,7 +51,7 @@ class ProfileRepository implements ProfileRepositoryContract
             'groups' => $selected_group,
         ];
 
-        $profile_listing = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $profile_listing = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
             return $this->wsuApi->sendRequest($params['method'], $params);
@@ -206,7 +209,7 @@ class ProfileRepository implements ProfileRepositoryContract
             'site_id' => $site_id,
         ];
 
-        $profile_groups = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $profile_groups = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
             return $this->wsuApi->sendRequest($params['method'], $params);
@@ -248,7 +251,7 @@ class ProfileRepository implements ProfileRepositoryContract
             'include_courses' => 'true',
         ];
 
-        $profiles = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $profiles = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
             return $this->wsuApi->sendRequest($params['method'], $params);
@@ -291,7 +294,7 @@ class ProfileRepository implements ProfileRepositoryContract
             'env' => config('app.env'),
         ];
 
-        $articles = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $articles = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             try {
                 $articles = $this->newsApi->request($params['method'], $params);
 

--- a/app/Repositories/PromoRepository.php
+++ b/app/Repositories/PromoRepository.php
@@ -9,9 +9,14 @@ use Contracts\Repositories\ModularPageRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\Connector;
 use Waynestate\Promotions\ParsePromos;
+use App\Traits\StaleCache;
+use App\Traits\FiltersExpiredItems;
 
 class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryContract
 {
+    use StaleCache;
+    use FiltersExpiredItems;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -58,9 +63,13 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
             'is_active' => '1',
         ];
 
-        $promo = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $promo = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
+
+        if (!empty($promo['promotion']) && $this->isExpired($promo['promotion'], ['end_date', 'display_end_date'])) {
+            $promo['promotion'] = [];
+        }
 
         $promo['promo'] = empty($promo['error']) ? $promo['promotion'] : [];
 
@@ -124,9 +133,13 @@ class PromoRepository implements RequestDataRepositoryContract, PromoRepositoryC
             'is_active' => '1',
         ];
 
-        $promos = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $promos = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
+
+        if (!empty($promos['promotions'])) {
+            $promos['promotions'] = $this->filterExpiredItems($promos['promotions'], ['end_date', 'display_end_date']);
+        }
 
         $group_config = $this->createGlobalPromoGroupConfig($data, $config, $groups);
 

--- a/app/Repositories/TopicRepository.php
+++ b/app/Repositories/TopicRepository.php
@@ -5,9 +5,12 @@ namespace App\Repositories;
 use Contracts\Repositories\TopicRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\News;
+use App\Traits\StaleCache;
 
 class TopicRepository implements TopicRepositoryContract
 {
+    use StaleCache;
+
     /** @var News */
     protected $newsApi;
 
@@ -33,7 +36,7 @@ class TopicRepository implements TopicRepositoryContract
             'method' => 'topics',
         ];
 
-        $topics['topics'] = $this->cache->remember('newsroom-topics'.md5(serialize($params)), config('cache.ttl'), function () use ($params, $subsite_folder) {
+        $topics['topics'] = $this->rememberWithFallback('newsroom-topics'.md5(serialize($params)), config('cache.ttl'), function () use ($params, $subsite_folder) {
             try {
                 $topics = $this->newsApi->request($params['method'], $params);
             } catch (\Exception $e) {
@@ -70,7 +73,7 @@ class TopicRepository implements TopicRepositoryContract
             'method' => 'topic/'.$slug,
         ];
 
-        $topic['topic'] = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $topic['topic'] = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->newsApi->request($params['method'], $params);
         });
 

--- a/app/Traits/FiltersExpiredItems.php
+++ b/app/Traits/FiltersExpiredItems.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Traits;
+
+use Carbon\Carbon;
+use Throwable;
+
+trait FiltersExpiredItems
+{
+    /**
+     * Whether an item's explicit expiration has passed, considering the
+     * earliest (or latest, when $useEarliest is false) of the given fields
+     * that are actually set. An item with none of the fields set never expires.
+     */
+    public function isExpired(array $item, array $fields, bool $useEarliest = true): bool
+    {
+        $dates = collect($fields)
+            ->map(fn ($field) => $this->parseExpiryDate($item[$field] ?? null))
+            ->filter();
+
+        if ($dates->isEmpty()) {
+            return false;
+        }
+
+        $boundary = $useEarliest ? $dates->min() : $dates->max();
+
+        return $boundary->isPast();
+    }
+
+    /**
+     * Reject expired items from a list. See isExpired() for field semantics.
+     */
+    public function filterExpiredItems(array $items, array $fields, bool $useEarliest = true): array
+    {
+        return collect($items)
+            ->reject(fn ($item) => $this->isExpired($item, $fields, $useEarliest))
+            ->toArray();
+    }
+
+    /**
+     * Parse a date field, treating empty strings, the '0000-00-00...' sentinel,
+     * and unparseable values as "not set" (never expires on that field alone).
+     * Date-only values (no time component) represent the whole day, so expiry
+     * is evaluated against the end of that day rather than its start.
+     */
+    private function parseExpiryDate($value): ?Carbon
+    {
+        if (empty($value) || !is_string($value) || str_starts_with(trim($value), '0000-00-00')) {
+            return null;
+        }
+
+        try {
+            $date = Carbon::parse($value);
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($value)) === 1) {
+            return $date->endOfDay();
+        }
+
+        return $date;
+    }
+}

--- a/app/Traits/StaleCache.php
+++ b/app/Traits/StaleCache.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+trait StaleCache
+{
+    /**
+     * Cache the result of a callback, falling back to a long-lived stale copy
+     * when the callback fails or returns null (API/DB outage), and falling
+     * back to $default when no stale copy exists yet (cold start).
+     */
+    public function rememberWithFallback(string $key, $ttl, callable $callback, $default = [])
+    {
+        $cached = $this->cache->get($key);
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $stale_key = 'stale_'.$key;
+        $exception = null;
+
+        try {
+            $value = $callback();
+        } catch (Throwable $e) {
+            $exception = $e;
+            $value = null;
+        }
+
+        if ($value !== null) {
+            $this->cache->put($key, $value, $ttl);
+            $this->cache->put($stale_key, $value, config('cache.stale_ttl'));
+
+            return $value;
+        }
+
+        $stale = $this->cache->get($stale_key);
+
+        Log::warning(sprintf(
+            'StaleCache: falling back to %s for cache key [%s]%s',
+            $stale !== null ? 'stale data' : 'default (no stale data available)',
+            $key,
+            $exception !== null ? ' after exception: '.$exception->getMessage() : ' after a null API response'
+        ));
+
+        return $stale !== null ? $stale : $default;
+    }
+}

--- a/config/cache.php
+++ b/config/cache.php
@@ -6,4 +6,6 @@ return [
 
     'ttl' => env('TTL'),
 
+    'stale_ttl' => env('CACHE_STALE_TTL', 604800),
+
 ];

--- a/tests/Unit/Repositories/EventRepositoryTest.php
+++ b/tests/Unit/Repositories/EventRepositoryTest.php
@@ -38,6 +38,24 @@ final class EventRepositoryTest extends TestCase
         // Expected events to be returned
         $expected = app(Event::class)->create(2);
 
+        // Event::create()'s faker dates default to somewhere earlier this month,
+        // which the repository's now-mandatory past-date expiry filter would
+        // strip out. Force both groups into the future so this test exercises
+        // grouping behavior without tripping that filter.
+        $future_dates = [now()->addDays(10)->format('Y-m-d'), now()->addDays(20)->format('Y-m-d')];
+        $expected = collect(array_values($expected))
+            ->mapWithKeys(function ($events, $index) use ($future_dates) {
+                $date = $future_dates[$index];
+
+                $events = collect($events)->map(function ($event) use ($date) {
+                    $event['date'] = $date;
+
+                    return $event;
+                })->all();
+
+                return [$date => $events];
+            })->all();
+
         // Maniuplate events to mimic the API return since they aren't grouped yet
         $return['events'] = collect($expected)->flatten(1)->toArray();
 

--- a/tests/Unit/Repositories/HomepageRepositoryTest.php
+++ b/tests/Unit/Repositories/HomepageRepositoryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\Test;
 use App\Repositories\HomepageRepository;
 use Factories\GenericPromo;
 use Factories\Page;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 use Mockery as Mockery;
 use Waynestate\Api\Connector;
@@ -15,11 +16,19 @@ final class HomepageRepositoryTest extends TestCase
     #[Test]
     public function getting_homepage_promos_should_return_array(): void
     {
-        $promo_return = app(GenericPromo::class)->create(4, false);
+        // getHomepagePromos() hardcodes group_reference [123 => 'example'], so its
+        // cache key never varies by test input — flush first so the array cache
+        // store (which persists across tests) can't serve a stale hit here.
+        Cache::flush();
+
+        // The API's listing method returns items under a 'promotions' key.
+        $promo_return = app(GenericPromo::class)->create(4, false, [
+            'promo_group_id' => 123,
+        ]);
 
         // Fake return
         $return = [
-            'promotion' => $promo_return,
+            'promotions' => $promo_return,
         ];
 
         // Mock the connector and set the return
@@ -30,6 +39,33 @@ final class HomepageRepositoryTest extends TestCase
         $promos = app(HomepageRepository::class, ['wsuApi' => $wsuApi])->getHomepagePromos($promo_return);
 
         $this->assertTrue(is_array($promos));
+        $this->assertNotEmpty($promos['example']);
+    }
+
+    #[Test]
+    public function expired_homepage_promo_is_filtered_out(): void
+    {
+        // Same fixed cache key concern as above.
+        Cache::flush();
+
+        $promo_return = app(GenericPromo::class)->create(1, false, [
+            'promo_group_id' => 123,
+            'end_date' => now()->subDays(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        // Fake return
+        $return = [
+            'promotions' => $promo_return,
+        ];
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn($return);
+
+        // Get the promos
+        $promos = app(HomepageRepository::class, ['wsuApi' => $wsuApi])->getHomepagePromos([]);
+
+        $this->assertEmpty($promos['example']);
     }
 
     #[Test]

--- a/tests/Unit/Repositories/PromoRepositoryTest.php
+++ b/tests/Unit/Repositories/PromoRepositoryTest.php
@@ -307,6 +307,75 @@ final class PromoRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function expired_promo_excluded_from_listing(): void
+    {
+        // Use a group id unique to this test so its cache key (derived from
+        // the group id list) can't collide with another test's cached entry
+        // under the array cache store, which persists across tests.
+        $group_id = $this->faker->unique()->numberBetween(100000, 999999);
+        $active_item_id = $this->faker->unique()->numberBetween(1, 99);
+
+        // Fake return: one expired item, one active item, same group
+        $return = [
+            'promotions' => [
+                [
+                    'promo_item_id' => $active_item_id + 1,
+                    'promo_group_id' => $group_id,
+                    'end_date' => now()->subDays(2)->format('Y-m-d H:i:s'),
+                    'display_end_date' => '0000-00-00 00:00:00',
+                ],
+                [
+                    'promo_item_id' => $active_item_id,
+                    'promo_group_id' => $group_id,
+                    'end_date' => '',
+                    'display_end_date' => '0000-00-00 00:00:00',
+                ],
+            ],
+        ];
+
+        // Create a fake data request
+        $data = app(Page::class)->create(1, true, [
+            'site' => [
+                'id' => 2,
+                'parent' => [
+                    'id' => 1,
+                ],
+            ],
+        ]);
+
+        // Build the config
+        config(['base.global' => [
+            'all' => [
+                'promos' => [],
+            ],
+            'sites' => [
+                $data['site']['id'] => [
+                    'promos' => [
+                        // merge_with_main_contact must be explicit false here — when
+                        // unset, manipulateGlobalPromos() merges in main_contact via
+                        // array_merge(), which renumbers purely-integer promo_item_id
+                        // keys and would make the key-based assertion below meaningless.
+                        'contact' => [
+                            'id' => $group_id,
+                            'merge_with_main_contact' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn($return);
+
+        // Get the promos
+        $promos = app(PromoRepository::class, ['wsuApi' => $wsuApi])->getRequestData($data);
+
+        $this->assertCount(1, $promos['contact']);
+        $this->assertEquals($active_item_id, $promos['contact'][$active_item_id]['promo_item_id']);
+    }
+
+    #[Test]
     public function subsite_under_menu_merging_with_no_main_under_menu(): void
     {
         // Fake return
@@ -381,6 +450,28 @@ final class PromoRepositoryTest extends TestCase
         $promo['promotion'] = $single_promo['promo'];
 
         $this->assertEquals($promo, ['promotion' => $promo_return]);
+    }
+
+    #[Test]
+    public function expired_single_promo_should_be_filtered_out(): void
+    {
+        $promo_return = app(GenericPromo::class)->create(1, true, [
+            'end_date' => now()->subDays(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        // Fake return
+        $return = [
+            'promotion' => $promo_return,
+        ];
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.info', Mockery::type('array'))->once()->andReturn($return);
+
+        // Get the promo
+        $single_promo = app(PromoRepository::class, ['wsuApi' => $wsuApi])->getPromoView($this->faker->randomDigit());
+
+        $this->assertEquals([], $single_promo['promo']);
     }
 
     #[Test]

--- a/tests/Unit/Traits/FiltersExpiredItemsTest.php
+++ b/tests/Unit/Traits/FiltersExpiredItemsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit\Traits;
+
+use App\Traits\FiltersExpiredItems;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class FiltersExpiredItemsTest extends TestCase
+{
+    private function subject(): object
+    {
+        return new class () {
+            use FiltersExpiredItems;
+        };
+    }
+
+    #[Test]
+    public function item_with_no_expiry_fields_set_is_never_expired(): void
+    {
+        $item = ['title' => 'Evergreen', 'end_date' => '', 'display_end_date' => '0000-00-00 00:00:00'];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['end_date', 'display_end_date']));
+    }
+
+    #[Test]
+    public function single_field_in_the_past_is_expired(): void
+    {
+        $item = ['date' => now()->subDays(3)->format('Y-m-d')];
+
+        $this->assertTrue($this->subject()->isExpired($item, ['date']));
+    }
+
+    #[Test]
+    public function single_field_today_is_not_expired(): void
+    {
+        // Date-only fields are evaluated against the END of that day, so an
+        // event happening later today isn't hidden as already past.
+        $item = ['date' => now()->format('Y-m-d')];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['date']));
+    }
+
+    #[Test]
+    public function single_field_in_the_future_is_not_expired(): void
+    {
+        $item = ['date' => now()->addDays(3)->format('Y-m-d')];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['date']));
+    }
+
+    #[Test]
+    public function earliest_mode_expires_when_the_earlier_field_has_passed(): void
+    {
+        $item = [
+            'end_date' => now()->subDays(1)->format('Y-m-d H:i:s'),
+            'display_end_date' => now()->addDays(10)->format('Y-m-d H:i:s'),
+        ];
+
+        $this->assertTrue($this->subject()->isExpired($item, ['end_date', 'display_end_date'], true));
+    }
+
+    #[Test]
+    public function latest_mode_does_not_expire_until_the_later_field_has_passed(): void
+    {
+        $item = [
+            'end_date' => now()->subDays(1)->format('Y-m-d'),
+            'repeat_end_date' => now()->addDays(10)->format('Y-m-d'),
+        ];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['end_date', 'repeat_end_date'], false));
+    }
+
+    #[Test]
+    public function latest_mode_expires_once_both_fields_have_passed(): void
+    {
+        $item = [
+            'end_date' => now()->subDays(10)->format('Y-m-d'),
+            'repeat_end_date' => now()->subDays(1)->format('Y-m-d'),
+        ];
+
+        $this->assertTrue($this->subject()->isExpired($item, ['end_date', 'repeat_end_date'], false));
+    }
+
+    #[Test]
+    public function sentinel_values_are_treated_as_not_set(): void
+    {
+        $item = [
+            'end_date' => '',
+            'display_end_date' => '0000-00-00 00:00:00',
+        ];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['end_date', 'display_end_date']));
+    }
+
+    #[Test]
+    public function unparseable_value_is_treated_as_not_set(): void
+    {
+        $item = ['end_date' => 'not-a-real-date'];
+
+        $this->assertFalse($this->subject()->isExpired($item, ['end_date']));
+    }
+
+    #[Test]
+    public function filter_expired_items_rejects_only_expired_entries(): void
+    {
+        $items = [
+            ['title' => 'Expired', 'end_date' => now()->subDays(1)->format('Y-m-d H:i:s'), 'display_end_date' => ''],
+            ['title' => 'Active', 'end_date' => now()->addDays(1)->format('Y-m-d H:i:s'), 'display_end_date' => ''],
+            ['title' => 'Evergreen', 'end_date' => '', 'display_end_date' => '0000-00-00 00:00:00'],
+        ];
+
+        $filtered = $this->subject()->filterExpiredItems($items, ['end_date', 'display_end_date']);
+
+        $this->assertCount(2, $filtered);
+        $this->assertEquals(['Active', 'Evergreen'], collect($filtered)->pluck('title')->values()->toArray());
+    }
+}

--- a/tests/Unit/Traits/StaleCacheTest.php
+++ b/tests/Unit/Traits/StaleCacheTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Traits;
+
+use App\Traits\StaleCache;
+use Illuminate\Cache\Repository;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Tests\TestCase;
+
+final class StaleCacheTest extends TestCase
+{
+    private function subject(): object
+    {
+        return new class (app(Repository::class)) {
+            use StaleCache;
+
+            public $cache;
+
+            public function __construct(Repository $cache)
+            {
+                $this->cache = $cache;
+            }
+        };
+    }
+
+    #[Test]
+    public function callback_success_populates_primary_and_stale_cache(): void
+    {
+        $key = 'test-key-'.$this->faker->uuid();
+        $value = ['data' => $this->faker->word()];
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () use ($value) {
+            return $value;
+        });
+
+        $this->assertEquals($value, $result);
+        $this->assertEquals($value, app(Repository::class)->get($key));
+        $this->assertEquals($value, app(Repository::class)->get('stale_'.$key));
+    }
+
+    #[Test]
+    public function primary_cache_hit_does_not_invoke_callback(): void
+    {
+        $key = 'test-key-'.$this->faker->uuid();
+        $value = ['data' => $this->faker->word()];
+
+        app(Repository::class)->put($key, $value, 60);
+
+        $invoked = false;
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () use ($value, &$invoked) {
+            $invoked = true;
+
+            return $value;
+        });
+
+        $this->assertEquals($value, $result);
+        $this->assertFalse($invoked);
+    }
+
+    #[Test]
+    public function callback_throwing_falls_back_to_stale_data_and_logs(): void
+    {
+        $key = 'test-key-'.$this->faker->uuid();
+        $stale_value = ['data' => $this->faker->word()];
+
+        app(Repository::class)->put('stale_'.$key, $stale_value, 604800);
+
+        Log::shouldReceive('warning')->once();
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () {
+            throw new RuntimeException('API is down');
+        });
+
+        $this->assertEquals($stale_value, $result);
+    }
+
+    #[Test]
+    public function callback_returning_null_falls_back_to_stale_data_and_logs(): void
+    {
+        // This is the total-outage path: vendor Connector::sendRequest() swallows
+        // failures and returns null rather than throwing.
+        $key = 'test-key-'.$this->faker->uuid();
+        $stale_value = ['data' => $this->faker->word()];
+
+        app(Repository::class)->put('stale_'.$key, $stale_value, 604800);
+
+        Log::shouldReceive('warning')->once();
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () {
+            return null;
+        });
+
+        $this->assertEquals($stale_value, $result);
+    }
+
+    #[Test]
+    public function callback_throwing_with_no_stale_data_returns_default_and_logs(): void
+    {
+        $key = 'test-key-'.$this->faker->uuid();
+
+        Log::shouldReceive('warning')->once();
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () {
+            throw new RuntimeException('API is down');
+        });
+
+        $this->assertEquals([], $result);
+    }
+
+    #[Test]
+    public function callback_returning_null_with_no_stale_data_returns_custom_default_and_logs(): void
+    {
+        $key = 'test-key-'.$this->faker->uuid();
+        $default = ['fallback' => true];
+
+        Log::shouldReceive('warning')->once();
+
+        $result = $this->subject()->rememberWithFallback($key, 60, function () {
+            return null;
+        }, $default);
+
+        $this->assertEquals($default, $result);
+    }
+}


### PR DESCRIPTION
## Reason for Change
A recent DB outage caused the WSU API to hang, and with no stale fallback, every page request blocked up to 20s before failing, taking down all front-end pages.  This applies graceful-degradation behavior (explicitly, with tests) and adds a follow-up requirement: stale data shouldn't resurrect content that has since expired on its own terms.

## Relevant Links
- https://3.basecamp.com/5750155/buckets/37389969/card_tables/cards/9976847319#__recording_10091181394

---
  
## Demo / Context
### Screenshots
<img width="1960" height="1408" alt="index" src="https://github.com/user-attachments/assets/2102e332-9914-4222-88dd-789d059b9420" />
<img width="1999" height="1414" alt="event listing" src="https://github.com/user-attachments/assets/aa689eb1-c7e0-4ea3-be6c-bbf7a4813a40" />
<img width="1368" height="491" alt="stale cache" src="https://github.com/user-attachments/assets/b4a21aae-7d5a-431f-a32d-f18678fcae28" />
<img width="979" height="112" alt="EventRepositoryTest" src="https://github.com/user-attachments/assets/77b2a3f6-ea45-4328-aaf9-ce20491112a9" />
<img width="962" height="421" alt="Cache tests" src="https://github.com/user-attachments/assets/e48f7162-6121-4050-8525-258f4f296ea0" />

---

  ### Final Checklist
  
  - [x] I have reviewed my code and it follows project standards
  - [x] I have tested the changes locally
  - [x] I have added or updated relevant documentation
  - [x] I have added tests (if applicable)
  - [x] I have communicated with the team about necessary post-deploy actions

---
  
## Testing Notes
### Manual outage simulation (local dev): 
1. Update the .env to a `TTL=15` to set a, temporary, 15 second cache
2. Open a page on a base site, using this branch, to store page and promo data in stale cache fallback
3. `docker stop wsu-api` (and/or `wsu-mysql`) after warming the cache
4. Tail the logs (`tail -f storage/logs/laravel.log`) for the site you're testing with
5. Refresh the pages you previously warmed the cache for
6. Confirm the page loads the same as when `wsu-api` and/or `wsu-mysql` were running before
7. Confirm you see `StaleCache: falling back to stale data for cache key [...] after a null API response` warnings for each promo, event, page data that is cached in the logs
8. Recover `wsu-api` (and/or `wsu-mysql`) in Docker
9. Confirm the pages are still showing as expected

## Post deploy steps
1. Add the `CACHE_STALE_TTL=` property and set an override value in seconds to the _.env_ 
  - *Current default used in _.env.example_ and _config/cache.php_ tested on my local dev is `604800`, which is 7 days
