### PR TITLE
Feature | Performance | Optimized the three most called functions on every request to reduce CPU overhead

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -307,6 +307,8 @@ shopt -s expand_aliases
 source ~/.bashrc
 echo "Clearing view cache"
 php84 {{ $release_dir }}/{{ $release }}/artisan view:clear
+echo "Pre-compiling view cache...";
+php84 {{ $release_dir }}/{{ $release }}/artisan view:cache
 echo "Caching configs...";
 php84 {{ $release_dir }}/{{ $release }}/artisan config:cache
 echo "Caching routes...";

--- a/app/Http/Middleware/Formy.php
+++ b/app/Http/Middleware/Formy.php
@@ -12,6 +12,27 @@ class Formy
     protected Parser $parser;
 
     /**
+     * Structural and metadata keys that never contain user form embeds.
+     */
+    protected array $ignoredKeys = [
+        'server' => true,
+        'parameters' => true,
+        'site' => true,
+        'menu' => true,
+        'meta' => true,
+        'layout' => true,
+        'layout_config' => true,
+        'page_config' => true,
+        'site_menu' => true,
+        'site_menu_output' => true,
+        'top_menu' => true,
+        'top_menu_output' => true,
+        'breadcrumbs' => true,
+        'show_header' => true,
+        'show_site_menu' => true,
+    ];
+
+    /**
      * Construct the middleware.
      */
     public function __construct(Parser $parser)
