### PR TITLE
BugFix - Fix PDF label handling for image-only PDF links

### DIFF
--- a/resources/js/modules/pdf.js
+++ b/resources/js/modules/pdf.js
@@ -10,13 +10,34 @@
 
         if (lastTextNode) {
             lastTextNode.textContent = lastTextNode.textContent.replace(/\s*$/, ' (pdf)');
-        } else {
-            link.appendChild(document.createTextNode(' (pdf)'));
+            return;
+        }
+
+        if (hasImageOrSvg(link)) {
+            appendPdfSpan(link);
         }
     });
 
     function hasPdfLabel(link) {
-        return /(?:\(\s*pdf\s*\)|\bpdf\b)/i.test(link.textContent);
+        return hasPdfText(link.textContent)
+            || hasPdfText(link.getAttribute('aria-label') || '');
+    }
+
+    function hasPdfText(text) {
+        return /(?:\(\s*pdf\s*\)|\bpdf\b)/i.test(text);
+    }
+
+    function hasImageOrSvg(link) {
+        return Boolean(link.querySelector('img, svg'));
+    }
+
+    function appendPdfSpan(link) {
+        link.classList.add('pdf-image');
+
+        const pdfSpan = document.createElement('span');
+        pdfSpan.appendChild(document.createTextNode(' (pdf)'));
+
+        link.appendChild(pdfSpan);
     }
 
     function getLastTextNode(element) {

--- a/resources/scss/components/_pdf.scss
+++ b/resources/scss/components/_pdf.scss
@@ -1,4 +1,11 @@
 /* pdf.js appends a span for styling */
 a[href$=".pdf"] img + span {
-    @apply bg-green-600 text-white rounded-sm absolute right-0 bottom-0 pt-0.5 pb-1 px-2 mr-1 mb-1 leading-none font-bold text-sm tracking-wide;
+    @apply bg-green-600 text-white 
+    rounded-sm absolute right-0 bottom-0 pt-0.5 pb-1 px-2 mr-1 mb-1 
+    leading-none font-bold text-sm tracking-wide;
+}
+
+.pdf-image {
+    position: relative;
+    display: inline-block;
 }


### PR DESCRIPTION
### Reason for Change

Some PDF links consist solely of an image or SVG, leaving no text node for the script to append the (pdf) label to. This update ensures those links receive a visible (pdf) label while providing a dedicated class for styling the generated label without affecting other PDF links.

---

### Demo / Context

This change maintains the existing behavior for text links while improving support for image-only PDF links.

Before
Text-based PDF links received the (pdf) label.
Image-only PDF links did not display a (pdf) label correctly.
<img width="1030" height="1135" alt="Screenshot 2026-07-15 at 2 54 07 PM" src="https://github.com/user-attachments/assets/1298ff4c-779f-48e7-9ac7-cd29826bc7ba" />


After
Text-based PDF links continue to receive the (pdf) label as before.
Image-only PDF links receive a generated <span>(pdf)</span> and the parent anchor is assigned the pdf-image class for styling.
<img width="982" height="1436" alt="Screenshot 2026-07-15 at 2 53 11 PM" src="https://github.com/user-attachments/assets/1ad906da-ef5f-48e8-9a6e-0d6e82cf720c" />

---



### Final Checklist

- [ x] I have reviewed my code and it follows project standards
- [ x] I have tested the changes locally
- [ ] I have added or updated relevant documentation
- [ ] I have added tests (if applicable)
- [ ] I have communicated with the team about necessary post-deploy actions

---