### PR TITLE
Feature/ Improve automatic PDF label placement for text, button, and icon PDF links

### DIFF
--- a/resources/js/modules/pdf.js
+++ b/resources/js/modules/pdf.js
@@ -2,18 +2,39 @@
     "use strict";
 
     document.querySelectorAll('a[href$=".pdf"]').forEach(function(link) {
-        const pdfSpan = document.createElement("span");
-        const pdfLabel = document.createTextNode(" (pdf)");
-        if(link.classList.contains('button') && link.children.length > 0) {
-            const lastChild = link.children.length - 1;
-            pdfSpan.appendChild(pdfLabel);
-            link.children[lastChild].appendChild(pdfSpan);
-        } else if(!link.classList.contains('button') && link.getElementsByTagName('img').length > 0) {
-            pdfSpan.appendChild(pdfLabel);
-            link.appendChild(pdfSpan);
+        if (link.textContent.toLowerCase().includes('(pdf)')) {
+            return;
+        }
 
+        const lastTextNode = getLastTextNode(link);
+
+        if (lastTextNode) {
+            lastTextNode.textContent = lastTextNode.textContent.replace(/\s*$/, ' (pdf)');
         } else {
-            link.innerHTML += ' (pdf)';
+            link.appendChild(document.createTextNode(' (pdf)'));
         }
     });
+
+    function getLastTextNode(element) {
+        const walker = document.createTreeWalker(
+            element,
+            NodeFilter.SHOW_TEXT,
+            {
+                acceptNode: function(node) {
+                    return node.textContent.trim().length > 0
+                        ? NodeFilter.FILTER_ACCEPT
+                        : NodeFilter.FILTER_REJECT;
+                }
+            }
+        );
+
+        let currentNode;
+        let lastTextNode = null;
+
+        while ((currentNode = walker.nextNode())) {
+            lastTextNode = currentNode;
+        }
+
+        return lastTextNode;
+    }
 })();

--- a/resources/js/modules/pdf.js
+++ b/resources/js/modules/pdf.js
@@ -2,7 +2,7 @@
     "use strict";
 
     document.querySelectorAll('a[href$=".pdf"]').forEach(function(link) {
-        if (link.textContent.toLowerCase().includes('(pdf)')) {
+        if (hasPdfLabel(link)) {
             return;
         }
 
@@ -14,6 +14,10 @@
             link.appendChild(document.createTextNode(' (pdf)'));
         }
     });
+
+    function hasPdfLabel(link) {
+        return /(?:\(\s*pdf\s*\)|\bpdf\b)/i.test(link.textContent);
+    }
 
     function getLastTextNode(element) {
         const walker = document.createTreeWalker(


### PR DESCRIPTION
### Reason for Change

This change improves how the PDF link JavaScript adds visible ` (pdf)` labels to PDF links.

The original issue was that the script relied too heavily on button class detection to decide where the PDF label should be placed. That worked for links using the generic `button` class, but it could miss newer button-style links that use classes like `green-button`, `gold-button`, or other button variants.

Rather than continuing to expand the JavaScript to account for every current or future button class name, this update changes the placement logic to focus on the actual readable link text.

The updated script now finds the last meaningful text node inside each PDF link and appends ` (pdf)` directly to that text. This makes the behavior more flexible across standard links, button-style links, links with nested elements, and links that include icons or images.

This change also adds stricter duplicate-label protection so links that already include `(pdf)` or standalone `pdf` are not modified again.

---

### Demo / Context

The updated PDF label logic now:

* Finds links where the `href` ends in `.pdf`
* Skips links that already include a PDF label
* Finds the last meaningful text node inside the link
* Appends ` (pdf)` directly to that text node
* Falls back to appending ` (pdf)` to the link if no text node exists

This avoids needing to account for every possible button class variation in the JavaScript.

Before, a button-style PDF link like this could require the generic `button` class as a workaround:

```html id="30t2lz"
<a class="green-button text-lg" href="/pdf/file.pdf">
    <img alt="PDF icon" src="/images/paper-pdf-icon.svg">
    Download the position profile
</a>
```

With this update, the script places the PDF label with the readable link text:

```html id="ezto5r"
<a class="green-button text-lg" href="/pdf/file.pdf">
    <img alt="PDF icon" src="/images/paper-pdf-icon.svg">
    Download the position profile (pdf)
</a>
```

The duplicate-label protection also prevents output like:

```txt id="rgvh71"
Download the report (pdf) (pdf)
```

### Final Checklist

* [ x] I have reviewed my code and it follows project standards
* [ x] I have tested the changes locally
* [ ] I have added or updated relevant documentation
* [ ] I have added tests (if applicable)
* [ ] I have communicated with the team about necessary post-deploy actions

---
Known limitation:

* The current selector targets links where the `href` ends exactly in `.pdf`. PDF links with query strings, such as `.pdf?download=true`, may require a separate update if those need to be included.