### PR TITLE
Feature | Relativize cross-site promo links pointing back to the current site

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -99,7 +99,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function parseComponentJSON(array $data)
+    public function parseComponentJSON(array $data): array
     {
         // Get data to send through parsePromos
         // Preserve component data
@@ -177,7 +177,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function getPromos($components, $site_id)
+    public function getPromos($components, $site_id): array
     {
         $params = [
             'method' => 'cms.promotions.listing',
@@ -238,12 +238,18 @@ class ModularPageRepository implements ModularPageRepositoryContract
     }
 
     /**
-     * Fully qualify a local or bare-domain URL using the provided base URL when needed.
+     * {@inheritdoc}
      */
     public function fullyQualifiedUrl(string $url, string $base_url = ''): string
     {
         if (Str::startsWith($url, '#')) {
             return $url;
+        }
+
+        $app_host = $this->normalizeHost((string) config('app.url'));
+
+        if ($app_host !== null && $this->normalizeHost($base_url) === $app_host) {
+            return $this->normalizeHost($url) === $app_host ? $this->relativePath($url) : $url;
         }
 
         if ($this->isAbsoluteUrl($url)) {
@@ -261,23 +267,71 @@ class ModularPageRepository implements ModularPageRepositoryContract
         return rtrim($this->urlWithScheme($base_url), '/').'/'.ltrim($url, '/');
     }
 
+    /**
+     * Determine if the URL is already absolute (has a scheme or is protocol-relative).
+     */
     protected function isAbsoluteUrl(string $url): bool
     {
         return Str::startsWith($url, '//') || parse_url($url, PHP_URL_SCHEME) !== null;
     }
 
+    /**
+     * Determine if the URL is a bare domain without a scheme, e.g. "wayne.edu/apply".
+     */
     protected function isUrlWithoutScheme(string $url): bool
     {
         return preg_match('/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:[\/?#]|$)/', $url) === 1;
     }
 
+    /**
+     * Add an https scheme to the URL if it doesn't already have one.
+     */
     protected function urlWithScheme(string $url): string
     {
-        if (parse_url($url, PHP_URL_SCHEME) === null) {
-            return 'https://'.$url;
+        if (parse_url($url, PHP_URL_SCHEME) !== null) {
+            return $url;
         }
 
-        return $url;
+        return Str::startsWith($url, '//') ? 'https:'.$url : 'https://'.$url;
+    }
+
+    /**
+     * Extract and normalize the host from a URL, or null when the URL has no host
+     * (e.g. a relative path or anchor).
+     */
+    protected function normalizeHost(string $url): ?string
+    {
+        if ($url === '' || Str::startsWith($url, '#')) {
+            return null;
+        }
+
+        if ($this->isAbsoluteUrl($url) || $this->isUrlWithoutScheme($url)) {
+            $host = parse_url($this->urlWithScheme($url), PHP_URL_HOST);
+        } else {
+            $host = null;
+        }
+
+        if (empty($host)) {
+            return null;
+        }
+
+        $host = strtolower($host);
+
+        return Str::startsWith($host, 'www.') ? substr($host, 4) : $host;
+    }
+
+    /**
+     * Strip the scheme and host from a URL, keeping the path, query, and fragment.
+     */
+    protected function relativePath(string $url): string
+    {
+        $parseable = $this->urlWithScheme($url);
+
+        $path = parse_url($parseable, PHP_URL_PATH) ?: '/';
+        $query = parse_url($parseable, PHP_URL_QUERY);
+        $fragment = parse_url($parseable, PHP_URL_FRAGMENT);
+
+        return $path.($query ? '?'.$query : '').($fragment ? '#'.$fragment : '');
     }
 
     /**
@@ -386,7 +440,6 @@ class ModularPageRepository implements ModularPageRepositoryContract
                     }
                 }
             } elseif (Str::startsWith($name, 'page-content') || Str::startsWith($name, 'heading') || Str::contains($name, 'page-config')) {
-                //} elseif (Str::startsWith($name, ['page-content', 'heading', 'layout'])) {
                 // If there's JSON but no news, events or promo data, assign the component array as data
                 // Page-content and heading components
                 $modularComponents[$name]['data'][] = $components['components'][$name] ?? [];
@@ -416,7 +469,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
         return $modularComponents;
     }
 
-    public function adjustPromoData($data, $component)
+    public function adjustPromoData($data, $component): array
     {
         if (isset($component['singlePromoView']) && $component['singlePromoView'] === true) {
             $data['link'] = 'view/'.Str::slug($data['title']).'-'.$data['promo_item_id'];
@@ -445,7 +498,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
     /**
     * {@inheritdoc}
     */
-    public function organizePromoItemsByOption(array $data)
+    public function organizePromoItemsByOption(array $data): array
     {
         $options_exist = collect($data)->filter(function ($item) {
             return !empty($item['option']);
@@ -464,7 +517,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
         return $data;
     }
 
-    public function componentClasses($components)
+    public function componentClasses($components): array
     {
         foreach ($components as $componentName => $component) {
             // Establishing final arrays so they will always exist
@@ -544,16 +597,14 @@ class ModularPageRepository implements ModularPageRepositoryContract
         return $components;
     }
 
-    public function componentStyles($components)
+    public function componentStyles($components): array
     {
         $expected_styles = [
             'backgroundImageUrl',
-            //'sectionStyle',
         ];
 
         foreach ($components as $componentName => $component) {
             if (!empty($component['component']['backgroundImageUrl'])) {
-                //$component['component']['backgroundImageUrl'] = "background-image:url('".$component['component']['backgroundImageUrl']."');";
                 $components[$componentName]['component']['backgroundImageUrl'] = "style=\"background-image:url('".$component['component']['backgroundImageUrl']."');\"";
             }
 
@@ -561,7 +612,6 @@ class ModularPageRepository implements ModularPageRepositoryContract
             foreach ($component['component'] as $option => $style) {
                 if (in_array($option, $expected_styles)) {
                     $styles[$componentName][] = $style;
-                    //$components[$componentName]['component']['componentStyle'] = "style=\"".implode(' ', $styles[$componentName])."\"";
                 }
             }
         }
@@ -572,7 +622,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
     /**
      * {@inheritdoc}
      */
-    public function legacyPageFieldSupport(array $data)
+    public function legacyPageFieldSupport(array $data): array
     {
         // Legacy support for accordion
         if (!empty($data['data']['accordion_promo_group_id'])) {

--- a/contracts/Repositories/ModularPageRepositoryContract.php
+++ b/contracts/Repositories/ModularPageRepositoryContract.php
@@ -9,7 +9,7 @@ interface ModularPageRepositoryContract
      *
      * @return array
      */
-    public function getModularComponents(array $data);
+    public function getModularComponents(array $data): array;
 
     /**
      * Get promotions for the listing.
@@ -23,14 +23,14 @@ interface ModularPageRepositoryContract
      *
      * @return array
      */
-    public function parseComponentJSON(array $data);
+    public function parseComponentJSON(array $data): array;
 
     /**
      * Get promotions for the listing.
      *
      * @return array
      */
-    public function getPromos($components, $site_id);
+    public function getPromos($components, $site_id): array;
 
     /**
      * Get promotions for the listing.
@@ -44,33 +44,39 @@ interface ModularPageRepositoryContract
      *
      * @return array
      */
-    public function adjustPromoData($data, $component);
+    public function adjustPromoData($data, $component): array;
 
     /**
      * Get promotions for the listing.
      *
      * @return array
      */
-    public function organizePromoItemsByOption(array $data);
+    public function organizePromoItemsByOption(array $data): array;
 
     /**
      * Get promotions for the listing.
      *
      * @return array
      */
-    public function componentClasses($components);
+    public function componentClasses($components): array;
 
     /**
      * Get promotions for the listing.
      *
      * @return array
      */
-    public function componentStyles($components);
+    public function componentStyles($components): array;
 
     /**
      * Get promotions for the listing.
      *
      * @return array
      */
-    public function legacyPageFieldSupport(array $data);
+    public function legacyPageFieldSupport(array $data): array;
+
+    /**
+     * Fully qualify a local or bare-domain URL using the provided base URL when needed.
+     * If the base URL belongs to the current site, the URL is made relative instead.
+     */
+    public function fullyQualifiedUrl(string $url, string $base_url = ''): string;
 }

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ eslintfix:
 	npm run lint:fix
 
 coverage: $(COMPOSERFILE)
-	phpbrew ext enable xdebug && XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html coverages && phpbrew ext disable xdebug
+	php -d error_reporting="E_ALL & ~E_DEPRECATED" /usr/bin/phpbrew ext enable xdebug && XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-html coverages && php -d error_reporting="E_ALL & ~E_DEPRECATED" /usr/bin/phpbrew ext disable xdebug
 
 envoy: $(DEPLOY)
 	envoy run deploy

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -742,6 +742,61 @@ final class ModularPageRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function does_not_replace_modular_page_relative_urls_and_local_links_for_promos_from_the_current_site(): void
+    {
+        $page_id = $this->faker->numberbetween(10, 50);
+        $promo_group_id = $this->faker->numberbetween(1, 3);
+        $current_site_id = 1561;
+
+        // Fake return
+        $return['promotions'] = app(GenericPromo::class)->create(5, false, [
+            'relative_url' => '/promo/image.jpg',
+            'filename_url' => 'https://base.wayne.edu/promo/image.jpg',
+            'secondary_relative_url' => '/promo/image2.jpg',
+            'secondary_filename_url' => 'https://base.wayne.edu/promo/image2.jpg',
+            'link' => '/apply',
+            'promo_group_id' => $promo_group_id,
+            'page_id' => $page_id,
+            'site' => [
+                'site_id' => $current_site_id,
+                'url' => 'https://base.wayne.edu',
+            ],
+            'group' => [
+                'promo_group_id' => $promo_group_id,
+            ],
+        ]);
+
+        // Create a fake data request
+        $data = app(Page::class)->create(1, true, [
+            'site' => [
+                'id' => $current_site_id,
+            ],
+            'page' => [
+                'controller' => 'ChildpageController',
+                'id' => $page_id,
+            ],
+            'data' => [
+                'modular-promo-column-1' => json_encode([
+                    'id' => $promo_group_id,
+                    'config' => 'randomize|limit:2',
+                ]),
+            ],
+        ]);
+
+        // Mock the connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('cms.promotions.listing', Mockery::type('array'))->once()->andReturn($return);
+
+        // Run the promos through the repository
+        $components = app(ModularPageRepository::class, ['wsuApi' => $wsuApi])->getModularComponents($data);
+        $component = collect($components['promo-column-1']['data'])->first();
+
+        $this->assertEquals('/promo/image.jpg', $component['relative_url']);
+        $this->assertEquals('/promo/image2.jpg', $component['secondary_relative_url']);
+        $this->assertEquals('/apply', $component['link']);
+    }
+
+    #[Test]
     public function get_modular_page_components_with_visibility_options(): void
     {
         $promo_group_id_summon = 9876;
@@ -906,6 +961,138 @@ final class ModularPageRepositoryTest extends TestCase
         $this->assertEquals(
             'https://wayne.edu/summer/',
             $repository->fullyQualifiedUrl('wayne.edu/summer/', 'https://wayne.wayne.localhost')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_mailto_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'mailto:mark.garrison@wayne.edu',
+            $repository->fullyQualifiedUrl('mailto:mark.garrison@wayne.edu', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_tel_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'tel:1-800-222-1222',
+            $repository->fullyQualifiedUrl('tel:1-800-222-1222', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_a_lone_anchor_symbol(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '#',
+            $repository->fullyQualifiedUrl('#', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_does_not_change_a_lone_protocol_relative_slashes(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '//',
+            $repository->fullyQualifiedUrl('//', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_resolves_a_lone_slash_against_base_url(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://base.wayne.edu/',
+            $repository->fullyQualifiedUrl('/', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_adds_scheme_to_bare_domain_links_with_numeric_subdomain(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://150.wayne.edu',
+            $repository->fullyQualifiedUrl('150.wayne.edu', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_adds_scheme_to_external_bare_www_domain_links(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://www.linkedin.com/in/janakabbani',
+            $repository->fullyQualifiedUrl('www.linkedin.com/in/janakabbani', 'https://base.wayne.edu')
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_makes_absolute_links_relative_when_the_promo_site_is_the_current_site(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '/apply',
+            $repository->fullyQualifiedUrl(config('app.url').'/apply', config('app.url'))
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_makes_links_relative_when_the_current_site_host_has_a_www_prefix(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '/apply',
+            $repository->fullyQualifiedUrl('www.'.parse_url(config('app.url'), PHP_URL_HOST).'/apply', config('app.url'))
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_keeps_query_and_fragment_when_relativizing_a_local_site_link(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '/apply?term=fall#form',
+            $repository->fullyQualifiedUrl(config('app.url').'/apply?term=fall#form', config('app.url'))
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_leaves_relative_links_unchanged_when_the_promo_site_is_the_current_site(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            '/apply',
+            $repository->fullyQualifiedUrl('/apply', config('app.url'))
+        );
+    }
+
+    #[Test]
+    public function fully_qualified_url_leaves_external_links_absolute_even_when_the_promo_site_is_the_current_site(): void
+    {
+        $repository = app(ModularPageRepository::class);
+
+        $this->assertEquals(
+            'https://wayne.edu/apply',
+            $repository->fullyQualifiedUrl('https://wayne.edu/apply', config('app.url'))
         );
     }
 }


### PR DESCRIPTION
### Feature | Relativize cross-site promo links pointing back to the current site

- **Type:** Feature / refactor
- **Affects:** `ModularPageRepository` (promo link resolution) and its contract, plus test coverage
- **Changes:** `fullyQualifiedUrl()` now detects when a promo's site URL matches the current app's own URL and, in that case, collapses an absolute link back down to a relative path instead of leaving it absolute. Also added missing return types across the repository's public methods and its contract, added test coverage for real-world URL styles pulled from a CSV export of existing promo links, and removed a few stale commented-out lines.

---

### Reason for Change

Building on the cross-site promo linking work from #1005, promos can now be reused across sites, so `fullyQualifiedUrl()` fully qualifies a promo's link using that promo's originating site URL. That's correct for promos coming from a *different* site, but for a promo that actually belongs to the current site, forcing the link to be absolute hardcodes a domain into what should just be a relative path (this matters since `APP_URL` can differ across sites built from this base template). This change compares the promo's site host against `config('app.url')` and relativizes the link when they match, while leaving genuinely external links (and foreign-site promos) fully qualified as before.

---

### Demo / Context

- Builds on: https://github.com/waynestate/base-site/pull/1005
- `fullyQualifiedUrl(string $url, string $base_url = ''): string` behavior:
    - Absolute link on the same host → relativized (`https://base.wayne.edu/apply` → `/apply`, query/fragment preserved)
    - Already-relative link → left unchanged
    - Link to a genuinely different host → left absolute/unchanged (safety check)
  - **Foreign-site promo** (site url host does not match `config('app.url')`): unchanged existing behavior — absolute/protocol-relative/`mailto:`/`tel:`/anchor links pass through untouched, bare domains get an `https://` scheme added, and relative links get prefixed with the site's base URL.
- Added test cases were derived from a CSV export of every link value that had actually been entered into promos in production, to make sure real-world formatting (leading/trailing whitespace-adjacent styles, bare `www.` domains, `mailto:`/`tel:` links, lone `#`/`//`/`/`, numeric subdomains, etc.) is covered.

---

### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---

### Testing Notes

- Edge cases covered by the new tests: `mailto:`/`tel:` links, lone `#`, lone `//`, lone `/` (resolved against `base_url`), bare domains with numeric subdomains, external bare `www.` domains, and the new local-site relativization paths (matching host, `www.`-prefixed host, query/fragment preservation, already-relative links, and external links on a local promo).

---

_Thanks for your contribution! 🎉_