### PR TITLE
Fix | Components | containerClass, backgroundClass, and componentClass usage no longer error on component usage

### DIFF
--- a/app/Repositories/ModularPageRepository.php
+++ b/app/Repositories/ModularPageRepository.php
@@ -521,13 +521,25 @@ class ModularPageRepository implements ModularPageRepositoryContract
     {
         foreach ($components as $componentName => $component) {
             // Establishing final arrays so they will always exist
-            $components[$componentName]['component']['containerClass'] = $component['component']['containerClass'] ?? [];
-            $components[$componentName]['component']['backgroundClass'] = $component['component']['backgroundClass'] ?? [];
-            $components[$componentName]['component']['componentClass'] = $component['component']['componentClass'] ?? [];
+            $components[$componentName]['component']['containerClass'] = [];
+            $components[$componentName]['component']['backgroundClass'] = [];
+            $components[$componentName]['component']['componentClass'] = [];
+
+            if (!empty($component['component']['containerClass'])) {
+                array_push($components[$componentName]['component']['containerClass'], $component['component']['containerClass']);
+            }
+
+            if (!empty($component['component']['backgroundClass'])) {
+                array_push($components[$componentName]['component']['backgroundClass'], $component['component']['backgroundClass']);
+            }
+
+            if (!empty($component['component']['componentClass'])) {
+                array_push($components[$componentName]['component']['componentClass'], $component['component']['componentClass']);
+            }
 
             // containerClass => filename
             if (!empty($component['component']['filename'])) {
-                $components[$componentName]['component']['containerClass'][] = $component['component']['filename'];
+                array_push($components[$componentName]['component']['containerClass'], $component['component']['filename']);
             }
 
             // containerClass => columnSpan
@@ -540,7 +552,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
                     array_push($components[$componentName]['component']['containerClass'], 'px-4', 'mt:colspan-6');
                 } else {
                     // Default width
-                    $components[$componentName]['component']['containerClass'][] = 'px-container';
+                    array_push($components[$componentName]['component']['containerClass'], 'px-container');
                 }
             }
 
@@ -566,7 +578,7 @@ class ModularPageRepository implements ModularPageRepositoryContract
                         strpos($class, 'order-') !== false
                     ) {
                         // containerClass
-                        $components[$componentName]['component']['containerClass'][] = $class;
+                        array_push($components[$componentName]['component']['containerClass'], $class);
                     } else {
                         // componentClass
                         $components[$componentName]['component']['componentClass'][] = $class;
@@ -582,16 +594,16 @@ class ModularPageRepository implements ModularPageRepositoryContract
             // Section gutters, bottom padding
             // - No gutter if component uses margin-bottom class
             // - No gutter on heading component
-            if (empty(preg_grep('/mb-/', $components[$componentName]['component']['containerClass']))
+            if (!empty($components[$componentName]['component']['containerClass']) && empty(preg_grep('/mb-/', $components[$componentName]['component']['containerClass']))
                 && !Str::contains($componentName, 'heading') && !Str::contains($componentName, 'hero')
             ) {
-                $components[$componentName]['component']['containerClass'][] = 'mb-gutter';
+                array_push($components[$componentName]['component']['containerClass'], 'mb-gutter');
             }
 
             // Implode party, assign all classes to their respective container
-            $components[$componentName]['component']['containerClass'] = implode(' ', $components[$componentName]['component']['containerClass']);
-            $components[$componentName]['component']['backgroundClass'] = implode(' ', $components[$componentName]['component']['backgroundClass']);
-            $components[$componentName]['component']['componentClass'] = implode(' ', $components[$componentName]['component']['componentClass']);
+            $components[$componentName]['component']['containerClass'] = is_array($components[$componentName]['component']['containerClass']) ? trim(implode(' ', $components[$componentName]['component']['containerClass'])) : '';
+            $components[$componentName]['component']['backgroundClass'] = is_array($components[$componentName]['component']['backgroundClass']) ? trim(implode(' ', $components[$componentName]['component']['backgroundClass'])) : '';
+            $components[$componentName]['component']['componentClass'] = is_array($components[$componentName]['component']['componentClass']) ? trim(implode(' ', $components[$componentName]['component']['componentClass'])) : '';
         }
 
         return $components;

--- a/tests/Unit/Repositories/ModularPageRepositoryTest.php
+++ b/tests/Unit/Repositories/ModularPageRepositoryTest.php
@@ -1095,4 +1095,95 @@ final class ModularPageRepositoryTest extends TestCase
             $repository->fullyQualifiedUrl('https://wayne.edu/apply', config('app.url'))
         );
     }