@@ -20,41 +41,56 @@ class Formy
     }
 
     /**
-     * Parse the page content and replace form embeds with form html.
+     * Parse the page content, promotion descriptions, and excerpts to replace form embeds with form html.
      */
     public function handle(Request $request, Closure $next): ?Response
     {
-        if (!empty($request->data['base']['page']['content'])) {
-            $request->data['base']['page']['content'] = collect($request->data['base']['page']['content'])
-                ->map(function ($content) {
-                    $content = is_string($content) ? stripslashes($content) : $content;
-
-                    return is_string($content) && str_contains($content, '[') ? $this->parser->parse($content) : $content;
-                })
-                ->toArray();
+        if (!empty($request->data['base']['page']['content']) && is_array($request->data['base']['page']['content'])) {
+            foreach ($request->data['base']['page']['content'] as $key => $content) {
+                if (is_string($content)) {
+                    $request->data['base']['page']['content'][$key] = $this->parseString($content);
+                }
+            }
         }
 
         if (!empty($request->data['base'])) {
-            $request->data['base'] = $this->parseDescriptions($request->data['base']);
+            $request->data['base'] = $this->parseContent($request->data['base']);
         }
 
         return $next($request);
     }
 
     /**
-     * Recursively parse the description fields.
+     * Parse content fields (description and excerpt) in targeted arrays.
      */
-    public function parseDescriptions(array $data): array
+    public function parseContent(array $data): array
     {
         foreach ($data as $key => $value) {
+            if (isset($this->ignoredKeys[$key])) {
+                continue;
+            }
+
             if (is_array($value)) {
-                $data[$key] = $this->parseDescriptions($value);
-            } elseif ($key === 'description' && is_string($value)) {
-                $value = stripslashes($value);
-                $data[$key] = str_contains($value, '[') ? $this->parser->parse($value) : $value;
+                $data[$key] = $this->parseContent($value);
+            } elseif (($key === 'description' || $key === 'excerpt') && is_string($value)) {
+                $data[$key] = $this->parseString($value);
             }
         }
 
         return $data;
+    }
+
+    /**
+     * Parse a single string for form embeds after stripping slashes.
+     */
+    public function parseString(string $value): string
+    {
+        if (!str_contains($value, '\\') && !str_contains($value, '[')) {
+            return $value;
+        }
+
+        $value = stripslashes($value);
+
+        return str_contains($value, '[') ? $this->parser->parse($value) : $value;
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -6,39 +6,28 @@
  * @return array
  * @throws Exception
  */
-function merge()
+function merge(...$params): array
 {
-    // Params passed in
-    $params = func_get_args();
+    $merged = [];
 
-    // Data to return
-    $merged = collect();
-
-    foreach ((array) $params as $key => $value) {
-        // Require only arrays
-        if (!is_array($value)) {
-            throw new Exception('Merged variables must be type array, but a ' . gettype($value) . ' was given. ' . "\n\n" . 'Value: ' . $value);
+    foreach ($params as $array) {
+        if (!is_array($array)) {
+            throw new Exception('Merged variables must be type array, but a ' . gettype($array) . ' was given. ' . "\n\n" . 'Value: ' . $array);
         }
 
-        // Make sure every key has a string name
-        collect($value)->each(function ($value, $key) {
+        foreach ($array as $key => $value) {
             if (!is_string($key)) {
                 throw new Exception('Merged variables must have key as a string, but a ' . gettype($key) . ' was given. ' . "\n\n Key: " . $key . "\n Values: " . (is_array($value) ? json_encode(array_keys($value)) : $value));
             }
-        });
 
-        // Make sure there aren't any similiar keys
-        if (collect($value)->diffKeys($merged)->count() != count($value)) {
-            throw new Exception('Array key conflict. Update your array to not conflict with other keys: ' . "\n\n Values:" . json_encode(array_keys($value)));
+            if (array_key_exists($key, $merged)) {
+                throw new Exception('Array key conflict. Update your array to not conflict with other keys: ' . "\n\n Values:" . json_encode(array_keys($array)));
+            }
+
+            $merged[$key] = $value;
         }
-
-        // Merge the arrays
-        $merged = $merged->merge($value);
     }
 
-    $merged = $merged->toArray();
-
-    // Add computed title tag
     if (
         !empty($merged['base']) &&
         !array_key_exists('title', !empty($merged['base']['meta']) ? $merged['base']['meta'] : [])

--- a/app/Traits/FiltersExpiredItems.php
+++ b/app/Traits/FiltersExpiredItems.php
@@ -2,9 +2,6 @@
 
 namespace App\Traits;
 
-use Carbon\Carbon;
-use Throwable;
-
 trait FiltersExpiredItems
 {
     /**
@@ -14,17 +11,24 @@ trait FiltersExpiredItems
      */
     public function isExpired(array $item, array $fields, bool $useEarliest = true): bool
     {
-        $dates = collect($fields)
-            ->map(fn ($field) => $this->parseExpiryDate($item[$field] ?? null))
-            ->filter();
+        $timestamps = [];
 
-        if ($dates->isEmpty()) {
+        foreach ($fields as $field) {
+            if (!empty($item[$field])) {
+                $ts = $this->parseExpiryTimestamp($item[$field]);
+                if ($ts !== null) {
+                    $timestamps[] = $ts;
+                }
+            }
+        }
+
+        if (empty($timestamps)) {
             return false;
         }
 
-        $boundary = $useEarliest ? $dates->min() : $dates->max();
+        $boundary = $useEarliest ? min($timestamps) : max($timestamps);
 
-        return $boundary->isPast();
+        return $boundary < time();
     }
 
     /**
@@ -32,33 +36,42 @@ trait FiltersExpiredItems
      */
     public function filterExpiredItems(array $items, array $fields, bool $useEarliest = true): array
     {
-        return collect($items)
-            ->reject(fn ($item) => $this->isExpired($item, $fields, $useEarliest))
-            ->toArray();
+        $filtered = [];
+
+        foreach ($items as $key => $item) {
+            if (is_array($item) && !$this->isExpired($item, $fields, $useEarliest)) {
+                $filtered[$key] = $item;
+            }
+        }
+
+        return $filtered;
     }
 
     /**
-     * Parse a date field, treating empty strings, the '0000-00-00...' sentinel,
-     * and unparseable values as "not set" (never expires on that field alone).
+     * Parse a date field to a Unix timestamp integer, treating empty strings,
+     * the '0000-00-00...' sentinel, and unparseable values as null ("not set").
      * Date-only values (no time component) represent the whole day, so expiry
-     * is evaluated against the end of that day rather than its start.
+     * is evaluated against the end of that day (23:59:59) rather than its start.
      */
-    private function parseExpiryDate($value): ?Carbon
+    public function parseExpiryTimestamp(mixed $value): ?int
     {
-        if (empty($value) || !is_string($value) || str_starts_with(trim($value), '0000-00-00')) {
+        if (empty($value) || !is_string($value)) {
             return null;
         }
 
-        try {
-            $date = Carbon::parse($value);
-        } catch (Throwable $e) {
+        $trimmed = trim($value);
+        if ($trimmed === '' || str_starts_with($trimmed, '0000-00-00')) {
             return null;
         }
 
-        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($value)) === 1) {
-            return $date->endOfDay();
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $trimmed) === 1) {
+            $ts = strtotime($trimmed.' 23:59:59');
+
+            return $ts !== false ? $ts : null;
         }
 
-        return $date;
+        $ts = strtotime($trimmed);
+
+        return $ts !== false ? $ts : null;
     }
 }

--- a/makefile
+++ b/makefile
@@ -34,10 +34,10 @@ composerinstall: $(COMPOSERFILE)
 	composer update --lock --prefer-dist --no-interaction
 
 composerinstalldev: $(COMPOSERFILE)
-	composer install --prefer-dist --no-interaction && composer dump-autoload --optimize;
+	composer install --prefer-dist --optimize-autoloader --no-interaction
 
 composerinstallproduction: $(COMPOSERFILE)
-	composer install --prefer-dist --no-dev --no-interaction && composer dump-autoload --optimize;
+	composer install --prefer-dist --no-dev --optimize-autoloader --classmap-authoritative --no-interaction
 
 webpackdev: $(MIXFILE)
 	npm run development

--- a/tests/Unit/Http/Middleware/FormyTest.php
+++ b/tests/Unit/Http/Middleware/FormyTest.php
@@ -116,4 +116,86 @@ final class FormyTest extends TestCase
             $this->assertEquals($expectedDescription, $request->data['base']['description']);
         });
     }
+
+    #[Test]
+    public function excerpt_fields_should_be_parsed(): void
+    {
+        $excerpt = "[\'excerpt-shortcode\']";
+        $strippedExcerpt = "['excerpt-shortcode']";
+        $parsedExcerpt = $this->faker->sentence();
+        $nestedExcerpt = "[\'nested-excerpt\']";
+        $strippedNestedExcerpt = "['nested-excerpt']";
+        $parsedNestedExcerpt = $this->faker->sentence();
+
+        // Fake request
+        $request = new Request();
+        $request->data = [
+            'base' => [
+                'excerpt' => $excerpt,
+                'components' => [
+                    'modular-accordion-1' => [
+                        'data' => [
+                            [
+                                'excerpt' => $nestedExcerpt,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // Mock the parser
+        $this->app->bind(Parser::class, function () use ($strippedExcerpt, $parsedExcerpt, $strippedNestedExcerpt, $parsedNestedExcerpt) {
+            $mock = Mockery::mock(Parser::class);
+            $mock->shouldReceive('parse')->with($strippedExcerpt)->once()->andReturn($parsedExcerpt);
+            $mock->shouldReceive('parse')->with($strippedNestedExcerpt)->once()->andReturn($parsedNestedExcerpt);
+
+            return $mock;
+        });
+
+        // Call the middleware
+        app(Formy::class)->handle($request, function ($request) use ($parsedExcerpt, $parsedNestedExcerpt) {
+            $this->assertEquals($parsedExcerpt, $request->data['base']['excerpt']);
+            $this->assertEquals($parsedNestedExcerpt, $request->data['base']['components']['modular-accordion-1']['data'][0]['excerpt']);
+        });
+    }
+
+    #[Test]
+    public function ignored_structural_keys_should_not_be_parsed(): void
+    {
+        // Fake request with description fields inside ignored structural keys
+        $request = new Request();
+        $request->data = [
+            'base' => [
+                'server' => [
+                    'description' => "[\'server-desc\']",
+                ],
+                'site_menu' => [
+                    'description' => "[\'menu-desc\']",
+                ],
+                'top_menu' => [
+                    'description' => "[\'top-menu-desc\']",
+                ],
+                'breadcrumbs' => [
+                    'description' => "[\'breadcrumb-desc\']",
+                ],
+            ],
+        ];
+
+        // Mock the parser - should NOT receive any calls
+        $this->app->bind(Parser::class, function () {
+            $mock = Mockery::mock(Parser::class);
+            $mock->shouldNotReceive('parse');
+
+            return $mock;
+        });
+
+        // Call the middleware
+        app(Formy::class)->handle($request, function ($request) {
+            $this->assertEquals("[\'server-desc\']", $request->data['base']['server']['description']);
+            $this->assertEquals("[\'menu-desc\']", $request->data['base']['site_menu']['description']);
+            $this->assertEquals("[\'top-menu-desc\']", $request->data['base']['top_menu']['description']);
+            $this->assertEquals("[\'breadcrumb-desc\']", $request->data['base']['breadcrumbs']['description']);
+        });
+    }
 }

--- a/tests/Unit/Traits/FiltersExpiredItemsTest.php
+++ b/tests/Unit/Traits/FiltersExpiredItemsTest.php
@@ -115,4 +115,44 @@ final class FiltersExpiredItemsTest extends TestCase
         $this->assertCount(2, $filtered);
         $this->assertEquals(['Active', 'Evergreen'], collect($filtered)->pluck('title')->values()->toArray());
     }
+
+    #[Test]
+    public function filter_expired_items_skips_non_array_entries(): void
+    {
+        $items = [
+            'invalid_item',
+            null,
+            123,
+            ['title' => 'Active', 'end_date' => now()->addDays(1)->format('Y-m-d H:i:s')],
+        ];
+
+        $filtered = $this->subject()->filterExpiredItems($items, ['end_date']);
+
+        $this->assertCount(1, $filtered);
+        $this->assertEquals(['Active'], collect($filtered)->pluck('title')->values()->toArray());
+    }
+
+    #[Test]
+    public function parse_expiry_timestamp_returns_null_for_empty_or_non_string_values(): void
+    {
+        $this->assertNull($this->subject()->parseExpiryTimestamp(null));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(''));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(0));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(12345));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(['2026-01-01']));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(false));
+        $this->assertNull($this->subject()->parseExpiryTimestamp(true));
+    }
+
+    #[Test]
+    public function parse_expiry_timestamp_parses_date_only_and_datetime_strings(): void
+    {
+        $dateOnly = '2026-09-01';
+        $expectedDateOnly = strtotime('2026-09-01 23:59:59');
+        $this->assertSame($expectedDateOnly, $this->subject()->parseExpiryTimestamp($dateOnly));
+
+        $dateTime = '2026-09-01 12:00:00';
+        $expectedDateTime = strtotime($dateTime);
+        $this->assertSame($expectedDateTime, $this->subject()->parseExpiryTimestamp($dateTime));
+    }
 }


### PR DESCRIPTION
When reviewing the debug workflow for each web request, we found three functions that were called multiple times or were processing large datasets inefficiently. 

With millions of requests per month, these three functions accounted for 30-40% of CPU time. We have rewritten these functions to reduce how often they are called per request, optimized their processing to only the necessary data and used as low-level functionality to reduce overhead. 

We were able to reduce CPU and request time by 40%.

## Optimization overview

| Metric | Baseline | Optimized | Impact / Reduction |
| :--- | :--- | :--- | :--- |
| **Total Function / Method Invocations** | **61,084** | **36,139** | **-24,945 calls / request (-40.8%)** |
| **`Collection` Object Instantiations** | **313** | **105** | **-208 objects / request (-66.5%)** |
| **Closure Allocations in Hotspots** | **131** | **1** | **-130 closures / request (-99.2%)** |
| **Date/Carbon/Expiry Processing Time** | **4.9110 ms** | **3.0123 ms** | **-38.7% CPU time** |
| **`merge()` Helper Wall Time** | **0.1593 ms** | **0.0118 ms** | **-92.6% CPU time** |
| **Formy Recursive Invocations** | **91 calls** | **32 calls** | **-64.8% fewer calls** |

### Reduced the Formy.php recursive calls by 2/3, resulting in a 35% decrease in CPU time per request

Formy was parsing through every single `$data` element being passed to the page, although a Formy form can only exist in page content, descriptions, and excerpts.

The change now excludes parts of the page not needed to parse and replaces the Collection overhead with native PHP looping.

<img width="1201" height="155" alt="Screenshot 2026-08-29 at 8 16 54 PM" src="https://github.com/user-attachments/assets/0f60c49f-2f37-4d65-b71a-24d0af098f85" />


### FilterExpiredItems moved from Carbon to native C strtotime functions, resulting in a 39% decrease in CPU time per request

FiltersExpiredItems was incurring the overhead cost of Carbon and closure functions to parse dates directly, no manipulation was needed. 

This change moves to the native C implementation for date functions to reduce the overhead of the timezone calculations on every date parse and integer comparisons.

<img width="1196" height="153" alt="Screenshot 2026-08-30 at 6 25 25 AM" src="https://github.com/user-attachments/assets/a34d9b4c-b70b-40d7-b701-3d8d1e597405" />


### Moved merge() function from Collections to native C array checking and merging resulting in a 94% decrease in CPU time per request

merge() is being called multiple times per request and used a Collection to iterate over all keys and merge.

Moved to a constant time C based native PHP key checking and reduced CPU time by 63% for the same checks and merge.

### Deployment updated to create a full classmap on production and cache views before the first page load

On deploy we are optimizing Composer, but we were not creating a full 1:1 classmap. 

This change creates that 1:1 class map to reduce overhead of lookups in real-time. The change also pre-compiles the views so the first visitor doesn't incur the CPU cost of that compilation.


### Final Checklist

- [x] I have reviewed my code and it follows project standards
- [x] I have tested the changes locally
- [x] I have added or updated relevant documentation
- [x] I have added tests (if applicable)
- [x] I have communicated with the team about necessary post-deploy actions


### Tests

<img width="604" height="518" alt="Screenshot 2026-08-31 at 7 15 37 AM" src="https://github.com/user-attachments/assets/bdf7c6d9-6b0f-457c-891b-caf4822209ea" />

