### PR TITLE
Feature | Fall back to batch profile image endpoint for missing pictures

### DIFF
--- a/app/Repositories/ProfileRepository.php
+++ b/app/Repositories/ProfileRepository.php
@@ -71,6 +71,11 @@ class ProfileRepository implements ProfileRepositoryContract
         // Make sure the return is an array
         $profiles['profiles'] = empty($profile_listing['error']) ? $profile_listing : [];
 
+        // Fall back to the batch faculty image endpoint for any profile missing a picture
+        if (config('base.profile.use_global_image') && !empty($profiles['profiles']) && $this->hasProfilesMissingPictures($profiles['profiles'])) {
+            $profiles = $this->getProfileImages($profiles);
+        }
+
         return $profiles;
     }
 
@@ -276,11 +281,19 @@ class ProfileRepository implements ProfileRepositoryContract
             $profiles['profiles']['articles'] = $this->getNewsArticles($accessid, 10);
         }
 
-        return [
+        $profile = [
             'profile' =>  Arr::get($profiles['profiles'], $site_id, []),
             'courses' => Arr::get($profiles, 'courses', []),
             'articles' => Arr::get($profiles['profiles'], 'articles', []),
         ];
+
+        // Fall back to the batch faculty image endpoint if this profile is missing a picture
+        if (config('base.profile.use_global_image') && !empty($profile['profile']['data']) && empty($profile['profile']['data']['Picture'])) {
+            $profile_images = $this->getProfileImages(['profiles' => [$site_id => $profile['profile']]]);
+            $profile['profile'] = $profile_images['profiles'][$site_id];
+        }
+
+        return $profile;
     }
 
     /**
@@ -478,6 +491,51 @@ class ProfileRepository implements ProfileRepositoryContract
         });
 
         return $profiles_ordered->merge($profiles_all)->toArray();
+    }
+
+    /**
+     * Determine if any profile in the collection is missing its picture.
+     *
+     * @param array $profiles
+     * @return bool
+     */
+    protected function hasProfilesMissingPictures(array $profiles): bool
+    {
+        return collect($profiles)->contains(function ($profile) {
+            return empty($profile['data']['Picture']);
+        });
+    }
+
+    /**
+     * Fill in missing profile pictures using the batch profile image endpoint.
+     *
+     * @param array $profiles
+     * @return array
+     */
+    protected function getProfileImages(array $profiles): array
+    {
+        $accessids = collect($profiles['profiles'])->map(function ($profile) {
+            return $profile['data']['AccessID'];
+        })->toArray();
+
+        $params = [
+            'method' => 'profile.users.batch',
+            'accessids' => $accessids,
+        ];
+
+        $profile_images = $this->rememberWithFallback($params['method'].md5(serialize($params)), config('cache.ttl'), function () use ($params) {
+            $this->wsuApi->nextRequestProduction();
+
+            return $this->wsuApi->sendRequest($params['method'], $params);
+        });
+
+        foreach ($profiles['profiles'] as $id => $profile) {
+            if (empty($profile['data']['Picture']) && !empty($profile_images[$id]['data']['Picture'])) {
+                $profiles['profiles'][$id]['data']['Picture'] = $profile_images[$id]['data']['Picture'];
+            }
+        }
+
+        return $profiles;
     }
 
     /**

--- a/config/base.php
+++ b/config/base.php
@@ -370,6 +370,18 @@ $global_config = [
         |
         */
         'table_of_contents' => null,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Use Global Image
