### PR TITLE
Feature | Performance | Optimize 404 handling to exit before the full request lifecycle

### DIFF
--- a/app/Http/Middleware/Data.php
+++ b/app/Http/Middleware/Data.php
@@ -29,6 +29,11 @@ class Data
             $data['parameters']['path'] = $this->getPathFromRequest($request);
         }
 
+        if (str_contains($data['parameters']['path'], '.')) {
+            return abort(404);
+        }
+
+
         // Set the current url
         $data['server']['url'] = $request->url();
         $data['server']['url_with_query'] = $request->fullUrl();

--- a/config/cache.php
+++ b/config/cache.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'default' => env('CACHE_STORE', env('CACHE_DRIVER', 'file')),
+
     'prefix' => null,
 
     'ttl' => env('TTL'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,4 +33,4 @@ Route::get('{any?}'.config('base.news_view_route').'/{slug}-{id}', [config('base
 
 // The wild card route is a catch all route that tries to resolve the requests path to a json file
 Route::match(['get', 'post'], '{path}', [WildCardController::class, 'index'])
-    ->where('path', '.*');
+    ->where('path', '^[a-zA-Z0-9\/\-_]*$');

--- a/tests/Feature/WildCardRouteTest.php
+++ b/tests/Feature/WildCardRouteTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+final class WildCardRouteTest extends TestCase
+{
+    #[Test]
+    public function request_with_file_extension_should_throw_not_found(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->call('GET', '/path/to/image.jpg');
+    }
+
+    #[Test]
+    public function request_with_dot_in_path_should_throw_not_found(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->call('GET', '/some.path/file');
+    }
+
+    #[Test]
+    public function request_with_file_extension_with_exception_handling_returns_404(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->call('GET', '/path/to/image.jpg');
+
+        $this->assertEquals(404, $response->status());
+    }
+}

--- a/tests/Unit/Http/Middleware/DataTest.php
+++ b/tests/Unit/Http/Middleware/DataTest.php
@@ -395,4 +395,16 @@ final class DataTest extends TestCase
             $this->assertFalse($request->data['base']['show_header']);
         });
     }
+
+    #[Test]
+    public function path_with_dot_should_abort_404(): void
+    {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        $request = new Request();
+        $request = $request->create('path/to/image.jpg');
+
+        app(Data::class)->handle($request, function () {
+        });
+    }
 }


### PR DESCRIPTION
With increased traffic on sites and bots scanning, 404 requests have gone up.

We are running into two issues at our scale:

1. Rate-limiting cache defaults should not be the filesystem
2. 404s are slow due to having to go through the entire request cycle

This change adjusts both of these situations.

## Rate limiting cache

Adds support for `CACHE_STORE` and `CACHE_DRIVER` to ensure alignment with our cache defaults and `.env` values

## 404 handling

If a file exists in the storage directory, it is served up directly. If it isn't found in the directory, the request defers to the web routes. 

Because we know our routes will not contain a dot ".", this change prevents URI requests with a dot from being processed through the full page lifecycle.

This also aborts early if the Data middleware is trying to access a path with a dot in it since all paths must conform to the Slug format.

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

## Tests

<img width="563" height="149" alt="Screenshot 2026-08-28 at 12 15 05 PM" src="https://github.com/user-attachments/assets/f369080c-b3de-438b-835c-3fab029787e6" />