### PR TITLE
Fix | Promo view | Placeholder image no longer shown if promo item does not contain the optional field

### DIFF
--- a/resources/views/promo-view.blade.php
+++ b/resources/views/promo-view.blade.php
@@ -5,13 +5,11 @@
         @include('components.page-content')
     @endif
 
-    <div class="w-full md:w-1/2 lg:w-1/3 mt-6 my-4 md:ml-4 float-right">
-        @if(!empty($promo['relative_url']))
+    @if(!empty($promo['relative_url']))
+        <div class="w-full md:w-1/2 lg:w-1/3 mt-6 my-4 md:ml-4 float-right">
             @image($promo['relative_url'], $promo['filename_alt_text'], 'mx-auto md:mx-0')
-        @else
-            <img src="/_resources/images/no-photo.svg" alt="{{ $base['page']['title'] }}" class="sm:h-64 md:h-auto block mx-auto md:mx-0">
-        @endif
-    </div>
+        </div>
+    @endif
 
     <div class="content pt-1">
         @include('partials.page-title', ['title' => $base['page']['title']])
@@ -25,11 +23,11 @@
         @endif
     </div>
 
-    <div>
-        @if($back_url != '')
+    @if($back_url != '')
+        <div>
             <p class="pt-4">
                 <a href="{{ $back_url }}" class="button">&larr; Return to listing</a>
             </p>
-        @endif
-    </div>
+        </div>
+    @endif
 @endsection


### PR DESCRIPTION
The individual promotion item view has an optional image:
https://base.wayne.edu/styleguide/view/title-12345#definition-promo-setup

If there is no uploaded image, a placeholder image is put in its place.

Since this is an optional field, the display of the image should be optional. This change removes the placeholder image when no image is available.

It also cleans up the potential of an empty `<div>` if there is no back button to be shown.

## Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

## Demo

| Before | After |
|--------|------|
| <img width="1262" height="863" alt="Screenshot 2026-08-06 at 4 05 46 PM" src="https://github.com/user-attachments/assets/31d379e8-bc2f-47f6-856a-2cbb1e2c798e" /> | <img width="1265" height="823" alt="Screenshot 2026-08-06 at 4 05 54 PM" src="https://github.com/user-attachments/assets/91a3a4bf-ed0b-431f-9c74-0c9738344fa7" /> |