+        |--------------------------------------------------------------------------
+        |
+        | When true, any profile missing a picture will fall back to the latest
+        | picture found for that AccessID from any site via the batch profile
+        | image endpoint.
+        |
+        */
+        'use_global_image' => false,
     ],
     /*
     |--------------------------------------------------------------------------

--- a/styleguide/Pages/ContactTables.php
+++ b/styleguide/Pages/ContactTables.php
@@ -37,7 +37,7 @@ class ContactTables extends Page
 "group_id":"1234,5678",
 "parent_group_id":"1234",
 "table_of_contents":"hide",
-"default_back_url":"/profiles/",
+"default_back_url":"/profiles/"
 }
 </pre>
                                 </td>

--- a/styleguide/Pages/ContactTablesNoTOC.php
+++ b/styleguide/Pages/ContactTablesNoTOC.php
@@ -38,7 +38,7 @@ class ContactTablesNoTOC extends Page
 "group_id":"1234,5678",
 "parent_group_id":"1234",
 "table_of_contents":"hide",
-"default_back_url":"/profiles/",
+"default_back_url":"/profiles/"
 }
 </pre>
                                 </td>

--- a/styleguide/Pages/Directory.php
+++ b/styleguide/Pages/Directory.php
@@ -35,8 +35,10 @@ class Directory extends Page
 "parent_group_id":"1234",
 "table_of_contents":"hide",
 "default_back_url":"/profiles/",
+"use_global_image": false
 }
 </pre>
+<p>Setting <code>use_global_image</code> to <code>true</code> will try to use ANY profile image available for the user for missing pictures.</p>
                                 </td>
                             </tr>
                         </tbody>

--- a/styleguide/Pages/DirectoryOrdered.php
+++ b/styleguide/Pages/DirectoryOrdered.php
@@ -41,8 +41,10 @@ class DirectoryOrdered extends Page
 "parent_group_id":"1234",
 "table_of_contents":"hide",
 "default_back_url":"/profiles/",
+"use_global_image": false
 }
 </pre>
+<p>Setting <code>use_global_image</code> to <code>true</code> will try to use ANY profile image available for the user for missing pictures.</p>
                                 </td>
                             </tr>
                         </tbody>

--- a/styleguide/Pages/Profiles.php
+++ b/styleguide/Pages/Profiles.php
@@ -37,9 +37,11 @@ class Profiles extends Page
 "parent_group_id":"1234",
 "table_of_contents":"hide",
 "default_back_url":"/profiles",
-"profiles_by_accessid":"aa0000,aa0001"
+"profiles_by_accessid":"aa0000,aa0001",
+"use_global_image": false
 }
 </pre>
+<p>Setting <code>use_global_image</code> to <code>true</code> will try to use ANY profile image available for the user for missing pictures.</p>
                                 </td>
                             </tr>
                         </tbody>

--- a/tests/Unit/Repositories/ProfileRepositoryTest.php
+++ b/tests/Unit/Repositories/ProfileRepositoryTest.php
@@ -257,6 +257,132 @@ final class ProfileRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function getting_profiles_with_missing_pictures_should_fill_them_in_from_batch_endpoint_when_use_global_image_is_enabled(): void
+    {
+        Config::set('base.profile.use_global_image', true);
+
+        // Fake return with the picture missing from one profile
+        $return = app(Profile::class)->create(3);
+        $missing_id = array_key_first($return);
+        $return[$missing_id]['data']['Picture'] = '';
+        $access_id = $return[$missing_id]['data']['AccessID'];
+
+        $batch_return = [
+            $missing_id => ['data' => ['Picture' => ['url' => '/global/picture.jpg']]],
+        ];
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.listing', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.batch', Mockery::on(function ($params) use ($access_id) {
+            return in_array($access_id, $params['accessids']);
+        }))->once()->andReturn($batch_return);
+        $wsuApi->shouldReceive('nextRequestProduction')->twice();
+
+        $profiles = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfiles($this->faker->numberBetween(1, 10));
+
+        $this->assertEquals(['url' => '/global/picture.jpg'], $profiles['profiles'][$missing_id]['data']['Picture']);
+    }
+
+    #[Test]
+    public function getting_profiles_with_all_pictures_present_should_not_call_batch_endpoint(): void
+    {
+        Config::set('base.profile.use_global_image', true);
+
+        // Fake return where every profile already has a picture
+        $return = app(Profile::class)->create(3);
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.listing', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.batch', Mockery::any())->never();
+        $wsuApi->shouldReceive('nextRequestProduction')->once();
+
+        app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfiles($this->faker->numberBetween(1, 10));
+    }
+
+    #[Test]
+    public function getting_profiles_with_missing_pictures_should_not_call_batch_endpoint_when_use_global_image_is_disabled(): void
+    {
+        Config::set('base.profile.use_global_image', false);
+
+        // Fake return with the picture missing from one profile
+        $return = app(Profile::class)->create(3);
+        $missing_id = array_key_first($return);
+        $return[$missing_id]['data']['Picture'] = '';
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.listing', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.batch', Mockery::any())->never();
+        $wsuApi->shouldReceive('nextRequestProduction')->once();
+
+        $profiles = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfiles($this->faker->numberBetween(1, 10));
+
+        $this->assertEquals('', $profiles['profiles'][$missing_id]['data']['Picture']);
+    }
+
+    #[Test]
+    public function getting_profile_with_missing_picture_should_fill_it_in_from_batch_endpoint_when_use_global_image_is_enabled(): void
+    {
+        Config::set('base.profile.use_global_image', true);
+
+        $site_id = $this->faker->numberBetween(1, 10);
+        $accessid = $this->faker->word();
+
+        $profile = app(Profile::class)->create(1, true);
+        $profile['data']['AccessID'] = $accessid;
+        $profile['data']['Picture'] = '';
+
+        $return = [
+            'profiles' => [$site_id => $profile],
+            'courses' => [],
+        ];
+
+        $batch_return = [
+            $site_id => ['data' => ['Picture' => ['url' => '/global/picture.jpg']]],
+        ];
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.view', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.batch', Mockery::type('array'))->once()->andReturn($batch_return);
+        $wsuApi->shouldReceive('nextRequestProduction')->twice();
+
+        $result = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfile($site_id, $accessid);
+
+        $this->assertEquals(['url' => '/global/picture.jpg'], $result['profile']['data']['Picture']);
+    }
+
+    #[Test]
+    public function getting_profile_with_missing_picture_should_not_call_batch_endpoint_when_use_global_image_is_disabled(): void
+    {
+        Config::set('base.profile.use_global_image', false);
+
+        $site_id = $this->faker->numberBetween(1, 10);
+        $accessid = $this->faker->word();
+
+        $profile = app(Profile::class)->create(1, true);
+        $profile['data']['AccessID'] = $accessid;
+        $profile['data']['Picture'] = '';
+
+        $return = [
+            'profiles' => [$site_id => $profile],
+            'courses' => [],
+        ];
+
+        // Mock the Connector and set the return
+        $wsuApi = Mockery::mock(Connector::class);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.view', Mockery::type('array'))->once()->andReturn($return);
+        $wsuApi->shouldReceive('sendRequest')->with('profile.users.batch', Mockery::any())->never();
+        $wsuApi->shouldReceive('nextRequestProduction')->once();
+
+        $result = app(ProfileRepository::class, ['wsuApi' => $wsuApi])->getProfile($site_id, $accessid);
+
+        $this->assertEquals('', $result['profile']['data']['Picture']);
+    }
+
+    #[Test]
     public function getting_profile_group_ids_should_return_correct_string(): void
     {
         // Fake a dropdown array of group_id => group name
@@ -463,6 +589,27 @@ final class ProfileRepositoryTest extends TestCase
 
         $this->assertEquals($site_id, config('base.profile.site_id'));
         $this->assertEquals($group_id, config('base.profile.group_id'));
+    }
+
+    #[Test]
+    public function get_profile_config_should_set_use_global_image_from_json_config(): void
+    {
+        $data = app(Page::class)->create(1, true, [
+            'page' => [
+                'controller' => 'ProfileController',
+            ],
+            'data' => [
+                'profile-config' => json_encode([
+                    'use_global_image' => true,
+                ]),
+            ],
+        ]);
+
+        $wsuApi = Mockery::mock(Connector::class);
+
+        app(ProfileRepository::class, ['wsuApi' => $wsuApi])->parseProfileConfig($data);
+
+        $this->assertTrue(config('base.profile.use_global_image'));
     }
 
     #[Test]


### PR DESCRIPTION
Fall back to batch profile image endpoint for missing pictures. Adds an optional fallback that batch-fetches profile pictures when they are missing from the primary listing/view API response

---

### Reason for Change

Some profiles returned by the listing and view endpoints come back without a `Picture` value. This left gaps in the UI wherever a profile image was expected. The fix adds a fallback that calls `profile.users.batch` to fill in any missing pictures, so profiles reliably have an image available.

The fallback is opt-in, gated behind `base.profile.use_global_image` (configurable via the `profile-config` custom field), so sites only get this extra request when they explicitly enable it.

---

### Demo / Context

- New config option: `base.profile.use_global_image` (see `config/base.php`)
- `ProfileRepository::hasProfilesMissingPictures()` checks a batch of profiles for missing pictures
- `ProfileRepository::getProfileImages()` performs the batch fallback request (cached via `rememberWithFallback`) and merges results back into the profile data
- Applies to both the profile listing path and the single-profile (`site_id`) lookup path

---

### Final Checklist

- [X] I have reviewed my code and it follows project standards
- [X] I have tested the changes locally
- [X] I have added or updated relevant documentation
- [X] I have added tests (if applicable)
- [X] I have communicated with the team about necessary post-deploy actions

---

### Testing Notes

- New coverage added in `tests/Unit/Repositories/ProfileRepositoryTest.php`

---

_Thanks for your contribution! 🎉_