+
+    #[Test]
+    public function get_modular_page_components_with_container_class(): void
+    {
+        // Create a fake data request with custom containerClass
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+            ],
+            'data' => [
+                'modular-page-content' => json_encode([
+                    'containerClass' => 'custom-container-class',
+                ]),
+            ],
+        ]);
+
+        // Run through repository
+        $components = app(ModularPageRepository::class)->getModularComponents($data);
+
+        $this->assertStringContainsString('custom-container-class', $components['page-content']['component']['containerClass']);
+        $this->assertStringStartsNotWith(' ', $components['page-content']['component']['containerClass']);
+    }
+
+    #[Test]
+    public function get_modular_page_components_with_background_class(): void
+    {
+        // Create a fake data request with custom backgroundClass
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+            ],
+            'data' => [
+                'modular-page-content' => json_encode([
+                    'backgroundClass' => 'custom-background-class',
+                ]),
+            ],
+        ]);
+
+        // Run through repository
+        $components = app(ModularPageRepository::class)->getModularComponents($data);
+
+        $this->assertStringContainsString('custom-background-class', $components['page-content']['component']['backgroundClass']);
+        $this->assertStringStartsNotWith(' ', $components['page-content']['component']['backgroundClass']);
+    }
+
+    #[Test]
+    public function get_modular_page_components_with_component_class(): void
+    {
+        // Create a fake data request with custom componentClass
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+            ],
+            'data' => [
+                'modular-page-content' => json_encode([
+                    'componentClass' => 'custom-component-class',
+                ]),
+            ],
+        ]);
+
+        // Run through repository
+        $components = app(ModularPageRepository::class)->getModularComponents($data);
+
+        $this->assertStringContainsString('custom-component-class', $components['page-content']['component']['componentClass']);
+        $this->assertStringStartsNotWith(' ', $components['page-content']['component']['componentClass']);
+    }
+
+    #[Test]
+    public function get_modular_page_components_with_all_custom_classes(): void
+    {
+        // Create a fake data request with containerClass, backgroundClass, and componentClass
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ChildpageController',
+            ],
+            'data' => [
+                'modular-page-content' => json_encode([
+                    'containerClass' => 'custom-container-class',
+                    'backgroundClass' => 'custom-background-class',
+                    'componentClass' => 'custom-component-class',
+                ]),
+            ],
+        ]);
+
+        // Run through repository
+        $components = app(ModularPageRepository::class)->getModularComponents($data);
+
+        $this->assertStringContainsString('custom-container-class', $components['page-content']['component']['containerClass']);
+        $this->assertStringContainsString('custom-background-class', $components['page-content']['component']['backgroundClass']);
+        $this->assertStringContainsString('custom-component-class', $components['page-content']['component']['componentClass']);
+    }
 }


### PR DESCRIPTION
Bug found during usage of documented functionality.

The way the `containerClass`, `backgroundClass`, and `componentClass` were being applied was throwing an error.

This change applies those properties correctly through the controller and view.

## Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions

## Testing
<img width="566" height="180" alt="Screenshot 2026-08-31 at 6 13 27 AM" src="https://github.com/user-attachments/assets/772c67e9-1c9f-4956-bcdf-0dee4e094ea9" />

## Demo

| Before | After |
|--------|------|
| <img width="1491" height="677" alt="Screenshot 2026-08-31 at 6 09 00 AM" src="https://github.com/user-attachments/assets/28fddecc-6f12-4868-bb9d-b32c83ac7ae0" /> | <img width="1487" height="326" alt="Screenshot 2026-08-29 at 8 38 10 AM" src="https://github.com/user-attachments/assets/7399ee1d-dae2-4b22-85e7-86cbcd19a053" /> |