### PR TITLE
UPDATE | Stubs - Repository | Use rememberWithFallback for caching

### DIFF
--- a/stubs/repository.stub
+++ b/stubs/repository.stub
@@ -6,9 +6,12 @@ use Contracts\Repositories\DummyRepositoryContract;
 use Illuminate\Cache\Repository;
 use Waynestate\Api\Connector;
 use Waynestate\Promotions\ParsePromos;
+use App\Traits\StaleCache;
 
 class DummyRepository implements DummyRepositoryContract
 {
+    use StaleCache;
+
     /** @var Connector */
     protected $wsuApi;
 
@@ -46,7 +49,7 @@ class DummyRepository implements DummyRepositoryContract
             'status' => 0,
         ];
 
-        $submissions = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $submissions = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             $this->wsuApi->nextRequestProduction();
 
             return $this->wsuApi->sendRequest($params['method'], $params);
@@ -72,7 +75,7 @@ class DummyRepository implements DummyRepositoryContract
             'is_active' => '1',
         ];
 
-        $promos = $this->cache->remember($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+        $promos = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
             return $this->wsuApi->sendRequest($params['method'], $params);
         });
 


### PR DESCRIPTION
## Reason for Change
@nickdenardis spotted a missed update in the `repository.stub` file where I forgot to replace `cache->remember` with `rememberWillFallback`.

## Final Checklist
- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions
