### PR TITLE
Feature | Accessibility | Footer contact information now consistent heading level with containing Contact header

### DIFF
--- a/resources/views/components/footer-contact.blade.php
+++ b/resources/views/components/footer-contact.blade.php
@@ -2,19 +2,20 @@
     $contact => array // ['title', 'link', 'description']
 --}}
 @if(is_array($contact) && count($contact) > 0)
+    <h2 class="visually-hidden">Contact</h2>
     <div class="bg-green-600">
         <div class="row lg:grid grid-cols-{{ count($contact)}} py-8">
             @foreach($contact as $info)
                 @if($loop->iteration == 1)
                     <div class="p-4 @if(count($contact) == 1)text-center @endif">
-                        <h2 class="text-gold-300 mb-1 print:text-black">{{ $info['title'] }}</h2>
+                        <h3 class="text-gold-300 mb-1 print:text-black">{{ $info['title'] }}</h3>
                         <div class="content white-links text-white print:text-black">
                             {!! $info['description'] !!}
                         </div>
                     </div>
                 @else
                     <div class="px-4 py-4 border-t lg:border-l lg:border-0 border-green-500">
-                        <h3 class="text-gold-300 mb-1 text-2xl">{{ $info['title'] }}</h2>
+                        <h3 class="text-gold-300 mb-1 text-2xl">{{ $info['title'] }}</h3>
                         <div class="content white-links text-white print:text-black">
                             {!! $info['description'] !!}
                         </div>


### PR DESCRIPTION
A few people have noticed the discrepancy in footer column header sizes when there are multiple columns.

After diving into the DOM structure, the first column is always an `<h2>` and the rest of the columns are `<h3>`. 

We could change the font size of the first to always match the subsequent, but after looking at usage, the second and past columns are not always subtopics of the first. Sometimes it is reversed and sometimes they are all independent.

From an accessibility standpoint, because there is no hierarchy of each column, they should all be the same level. They could be all H2's, but since they are all related to contact, it puts their prominence too high. They could all be H3's, but then they would need a containing header.

After discussion on accessibility, we landed on this change. The contact footer always contains a screen reader-only visible H2, for "Contact". And all columns, single or multiple, are H3's under the "Contact" heading.

This allows the content to be nested ideally for accessibility and DOM structure while keeping all the heading sizes visually consistent regardless of whether there is one or multiple columns.

This change also fixes an open `<h3>` validation bug on the multiple-column footer.

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [ x] I have communicated with the team about necessary post-deploy actions

---

## Demo

| Before | After |
|--------|------|
| <img width="345" height="272" alt="Screenshot 2026-08-06 at 5 34 32 PM" src="https://github.com/user-attachments/assets/b5615f6d-ac64-4d03-a8de-9aa4a4551000" /> | <img width="353" height="317" alt="Screenshot 2026-08-06 at 5 34 09 PM" src="https://github.com/user-attachments/assets/9ac6cb21-9a4d-419f-a13a-f97c5e9d550e" /> |